### PR TITLE
feat: counter-tracked revision loops with severity rubric

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,7 +552,7 @@ How a feature goes from idea to merged PR.
                             │
                             ▼
 ┌─────────────────────────────────────────────────────────────┐
-│ 4. DESIGN + REVIEW LOOP (iterates 4-6 times)               │
+│ 4. DESIGN + REVIEW LOOP (iterates until no P0/P1/P2)       │
 │                                                             │
 │    ┌───────────────────────────────────────────┐            │
 │    │ a. /superpowers:brainstorming              │            │
@@ -571,11 +571,11 @@ How a feature goes from idea to merged PR.
 │    └──────────────────┬────────────────────────┘   │       │
 │                       ▼                             │       │
 │              ┌────────────────┐                     │       │
-│              │ P0/P1 issues?  │── Yes ──► Edit ─────┘       │
+│              │ P0/P1/P2?      │── Yes ──► Edit ─────┘       │
 │              └───────┬────────┘          plan                │
 │                      No                                     │
 │                      ▼                                      │
-│              No P0/P1s → Plan approved ✓                    │
+│              No P0/P1/P2s → Plan approved ✓                 │
 └─────────────────────────────────────────────────────────────┘
                             │
                             ▼

--- a/README.md
+++ b/README.md
@@ -565,9 +565,9 @@ How a feature goes from idea to merged PR.
 │    └──────────────────┬────────────────────────┘            │
 │                       ▼                                     │
 │    ┌───────────────────────────────────────────┐            │
-│    │ c. /codex review the plan                  │◄──┐       │
-│    │    → Independent validation                │   │       │
-│    │    → If no Codex: user reviews manually    │   │       │
+│    │ c. Claude + /codex review the plan          │◄──┐       │
+│    │    → Two independent validations           │   │       │
+│    │    → If no Codex: user reviews instead     │   │       │
 │    └──────────────────┬────────────────────────┘   │       │
 │                       ▼                             │       │
 │              ┌────────────────┐                     │       │

