### PR TITLE
fix: block global package installs in bash safety hook

### DIFF
--- a/hooks/check-bash-safety.ps1
+++ b/hooks/check-bash-safety.ps1
@@ -83,6 +83,19 @@ elseif ($Command -match 'Remove-Item.*-Recurse.*[A-Z]:\\$') {
 elseif ($Command -match '(sed|awk|echo|tee|printf|Set-Content|Out-File).*\.claude[/\\](settings|config)') {
     $Reason = "Attempting to modify Claude Code configuration via Bash"
 }
+# 7. Global package installs (supply chain attack vector — see Clinejection)
+elseif ($Command -match 'npm\s+(install|i)\s+(-g|--global)|npm\s+(-g|--global)\s+(install|i)') {
+    $Reason = "Global npm package install detected (supply chain risk)"
+}
+elseif ($Command -match 'yarn\s+global\s+add') {
+    $Reason = "Global yarn package install detected (supply chain risk)"
+}
+elseif ($Command -match 'pnpm\s+(add|install|i)\s+(-g|--global)|pnpm\s+(-g|--global)\s+(add|install|i)') {
+    $Reason = "Global pnpm package install detected (supply chain risk)"
+}
+elseif ($Command -match '(^|\s)pip3?\s+install\s+[^-]' -and $Command -notmatch 'pip3?\s+install\s+(-r\s|-e\s|\.\s*$)|uv\s+pip') {
+    $Reason = "Unscoped pip install detected (supply chain risk — use venv or uv)"
+}
 
 # --- Block or allow ---
 if ($Reason) {

--- a/hooks/check-bash-safety.sh
+++ b/hooks/check-bash-safety.sh
@@ -74,6 +74,16 @@ elif echo "$COMMAND" | grep -qE 'rm\s+-[rf]*\s+/' 2>/dev/null && ! echo "$COMMAN
 # 6. Modifying Claude Code's own config via Bash (defense in depth with ConfigChange hook)
 elif echo "$COMMAND" | grep -qE '(sed|awk|echo|tee|printf).*\.claude/(settings|config)' 2>/dev/null; then
     REASON="Attempting to modify Claude Code configuration via Bash"
+
+# 7. Global package installs (supply chain attack vector — see Clinejection)
+elif echo "$COMMAND" | grep -qE 'npm\s+(install|i)\s+(-g|--global)|npm\s+(-g|--global)\s+(install|i)' 2>/dev/null; then
+    REASON="Global npm package install detected (supply chain risk)"
+elif echo "$COMMAND" | grep -qE 'yarn\s+global\s+add' 2>/dev/null; then
+    REASON="Global yarn package install detected (supply chain risk)"
+elif echo "$COMMAND" | grep -qE 'pnpm\s+(add|install|i)\s+(-g|--global)|pnpm\s+(-g|--global)\s+(add|install|i)' 2>/dev/null; then
+    REASON="Global pnpm package install detected (supply chain risk)"
+elif echo "$COMMAND" | grep -qE '(^|\s)pip3?\s+install\s+[^-]' 2>/dev/null && ! echo "$COMMAND" | grep -qE 'pip3?\s+install\s+(-r\s|-e\s|\.\s*$)|uv\s+pip' 2>/dev/null; then
+    REASON="Unscoped pip install detected (supply chain risk — use venv or uv)"
 fi
 
 # --- Block or allow ---


### PR DESCRIPTION
## Summary

Closes #63

- Adds check #7 to `check-bash-safety.sh` and `.ps1` to block global package installs — the exact vector used in the Clinejection supply chain attack
- Blocks: `npm install -g`, `yarn global add`, `pnpm add -g`, unscoped `pip install`
- Allows: local `npm install`, `pip install -r`/`-e`, `uv pip install`

## Test plan

- [x] Verified all 8 dangerous patterns are blocked (npm -g, yarn global, pnpm -g, pip/pip3)
- [x] Verified 7 safe patterns are allowed (local npm, pip -r, pip -e, uv pip, etc.)
- [x] Both .sh and .ps1 variants updated with matching logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)