--- a/commands/fix-bug.md
+++ b/commands/fix-bug.md
@@ -129,9 +129,9 @@ Write the `## Workflow` section in CONTINUITY.md (create the file if it doesn't 
 - [ ] Design guidance loaded (if UI fix)
 - [ ] Brainstorming complete (if complex)
 - [ ] Plan written (if complex)
-- [ ] Plan vs code verified (if complex)
+- [ ] Plan review loop (0 iterations, if complex) — iterate until no P0/P1/P2
 - [ ] TDD fix execution complete
-- [ ] Code review loop (no P0/P1/P2)
+- [ ] Code review loop (0 iterations) — iterate until no P0/P1/P2
 - [ ] Simplified
 - [ ] Verified (tests/lint/types)
 - [ ] E2E tested (if API changed)
@@ -239,9 +239,13 @@ This ensures UI fixes maintain visual quality — don't regress the design while
 /superpowers:writing-plans
 ```
 
-#### 3.3 Plan vs Code Verification — Dual Review (MANDATORY)
+#### 3.3 Plan Review Loop — Dual Review (MANDATORY)
 
-Go back to the fix plan and check everything proposed against the actual code. Verify it's the simplest, fastest, best way to do it. Two independent reviews run **in parallel**:
+Go back to the fix plan and check everything proposed against the actual code. Two independent reviews run **in parallel**, iterating until clean.
+
+**Per iteration:**
+
+**Step A — Run both reviews in parallel:**
 
 **a) Claude (you) reviews the plan against the codebase:**
 
@@ -252,9 +256,9 @@ Read every file the plan proposes to modify. For each change, ask:
 - Are there existing utilities, patterns, or abstractions the plan should use instead of creating new ones?
 - Is anything proposed that's unnecessary or over-engineered?
 
-Document your findings as a list of concerns (P0/P1/P2).
+Document your findings as a severity-tagged list (P0/P1/P2/P3).
 
-**b) Codex reviews independently and separately:**
+**b) Codex reviews independently:**
 
 Check if Codex CLI is available:
 
@@ -268,21 +272,35 @@ If available:
 /codex review the fix plan and check everything we're proposing versus the code — is this the simplest, fastest, best way to do it? Flag any concerns.
 ```
 
+Note: The `/codex` command's Design Review Mode uses its own fixed prompt — it may not return P0/P1/P2/P3 tags directly. After receiving Codex's output, classify each finding into P0/P1/P2/P3 using the severity rubric before evaluating exit criteria.
+
 If Codex is NOT available:
 
 - Present your own review findings plus a summary of the plan to the user
 - Ask: "Does this fix approach look right before I start implementing?"
-- Wait for user confirmation before proceeding to Phase 4
+- User confirmation replaces Codex as the second reviewer
 
-#### 3.4 Iterate until approved
+**Step B — Collect findings and evaluate:**
 
-**If either review finds P0 or P1 issues:**
+Gather severity-tagged findings from all available reviewers. Use this rubric:
 
-1. Edit the plan to address the issues
-2. Run **both** reviews again (Claude + Codex in parallel)
-3. Repeat until there are **no P0 or P1 issues** from either reviewer
+| Level | Meaning | Action |
+|-------|---------|--------|
+| P0 | Broken — will crash, lose data, or security vulnerability | Must fix |
+| P1 | Wrong — incorrect behavior, logic error, missing edge case | Must fix |
+| P2 | Poor — code smell, maintainability, unclear intent, missing test | Must fix |
+| P3 | Nit — style, naming, minor suggestion | May fix, does not block |
 
-Do NOT proceed to Phase 4 until the plan is approved.
+**Step C — Exit criteria:**
+
+- **P0/P1/P2 found by any reviewer →** Fix the plan, increment iteration counter in CONTINUITY checklist (`Plan review loop (N iterations)`), go back to Step A.
+- **Only P3 or clean from all available reviewers on the same pass →** Check the box in CONTINUITY with final count: `- [x] Plan review loop (3 iterations) — PASS`. Proceed to Phase 4.
+
+**Rules:**
+- Do NOT check the box until all available reviewers report no P0/P1/P2 on the same pass
+- "Available reviewers" = Claude always + Codex if installed, or user if Codex unavailable
+- Typically 2-3 iterations
+- Do NOT proceed to Phase 4 until the plan is approved
 
 > **Why mandatory?** A wrong fix plan leads to wasted effort and potentially new bugs. Two independent reviewers checking the plan against the actual code catches things a single pass misses.
 
@@ -313,9 +331,13 @@ Or for simple fixes, write a failing test first, then fix.
 > - Perform equivalent checks manually (see fallbacks below)
 > - Do NOT skip quality gates
 
-### 5.1 Code Review Loop (repeats until no P0/P1/P2 issues — P3s acceptable)
+### 5.1 Code Review Loop — Dual Review (MANDATORY)
 
-Run both reviews **in parallel**:
+Run both reviews **in parallel**, iterating until clean.
+
+**Per iteration:**
+
+**Step A — Run both reviews in parallel:**
 
 **a) Second Opinion (Codex CLI):**
 
@@ -331,6 +353,8 @@ If available:
 /codex review
 ```
 
+Note: `/codex review` uses the codex.md command which has its own prompt format. After receiving Codex's output, classify each finding into P0/P1/P2/P3 using the severity rubric before evaluating exit criteria.
+
 **b) Deep Review (PR Review Toolkit):**
 
 ```
@@ -339,13 +363,25 @@ If available:
 
 This runs 6 specialized agents: code-reviewer, silent-failure-hunter, pr-test-analyzer, comment-analyzer, type-design-analyzer, and code-simplifier.
 
-**Fallback if unavailable:** Use `pr-review-toolkit:code-reviewer` agent on modified files.
+**Tool availability:**
+- **Both available (normal):** Run Codex + PR Toolkit in parallel
+- **Codex unavailable:** PR Toolkit alone is sufficient
+- **PR Toolkit unavailable:** Codex alone is sufficient
+- **Neither available:** Alert user, perform manual review, get user sign-off
 
-**Iterate:** If either review finds P0, P1, or P2 issues:
+**Step B — Collect findings and evaluate:**
 
-1. Fix the issues
-2. Run **both** reviews again
-3. Repeat until there are **no P0/P1/P2 issues** (P3s are acceptable)
+Gather severity-tagged findings from all available reviewers. Use the same P0–P3 rubric from the plan review loop.
+
+**Step C — Exit criteria:**
+
+- **P0/P1/P2 found by any reviewer →** Fix the issues. If fixes are substantial (3+ files changed), re-run verify-app before next review iteration to catch regressions early. Increment counter in CONTINUITY checklist (`Code review loop (N iterations)`), go back to Step A.
+- **Only P3 or clean from all available reviewers on the same pass →** Check the box in CONTINUITY with final count: `- [x] Code review loop (3 iterations) — PASS`. Proceed to 5.2.
+
+**Rules:**
+- Do NOT check the box until all available reviewers report no P0/P1/P2 on the same pass
+- Typically 2-3 iterations
+- P3s are acceptable — do not iterate for P3-only findings
 
 ### 5.2 Simplify
 

--- a/commands/fix-bug.md
+++ b/commands/fix-bug.md
@@ -239,9 +239,9 @@ This ensures UI fixes maintain visual quality — don't regress the design while
 /superpowers:writing-plans
 ```
 
-#### 3.3 Plan Review Loop — Dual Review (MANDATORY)
+#### 3.3 Plan Review Loop (MANDATORY)
 
-Go back to the fix plan and check everything proposed against the actual code. Two independent reviews run **in parallel**, iterating until clean.
+Go back to the fix plan and check everything proposed against the actual code. All available reviewers run **in parallel**, iterating until clean.
 
 **Per iteration:**
 
@@ -284,12 +284,12 @@ If Codex is NOT available:
 
 Gather severity-tagged findings from all available reviewers. Use this rubric:
 
-| Level | Meaning | Action |
-|-------|---------|--------|
-| P0 | Broken — will crash, lose data, or security vulnerability | Must fix |
-| P1 | Wrong — incorrect behavior, logic error, missing edge case | Must fix |
-| P2 | Poor — code smell, maintainability, unclear intent, missing test | Must fix |
-| P3 | Nit — style, naming, minor suggestion | May fix, does not block |
+| Level | Meaning                                                                | Action                     |
+| ----- | ---------------------------------------------------------------------- | -------------------------- |
+| P0    | Broken — will crash, lose data, or create security vulnerability       | Must fix before proceeding |
+| P1    | Wrong — incorrect behavior, logic error, missing edge case             | Must fix before proceeding |
+| P2    | Poor — code smell, maintainability issue, unclear intent, missing test | Must fix before proceeding |
+| P3    | Nit — style, naming, minor suggestion                                  | May fix, does not block    |
 
 **Step C — Exit criteria:**
 
@@ -297,6 +297,7 @@ Gather severity-tagged findings from all available reviewers. Use this rubric:
 - **Only P3 or clean from all available reviewers on the same pass →** Check the box in CONTINUITY with final count: `- [x] Plan review loop (3 iterations) — PASS`. Proceed to Phase 4.
 
 **Rules:**
+
 - Do NOT check the box until all available reviewers report no P0/P1/P2 on the same pass
 - "Available reviewers" = Claude always + Codex if installed, or user if Codex unavailable
 - Typically 2-3 iterations
@@ -331,9 +332,9 @@ Or for simple fixes, write a failing test first, then fix.
 > - Perform equivalent checks manually (see fallbacks below)
 > - Do NOT skip quality gates
 
-### 5.1 Code Review Loop — Dual Review (MANDATORY)
+### 5.1 Code Review Loop (MANDATORY)
 
-Run both reviews **in parallel**, iterating until clean.
+Run all available reviews **in parallel**, iterating until clean.
 
 **Per iteration:**
 
@@ -364,6 +365,7 @@ Note: `/codex review` uses the codex.md command which has its own prompt format.
 This runs 6 specialized agents: code-reviewer, silent-failure-hunter, pr-test-analyzer, comment-analyzer, type-design-analyzer, and code-simplifier.
 
 **Tool availability:**
+
 - **Both available (normal):** Run Codex + PR Toolkit in parallel
 - **Codex unavailable:** PR Toolkit alone is sufficient
 - **PR Toolkit unavailable:** Codex alone is sufficient
@@ -379,6 +381,7 @@ Gather severity-tagged findings from all available reviewers. Use the same P0–
 - **Only P3 or clean from all available reviewers on the same pass →** Check the box in CONTINUITY with final count: `- [x] Code review loop (3 iterations) — PASS`. Proceed to 5.2.
 
 **Rules:**
+
 - Do NOT check the box until all available reviewers report no P0/P1/P2 on the same pass
 - Typically 2-3 iterations
 - P3s are acceptable — do not iterate for P3-only findings

--- a/commands/new-feature.md
+++ b/commands/new-feature.md
@@ -228,9 +228,9 @@ This loads the full design skill — creative direction, animation techniques, t
 /superpowers:writing-plans
 ```
 
-### 3.3 Plan Review Loop — Dual Review (MANDATORY)
+### 3.3 Plan Review Loop (MANDATORY)
 
-Go back to the implementation plan and check everything proposed against the actual code. Two independent reviews run **in parallel**, iterating until clean.
+Go back to the implementation plan and check everything proposed against the actual code. All available reviewers run **in parallel**, iterating until clean.
 
 **Per iteration:**
 
@@ -273,12 +273,12 @@ If Codex is NOT available:
 
 Gather severity-tagged findings from all available reviewers. Use this rubric:
 
-| Level | Meaning | Action |
-|-------|---------|--------|
-| P0 | Broken — will crash, lose data, or security vulnerability | Must fix |
-| P1 | Wrong — incorrect behavior, logic error, missing edge case | Must fix |
-| P2 | Poor — code smell, maintainability, unclear intent, missing test | Must fix |
-| P3 | Nit — style, naming, minor suggestion | May fix, does not block |
+| Level | Meaning                                                                | Action                     |
+| ----- | ---------------------------------------------------------------------- | -------------------------- |
+| P0    | Broken — will crash, lose data, or create security vulnerability       | Must fix before proceeding |
+| P1    | Wrong — incorrect behavior, logic error, missing edge case             | Must fix before proceeding |
+| P2    | Poor — code smell, maintainability issue, unclear intent, missing test | Must fix before proceeding |
+| P3    | Nit — style, naming, minor suggestion                                  | May fix, does not block    |
 
 **Step C — Exit criteria:**
 
@@ -286,6 +286,7 @@ Gather severity-tagged findings from all available reviewers. Use this rubric:
 - **Only P3 or clean from all available reviewers on the same pass →** Check the box in CONTINUITY with final count: `- [x] Plan review loop (3 iterations) — PASS`. Proceed to Phase 4.
 
 **Rules:**
+
 - Do NOT check the box until all available reviewers report no P0/P1/P2 on the same pass
 - "Available reviewers" = Claude always + Codex if installed, or user if Codex unavailable
 - Typically 2-3 iterations
@@ -324,9 +325,9 @@ Implement using TDD (Red-Green-Refactor):
 > - Perform equivalent checks manually (see fallbacks below)
 > - Do NOT skip quality gates
 
-### 5.1 Code Review Loop — Dual Review (MANDATORY)
+### 5.1 Code Review Loop (MANDATORY)
 
-Run both reviews **in parallel**, iterating until clean.
+Run all available reviews **in parallel**, iterating until clean.
 
 **Per iteration:**
 
@@ -357,6 +358,7 @@ Note: `/codex review` uses the codex.md command which has its own prompt format.
 This runs 6 specialized agents: code-reviewer, silent-failure-hunter, pr-test-analyzer, comment-analyzer, type-design-analyzer, and code-simplifier.
 
 **Tool availability:**
+
 - **Both available (normal):** Run Codex + PR Toolkit in parallel
 - **Codex unavailable:** PR Toolkit alone is sufficient
 - **PR Toolkit unavailable:** Codex alone is sufficient
@@ -372,6 +374,7 @@ Gather severity-tagged findings from all available reviewers. Use the same P0–
 - **Only P3 or clean from all available reviewers on the same pass →** Check the box in CONTINUITY with final count: `- [x] Code review loop (3 iterations) — PASS`. Proceed to 5.2.
 
 **Rules:**
+
 - Do NOT check the box until all available reviewers report no P0/P1/P2 on the same pass
 - Typically 2-3 iterations
 - P3s are acceptable — do not iterate for P3-only findings

--- a/commands/new-feature.md
+++ b/commands/new-feature.md
@@ -129,9 +129,9 @@ Write the `## Workflow` section in CONTINUITY.md (create the file if it doesn't 
 - [ ] Design guidance loaded (if UI)
 - [ ] Brainstorming complete
 - [ ] Plan written
-- [ ] Plan vs code verified (dual review)
+- [ ] Plan review loop (0 iterations) — iterate until no P0/P1/P2
 - [ ] TDD execution complete
-- [ ] Code review loop (no P0/P1/P2)
+- [ ] Code review loop (0 iterations) — iterate until no P0/P1/P2
 - [ ] Simplified
 - [ ] Verified (tests/lint/types)
 - [ ] E2E tested (if API changed)
@@ -202,7 +202,7 @@ Before writing ANY code, research the problem space:
 
 ---
 
-## Phase 3: Design + Review Loop (iterates until no P0/P1 issues)
+## Phase 3: Design + Review Loop (iterates until no P0/P1/P2 issues)
 
 > **Checkpoint:** Update `## Workflow` in CONTINUITY.md — Phase: `3 — Design`, check off "Research done".
 
@@ -228,9 +228,13 @@ This loads the full design skill — creative direction, animation techniques, t
 /superpowers:writing-plans
 ```
 
-### 3.3 Plan vs Code Verification — Dual Review (MANDATORY)
+### 3.3 Plan Review Loop — Dual Review (MANDATORY)
 
-Go back to the implementation plan and check everything proposed against the actual code. Verify it's the simplest, fastest, best way to do it. Two independent reviews run **in parallel**:
+Go back to the implementation plan and check everything proposed against the actual code. Two independent reviews run **in parallel**, iterating until clean.
+
+**Per iteration:**
+
+**Step A — Run both reviews in parallel:**
 
 **a) Claude (you) reviews the plan against the codebase:**
 
@@ -241,9 +245,9 @@ Read every file the plan proposes to modify. For each change, ask:
 - Are there existing utilities, patterns, or abstractions the plan should use instead of creating new ones?
 - Is anything proposed that's unnecessary or over-engineered?
 
-Document your findings as a list of concerns (P0/P1/P2).
+Document your findings as a severity-tagged list (P0/P1/P2/P3).
 
-**b) Codex reviews independently and separately:**
+**b) Codex reviews independently:**
 
 Check if Codex CLI is available:
 
@@ -257,21 +261,35 @@ If available:
 /codex review the implementation plan and check everything we're proposing versus the code — is this the simplest, fastest, best way to do it? Flag any architectural concerns.
 ```
 
+Note: The `/codex` command's Design Review Mode uses its own fixed prompt — it may not return P0/P1/P2/P3 tags directly. After receiving Codex's output, classify each finding into P0/P1/P2/P3 using the severity rubric before evaluating exit criteria.
+
 If Codex is NOT available:
 
 - Present your own review findings plus a summary of the plan to the user
 - Ask: "Does this design approach look right before I start implementing?"
-- Wait for user confirmation before proceeding to Phase 4
+- User confirmation replaces Codex as the second reviewer
 
-### 3.4 Iterate until approved
+**Step B — Collect findings and evaluate:**
 
-**If either review finds P0 or P1 issues:**
+Gather severity-tagged findings from all available reviewers. Use this rubric:
 
-1. Edit the plan to address the issues
-2. Run **both** reviews again (Claude + Codex in parallel)
-3. Repeat until there are **no P0 or P1 issues** from either reviewer
+| Level | Meaning | Action |
+|-------|---------|--------|
+| P0 | Broken — will crash, lose data, or security vulnerability | Must fix |
+| P1 | Wrong — incorrect behavior, logic error, missing edge case | Must fix |
+| P2 | Poor — code smell, maintainability, unclear intent, missing test | Must fix |
+| P3 | Nit — style, naming, minor suggestion | May fix, does not block |
 
-This loop typically runs 4-6 times. Do NOT proceed to Phase 4 until the plan is approved.
+**Step C — Exit criteria:**
+
+- **P0/P1/P2 found by any reviewer →** Fix the plan, increment iteration counter in CONTINUITY checklist (`Plan review loop (N iterations)`), go back to Step A.
+- **Only P3 or clean from all available reviewers on the same pass →** Check the box in CONTINUITY with final count: `- [x] Plan review loop (3 iterations) — PASS`. Proceed to Phase 4.
+
+**Rules:**
+- Do NOT check the box until all available reviewers report no P0/P1/P2 on the same pass
+- "Available reviewers" = Claude always + Codex if installed, or user if Codex unavailable
+- Typically 2-3 iterations
+- Do NOT proceed to Phase 4 until the plan is approved
 
 > **Why mandatory?** Fixing a design flaw after implementation is 10x more expensive than catching it here. Two independent reviewers checking the plan against the actual code catches things a single pass misses.
 
@@ -306,9 +324,13 @@ Implement using TDD (Red-Green-Refactor):
 > - Perform equivalent checks manually (see fallbacks below)
 > - Do NOT skip quality gates
 
-### 5.1 Code Review Loop (repeats until no P0/P1/P2 issues — P3s acceptable)
+### 5.1 Code Review Loop — Dual Review (MANDATORY)
 
-Run both reviews **in parallel**:
+Run both reviews **in parallel**, iterating until clean.
+
+**Per iteration:**
+
+**Step A — Run both reviews in parallel:**
 
 **a) Second Opinion (Codex CLI):**
 
@@ -324,6 +346,8 @@ If available:
 /codex review
 ```
 
+Note: `/codex review` uses the codex.md command which has its own prompt format. After receiving Codex's output, classify each finding into P0/P1/P2/P3 using the severity rubric before evaluating exit criteria.
+
 **b) Deep Review (PR Review Toolkit):**
 
 ```
@@ -332,13 +356,25 @@ If available:
 
 This runs 6 specialized agents: code-reviewer, silent-failure-hunter, pr-test-analyzer, comment-analyzer, type-design-analyzer, and code-simplifier.
 
-**Fallback if unavailable:** Use `pr-review-toolkit:code-reviewer` agent on modified files.
+**Tool availability:**
+- **Both available (normal):** Run Codex + PR Toolkit in parallel
+- **Codex unavailable:** PR Toolkit alone is sufficient
+- **PR Toolkit unavailable:** Codex alone is sufficient
+- **Neither available:** Alert user, perform manual review, get user sign-off
 
-**Iterate:** If either review finds P0, P1, or P2 issues:
+**Step B — Collect findings and evaluate:**
 
-1. Fix the issues
-2. Run **both** reviews again
-3. Repeat until there are **no P0/P1/P2 issues** (P3s are acceptable)
+Gather severity-tagged findings from all available reviewers. Use the same P0–P3 rubric from the plan review loop.
+
+**Step C — Exit criteria:**
+
+- **P0/P1/P2 found by any reviewer →** Fix the issues. If fixes are substantial (3+ files changed), re-run verify-app before next review iteration to catch regressions early. Increment counter in CONTINUITY checklist (`Code review loop (N iterations)`), go back to Step A.
+- **Only P3 or clean from all available reviewers on the same pass →** Check the box in CONTINUITY with final count: `- [x] Code review loop (3 iterations) — PASS`. Proceed to 5.2.
+
+**Rules:**
+- Do NOT check the box until all available reviewers report no P0/P1/P2 on the same pass
+- Typically 2-3 iterations
+- P3s are acceptable — do not iterate for P3-only findings
 
 ### 5.2 Simplify
 

--- a/hooks/check-workflow-gates.ps1
+++ b/hooks/check-workflow-gates.ps1
@@ -50,6 +50,9 @@ $unchecked = @()
 foreach ($line in ($content -split "`n")) {
     if ($line -match '^### Checklist') { $inChecklist = $true; continue }
     if ($line -match '^## ' -and $inChecklist) { break }
+    # Only gate on: "Code review loop", "Simplified", "Verified (tests"
+    # Exclude: "PR reviews addressed" (post-PR), "Plugins verified" (pre-flight),
+    #          "Plan review loop" (design phase discipline, not pre-ship gate)
     if ($inChecklist -and $line -match '- \[ \]' -and $line -match '(Code review loop|Simplified|Verified \(tests)') {
         $unchecked += $line
     }

--- a/hooks/check-workflow-gates.sh
+++ b/hooks/check-workflow-gates.sh
@@ -59,7 +59,7 @@ CHECKLIST=$(sed -n '/^### Checklist/,/^## /p' CONTINUITY.md 2>/dev/null)
 # Explicitly exclude non-gate items that contain similar words:
 #   "PR reviews addressed" — happens AFTER PR, not a pre-ship gate
 #   "Plugins verified" — pre-flight check, not a quality gate
-#   "Plan vs code verified" — design phase, not a quality gate
+#   "Plan review loop" — design phase discipline, not a pre-ship gate
 UNCHECKED=$(echo "$CHECKLIST" | grep '\- \[ \]' | grep -iE '(Code review loop|Simplified|Verified \(tests)' || true)
 
 if [ -n "$UNCHECKED" ]; then

--- a/rules/workflow.md
+++ b/rules/workflow.md
@@ -24,3 +24,33 @@
 4. **On phase transition**: Update the `Phase` field
 
 The Stop hook reminds you of the current phase on every response. The PreToolUse hook blocks commit/push/PR if quality gates are incomplete. This rule is re-injected every turn — it survives context compaction.
+
+## Severity Rubric
+
+| Level | Meaning | Action |
+|-------|---------|--------|
+| P0 | Broken — will crash, lose data, or create security vulnerability | Must fix before proceeding |
+| P1 | Wrong — incorrect behavior, logic error, missing edge case | Must fix before proceeding |
+| P2 | Poor — code smell, maintainability issue, unclear intent, missing test | Must fix before proceeding |
+| P3 | Nit — style, naming, minor suggestion | May fix, does not block |
+
+## Revision Loop Protocol
+
+Two revision loops enforce quality as a discipline protocol. Both follow the same pattern:
+
+1. Run all available reviewers in parallel
+2. Collect severity-tagged findings (P0/P1/P2/P3) using the rubric above
+3. If P0/P1/P2 found → fix, increment counter in CONTINUITY checklist, repeat
+4. If only P3 or clean → check the box with final iteration count, proceed (P3s do not block)
+
+**Plan review loop** (Phase 3): Claude + Codex review the plan against actual code.
+Exit when: no P0/P1/P2 from all available reviewers on the same pass.
+If Codex unavailable: Claude + user confirmation is sufficient.
+
+**Code review loop** (Phase 5): Codex + PR Review Toolkit review the implementation.
+Exit when: no P0/P1/P2 from all available reviewers on the same pass.
+If Codex unavailable: PR Toolkit alone is sufficient.
+If PR Toolkit unavailable: Codex alone is sufficient.
+If neither available: alert user, manual review + user sign-off.
+
+Never check a loop box until all available reviewers pass clean on the same iteration.

--- a/rules/workflow.md
+++ b/rules/workflow.md
@@ -27,12 +27,12 @@ The Stop hook reminds you of the current phase on every response. The PreToolUse
 
 ## Severity Rubric
 
-| Level | Meaning | Action |
-|-------|---------|--------|
-| P0 | Broken — will crash, lose data, or create security vulnerability | Must fix before proceeding |
-| P1 | Wrong — incorrect behavior, logic error, missing edge case | Must fix before proceeding |
-| P2 | Poor — code smell, maintainability issue, unclear intent, missing test | Must fix before proceeding |
-| P3 | Nit — style, naming, minor suggestion | May fix, does not block |
+| Level | Meaning                                                                | Action                     |
+| ----- | ---------------------------------------------------------------------- | -------------------------- |
+| P0    | Broken — will crash, lose data, or create security vulnerability       | Must fix before proceeding |
+| P1    | Wrong — incorrect behavior, logic error, missing edge case             | Must fix before proceeding |
+| P2    | Poor — code smell, maintainability issue, unclear intent, missing test | Must fix before proceeding |
+| P3    | Nit — style, naming, minor suggestion                                  | May fix, does not block    |
 
 ## Revision Loop Protocol
 
@@ -43,9 +43,10 @@ Two revision loops enforce quality as a discipline protocol. Both follow the sam
 3. If P0/P1/P2 found → fix, increment counter in CONTINUITY checklist, repeat
 4. If only P3 or clean → check the box with final iteration count, proceed (P3s do not block)
 
-**Plan review loop** (Phase 3): Claude + Codex review the plan against actual code.
+**Plan review loop** (Phase 3, when entered): Claude + Codex review the plan against actual code.
 Exit when: no P0/P1/P2 from all available reviewers on the same pass.
 If Codex unavailable: Claude + user confirmation is sufficient.
+Note: `/fix-bug` skips Phase 3 for simple fixes (1-2 files) — the plan review loop only runs for complex fixes.
 
 **Code review loop** (Phase 5): Codex + PR Review Toolkit review the implementation.
 Exit when: no P0/P1/P2 from all available reviewers on the same pass.


### PR DESCRIPTION
## Summary

- **Two explicit revision loops** replace loose "iterate until clean" instructions in `/new-feature` and `/fix-bug` commands
- **Plan review loop** (Phase 3): Claude + Codex in parallel, counter-tracked iterations, exit when no P0/P1/P2 from all available reviewers on same pass
- **Code review loop** (Phase 5): Codex + PR Review Toolkit in parallel, same protocol
- **P0/P1/P2/P3 severity rubric** added to `rules/workflow.md` — survives context compaction
- **Tool-unavailable fallback matrix** for graceful degradation (Codex missing, PR Toolkit missing, both missing)
- Hook comments updated for parity (.sh + .ps1), README diagram thresholds updated

## Files changed (6)

| File | Change |
|------|--------|
| `commands/new-feature.md` | Checklist items + rewritten Phase 3.3 and 5.1 with loop protocol |
| `commands/fix-bug.md` | Same changes, plan loop conditional ("if complex") |
| `rules/workflow.md` | Added Severity Rubric + Revision Loop Protocol sections |
| `hooks/check-workflow-gates.sh` | Comment update only (stale reference) |
| `hooks/check-workflow-gates.ps1` | Added exclusion comments |
| `README.md` | Diagram thresholds + dual-reviewer label |

## Review process

- 7 Codex plan review iterations to reach zero P0/P1/P2
- 2 code review iterations (Codex + PR Review Toolkit in parallel) to reach zero P0/P1/P2
- Hook compatibility verified with regex tests + mock CONTINUITY.md end-to-end

## Test plan

- [x] Hook regex matches new "Code review loop (0 iterations)" text
- [x] Hook regex does NOT match "Plan review loop" (not a pre-ship gate)
- [x] Mock CONTINUITY.md: hook blocks when gates incomplete (exit 2)
- [x] Mock CONTINUITY.md: hook allows when all gates checked (exit 0)
- [x] No behavioral changes to hooks — comments only

🤖 Generated with [Claude Code](https://claude.com/claude-code)