### PR TITLE
feat: user-centric E2E testing with use case template

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This template adds structured workflows, automated quality gates, knowledge comp
 | Context lost between sessions              | **State persistence** — CONTINUITY.md tracks Done/Now/Next across sessions                                                                                     |
 | Can't run multiple features in parallel    | **Git worktrees** — isolated workspaces for parallel Claude sessions                                                                                           |
 | Code review happens too late               | **Multi-layer review** — `/codex review` (first, independent) → `/pr-review-toolkit:review-pr` (deep) → `/simplify` → `/review-pr-comments` (post-PR comments) |
-| E2E testing skipped                        | **Playwright MCP** — browser testing via standalone MCP server for UI/API changes                                                                              |
+| E2E testing skipped                        | **Playwright MCP** — user use case tests via standalone MCP server for any user-facing changes                                                                 |
 
 ## Key Features
 

--- a/README.md
+++ b/README.md
@@ -632,9 +632,9 @@ How a feature goes from idea to merged PR.
                             │
                             ▼
 ┌─────────────────────────────────────────────────────────────┐
-│ 9. E2E TESTING (if UI/API changed)                          │
+│ 9. E2E USE CASE TESTS (if user-facing changes)              │
 │    Playwright MCP server                                    │
-│    → Browser tests against affected routes                 │
+│    → User use cases: intent, steps, verify, persist        │
 └─────────────────────────────────────────────────────────────┘
                             │
                             ▼

--- a/agents/verify-app.md
+++ b/agents/verify-app.md
@@ -13,12 +13,14 @@ You are a verification specialist. Your job is to run ALL verification (unit tes
 ## Verification Process
 
 ### Step 1: Identify What Changed
+
 ```bash
 git diff --name-only HEAD
 git status --porcelain
 ```
 
 Categorize:
+
 - Python files → backend tests + types + lint
 - TypeScript/TSX files → frontend tests + build
 - Models/schema files → migration check
@@ -26,6 +28,7 @@ Categorize:
 ### Step 2: Run Unit Tests
 
 **Backend (if Python files changed):**
+
 ```bash
 cd src && uv run pytest -v --tb=short
 cd src && uv run mypy --strict {package_name}
@@ -33,6 +36,7 @@ cd src && uv run ruff check .
 ```
 
 **Frontend (if TS/TSX files changed):**
+
 ```bash
 cd frontend && pnpm test
 cd frontend && pnpm build
@@ -41,6 +45,7 @@ cd frontend && pnpm build
 ### Step 3: Check Migrations
 
 If model/schema files changed, check for pending migrations:
+
 ```bash
 # Alembic
 cd src && alembic current && alembic heads
@@ -82,12 +87,14 @@ Use this format:
 ## When to Approve
 
 ✅ **APPROVE if:**
+
 - All unit tests pass
 - No type errors or lint errors
 - Build succeeds
 - No pending migrations (or migration was created)
 
 ❌ **DO NOT APPROVE if:**
+
 - Any test fails
 - Type/lint errors exist
 - Build fails
@@ -96,11 +103,13 @@ Use this format:
 ## Example Responses
 
 **Approved:**
+
 > "✅ APPROVED. 127 backend tests pass, frontend builds, no pending migrations."
 
 **Needs work:**
+
 > "❌ NEEDS WORK. Migration needed: User model has new 'role' field but no migration. Run: alembic revision --autogenerate -m 'add user role'"
 
 ---
 
-**Reminder:** After this agent passes, use the Playwright MCP server for E2E verification of UI/API changes.
+**Reminder:** After this agent passes, execute E2E use case tests via Playwright MCP for any user-facing changes.

--- a/commands/fix-bug.md
+++ b/commands/fix-bug.md
@@ -134,7 +134,7 @@ Write the `## Workflow` section in CONTINUITY.md (create the file if it doesn't 
 - [ ] Code review loop (0 iterations) — iterate until no P0/P1/P2
 - [ ] Simplified
 - [ ] Verified (tests/lint/types)
-- [ ] E2E tested (if API changed)
+- [ ] E2E use cases tested (if user-facing)
 - [ ] Learning documented
 - [ ] State files updated
 - [ ] Committed and pushed
@@ -238,6 +238,21 @@ This ensures UI fixes maintain visual quality — don't regress the design while
 ```
 /superpowers:writing-plans
 ```
+
+#### 3.2b Design E2E Use Cases (if user-facing)
+
+If this fix changes any user-facing behavior, design E2E use cases NOW.
+
+Write use cases in the plan file using the template from `rules/testing.md`. Each use case needs: **Intent, Steps, Verification, Persistence**.
+
+For bug fixes, think about:
+- What was the user doing when the bug occurred? Reproduce that as a use case.
+- After the fix, does the happy path still work?
+- Could the fix break any adjacent user flow?
+
+**Minimum:** 1 use case that reproduces the original bug through the UI and verifies the fix.
+
+**If purely internal (no user-facing impact):** Write "E2E: N/A — [reason]" in the plan.
 
 #### 3.3 Plan Review Loop (MANDATORY)
 
@@ -417,17 +432,23 @@ pytest && ruff check . && mypy .  # Python
 npm test && npm run lint && npm run typecheck  # Node
 ```
 
-### 5.4 E2E Tests (MANDATORY if API changed)
+### 5.4 E2E Use Case Tests (MANDATORY if user-facing)
 
-**If you modified ANY API endpoint, you MUST run E2E tests.**
+**If this fix changes ANY user-facing behavior, execute E2E tests.**
 
-The API doesn't exist in isolation - frontend code depends on it. Even if you didn't touch the frontend, API changes can break existing UI functionality.
+User-facing means: API changes, UI changes, new pages, flow changes, form changes, navigation changes, permission changes — anything a user would notice.
 
-**Step 1: Find what uses the changed API**
+**If purely internal (no user-facing impact):** Check the box with justification:
+`- [x] E2E use cases tested — N/A: internal migration, no user-facing changes`
 
-```bash
-# Search frontend for API endpoint usage
-grep -r "your-endpoint-path" frontend/
+**Step 1: Review use cases from Phase 3 plan**
+
+Open the plan file and review the E2E use cases designed earlier. Refine if implementation revealed new scenarios. Add the use cases to CONTINUITY.md for tracking:
+
+```markdown
+#### E2E Use Cases
+- [ ] UC1: [Intent] — [one-line summary]
+- [ ] UC2: [Intent] — [one-line summary]
 ```
 
 **Step 2: Restart servers from worktree (CRITICAL if in worktree)**
@@ -438,17 +459,31 @@ Stop the current development servers and start them from this worktree directory
 
 Wait for servers to be ready before proceeding.
 
-**Step 3: Run E2E tests using Playwright MCP**
+**Step 3: Execute each use case with Playwright MCP**
 
-Use the Playwright MCP server to run browser tests against affected routes. Navigate to the affected pages, interact with the changed functionality, and verify it works end-to-end.
+For each use case, execute the Steps through the browser:
+- Navigate to the starting page
+- Perform each user action (click, fill, select, submit)
+- Verify the expected outcome is visible
+- **Reload the page and confirm persistence**
 
-**DO NOT skip this step by saying:**
+Check off each use case in CONTINUITY.md as it passes.
 
-- ❌ "No frontend exists for this endpoint" → Test the UI that USES the API
-- ❌ "Unit tests cover it" → Unit tests don't catch integration issues
-- ❌ "The fix is backend only" → Backend fixes can break frontend behavior
+**Step 4: Test error paths**
 
-**Only skip if:** The change is purely backend with NO frontend consumers.
+For each error use case:
+- Trigger the error condition through the UI
+- Verify the user sees an appropriate error message
+- Verify no data was corrupted (check the happy path still works)
+
+**DO NOT skip by saying:**
+
+- ❌ "No frontend exists" → Test the UI that consumes the API
+- ❌ "Unit tests cover it" → Unit tests don't test user workflows
+- ❌ "It's a small change" → Small changes break real user flows
+- ❌ "I tested it manually" → Playwright MCP IS the manual test, automated
+
+**Only skip if:** Purely internal with zero user-facing impact (must justify in checklist).
 
 ---
 

--- a/commands/fix-bug.md
+++ b/commands/fix-bug.md
@@ -241,11 +241,12 @@ This ensures UI fixes maintain visual quality — don't regress the design while
 
 #### 3.2b Design E2E Use Cases (if user-facing)
 
-If this fix changes any user-facing behavior, design E2E use cases NOW.
+If this fix changes any user-facing behavior (UI, API, flows, forms, navigation, permissions), design E2E use cases NOW — before implementation, not after.
 
 Write use cases in the plan file using the template from `rules/testing.md`. Each use case needs: **Intent, Steps, Verification, Persistence**.
 
 For bug fixes, think about:
+
 - What was the user doing when the bug occurred? Reproduce that as a use case.
 - After the fix, does the happy path still work?
 - Could the fix break any adjacent user flow?
@@ -441,12 +442,17 @@ User-facing means: API changes, UI changes, new pages, flow changes, form change
 **If purely internal (no user-facing impact):** Check the box with justification:
 `- [x] E2E use cases tested — N/A: internal migration, no user-facing changes`
 
-**Step 1: Review use cases from Phase 3 plan**
+**Step 1: Review or design use cases**
 
-Open the plan file and review the E2E use cases designed earlier. Refine if implementation revealed new scenarios. Add the use cases to CONTINUITY.md for tracking:
+If Phase 3 was used (complex fix): open the plan file and review the E2E use cases designed earlier. Refine if implementation revealed new scenarios.
+
+If Phase 3 was skipped (simple fix): design use cases now using the template from `rules/testing.md`. At minimum: 1 use case that reproduces the original bug through the UI and verifies the fix.
+
+Add the use cases to CONTINUITY.md for tracking:
 
 ```markdown
 #### E2E Use Cases
+
 - [ ] UC1: [Intent] — [one-line summary]
 - [ ] UC2: [Intent] — [one-line summary]
 ```
@@ -462,6 +468,7 @@ Wait for servers to be ready before proceeding.
 **Step 3: Execute each use case with Playwright MCP**
 
 For each use case, execute the Steps through the browser:
+
 - Navigate to the starting page
 - Perform each user action (click, fill, select, submit)
 - Verify the expected outcome is visible
@@ -472,6 +479,7 @@ Check off each use case in CONTINUITY.md as it passes.
 **Step 4: Test error paths**
 
 For each error use case:
+
 - Trigger the error condition through the UI
 - Verify the user sees an appropriate error message
 - Verify no data was corrupted (check the happy path still works)
@@ -484,6 +492,8 @@ For each error use case:
 - ❌ "I tested it manually" → Playwright MCP IS the manual test, automated
 
 **Only skip if:** Purely internal with zero user-facing impact (must justify in checklist).
+
+**Non-browser projects** (API-only services, CLIs, mobile backends): If there's no web UI to drive, execute use cases via API calls (curl/httpie), CLI commands, or document the manual verification steps. The use case template (Intent, Steps, Verification, Persistence) still applies — just replace "UI interactions" with the appropriate interface.
 
 ---
 

--- a/commands/fix-bug.md
+++ b/commands/fix-bug.md
@@ -251,7 +251,7 @@ For bug fixes, think about:
 - After the fix, does the happy path still work?
 - Could the fix break any adjacent user flow?
 
-**Minimum:** 1 use case that reproduces the original bug through the UI and verifies the fix.
+**Minimum:** 1 use case that reproduces the original bug through the user's interface and verifies the fix.
 
 **If purely internal (no user-facing impact):** Write "E2E: N/A — [reason]" in the plan.
 
@@ -446,7 +446,7 @@ User-facing means: API changes, UI changes, new pages, flow changes, form change
 
 If Phase 3 was used (complex fix): open the plan file and review the E2E use cases designed earlier. Refine if implementation revealed new scenarios.
 
-If Phase 3 was skipped (simple fix): design use cases now using the template from `rules/testing.md`. At minimum: 1 use case that reproduces the original bug through the UI and verifies the fix.
+If Phase 3 was skipped (simple fix): design use cases now using the template from `rules/testing.md`. At minimum: 1 use case that reproduces the original bug through the user's interface and verifies the fix.
 
 Add the use cases to CONTINUITY.md for tracking:
 
@@ -486,10 +486,9 @@ For each error use case:
 
 **DO NOT skip by saying:**
 
-- ❌ "No frontend exists" → Test the UI that consumes the API
 - ❌ "Unit tests cover it" → Unit tests don't test user workflows
 - ❌ "It's a small change" → Small changes break real user flows
-- ❌ "I tested it manually" → Playwright MCP IS the manual test, automated
+- ❌ "I'll test it later" → E2E happens now, not after merge
 
 **Only skip if:** Purely internal with zero user-facing impact (must justify in checklist).
 

--- a/commands/new-feature.md
+++ b/commands/new-feature.md
@@ -134,7 +134,7 @@ Write the `## Workflow` section in CONTINUITY.md (create the file if it doesn't 
 - [ ] Code review loop (0 iterations) — iterate until no P0/P1/P2
 - [ ] Simplified
 - [ ] Verified (tests/lint/types)
-- [ ] E2E tested (if API changed)
+- [ ] E2E use cases tested (if user-facing)
 - [ ] Learnings documented (if any)
 - [ ] State files updated
 - [ ] Committed and pushed
@@ -227,6 +227,21 @@ This loads the full design skill — creative direction, animation techniques, t
 ```
 /superpowers:writing-plans
 ```
+
+### 3.2b Design E2E Use Cases (if user-facing)
+
+If this feature changes any user-facing behavior (UI, API, flows, forms, navigation, permissions), design E2E use cases NOW — before implementation, not after.
+
+Write use cases in the plan file using the template from `rules/testing.md`. Each use case needs: **Intent, Steps, Verification, Persistence**.
+
+Think like a user, not a developer:
+- What will the user try to do with this feature?
+- What's the happy path? What are the error paths?
+- What existing flows could this break?
+
+**Minimum:** 1 happy-path use case + 1 error/edge case. Complex features need more.
+
+**If purely internal (no user-facing impact):** Write "E2E: N/A — [reason]" in the plan.
 
 ### 3.3 Plan Review Loop (MANDATORY)
 
@@ -410,17 +425,23 @@ pytest && ruff check . && mypy .  # Python
 npm test && npm run lint && npm run typecheck  # Node
 ```
 
-### 5.4 E2E Tests (MANDATORY if API changed)
+### 5.4 E2E Use Case Tests (MANDATORY if user-facing)
 
-**If you modified ANY API endpoint, you MUST run E2E tests.**
+**If this feature changes ANY user-facing behavior, execute E2E tests.**
 
-The API doesn't exist in isolation - frontend code depends on it. Even if you didn't touch the frontend, API changes can break existing UI functionality.
+User-facing means: API changes, UI changes, new pages, flow changes, form changes, navigation changes, permission changes — anything a user would notice.
 
-**Step 1: Find what uses the changed API**
+**If purely internal (no user-facing impact):** Check the box with justification:
+`- [x] E2E use cases tested — N/A: internal migration, no user-facing changes`
 
-```bash
-# Search frontend for API endpoint usage
-grep -r "your-endpoint-path" frontend/
+**Step 1: Review use cases from Phase 3 plan**
+
+Open the plan file and review the E2E use cases designed earlier. Refine if implementation revealed new scenarios. Add the use cases to CONTINUITY.md for tracking:
+
+```markdown
+#### E2E Use Cases
+- [ ] UC1: [Intent] — [one-line summary]
+- [ ] UC2: [Intent] — [one-line summary]
 ```
 
 **Step 2: Restart servers from worktree (CRITICAL if in worktree)**
@@ -431,17 +452,31 @@ Stop the current development servers and start them from this worktree directory
 
 Wait for servers to be ready before proceeding.
 
-**Step 3: Run E2E tests using Playwright MCP**
+**Step 3: Execute each use case with Playwright MCP**
 
-Use the Playwright MCP server to run browser tests against affected routes. Navigate to the affected pages, interact with the changed functionality, and verify it works end-to-end.
+For each use case, execute the Steps through the browser:
+- Navigate to the starting page
+- Perform each user action (click, fill, select, submit)
+- Verify the expected outcome is visible
+- **Reload the page and confirm persistence**
 
-**DO NOT skip this step by saying:**
+Check off each use case in CONTINUITY.md as it passes.
 
-- ❌ "No frontend exists for this endpoint" → Test the UI that USES the API
-- ❌ "Unit tests cover it" → Unit tests don't catch integration issues
-- ❌ "The API is new" → New APIs should be integration tested
+**Step 4: Test error paths**
 
-**Only skip if:** The change is purely backend with NO frontend consumers (e.g., internal scripts, migrations).
+For each error use case:
+- Trigger the error condition through the UI
+- Verify the user sees an appropriate error message
+- Verify no data was corrupted (check the happy path still works)
+
+**DO NOT skip by saying:**
+
+- ❌ "No frontend exists" → Test the UI that consumes the API
+- ❌ "Unit tests cover it" → Unit tests don't test user workflows
+- ❌ "It's a small change" → Small changes break real user flows
+- ❌ "I tested it manually" → Playwright MCP IS the manual test, automated
+
+**Only skip if:** Purely internal with zero user-facing impact (must justify in checklist).
 
 ---
 

--- a/commands/new-feature.md
+++ b/commands/new-feature.md
@@ -235,6 +235,7 @@ If this feature changes any user-facing behavior (UI, API, flows, forms, navigat
 Write use cases in the plan file using the template from `rules/testing.md`. Each use case needs: **Intent, Steps, Verification, Persistence**.
 
 Think like a user, not a developer:
+
 - What will the user try to do with this feature?
 - What's the happy path? What are the error paths?
 - What existing flows could this break?
@@ -440,6 +441,7 @@ Open the plan file and review the E2E use cases designed earlier. Refine if impl
 
 ```markdown
 #### E2E Use Cases
+
 - [ ] UC1: [Intent] — [one-line summary]
 - [ ] UC2: [Intent] — [one-line summary]
 ```
@@ -455,6 +457,7 @@ Wait for servers to be ready before proceeding.
 **Step 3: Execute each use case with Playwright MCP**
 
 For each use case, execute the Steps through the browser:
+
 - Navigate to the starting page
 - Perform each user action (click, fill, select, submit)
 - Verify the expected outcome is visible
@@ -465,6 +468,7 @@ Check off each use case in CONTINUITY.md as it passes.
 **Step 4: Test error paths**
 
 For each error use case:
+
 - Trigger the error condition through the UI
 - Verify the user sees an appropriate error message
 - Verify no data was corrupted (check the happy path still works)
@@ -477,6 +481,8 @@ For each error use case:
 - ❌ "I tested it manually" → Playwright MCP IS the manual test, automated
 
 **Only skip if:** Purely internal with zero user-facing impact (must justify in checklist).
+
+**Non-browser projects** (API-only services, CLIs, mobile backends): If there's no web UI to drive, execute use cases via API calls (curl/httpie), CLI commands, or document the manual verification steps. The use case template (Intent, Steps, Verification, Persistence) still applies — just replace "UI interactions" with the appropriate interface.
 
 ---
 

--- a/commands/new-feature.md
+++ b/commands/new-feature.md
@@ -475,10 +475,9 @@ For each error use case:
 
 **DO NOT skip by saying:**
 
-- ❌ "No frontend exists" → Test the UI that consumes the API
 - ❌ "Unit tests cover it" → Unit tests don't test user workflows
 - ❌ "It's a small change" → Small changes break real user flows
-- ❌ "I tested it manually" → Playwright MCP IS the manual test, automated
+- ❌ "I'll test it later" → E2E happens now, not after merge
 
 **Only skip if:** Purely internal with zero user-facing impact (must justify in checklist).
 

--- a/hooks/check-workflow-gates.ps1
+++ b/hooks/check-workflow-gates.ps1
@@ -7,7 +7,7 @@
 # 3. Always-required quality gate checklist items aren't checked off
 #
 # Only gates on ALWAYS-REQUIRED items (review, simplify, verify).
-# Conditional items like "E2E tested (if API changed)" are NOT gated.
+# Conditional items like "E2E use cases tested (if user-facing)" are NOT gated.
 #
 # Requirements: PowerShell 5.1+
 

--- a/hooks/check-workflow-gates.sh
+++ b/hooks/check-workflow-gates.sh
@@ -8,7 +8,7 @@
 # 3. Always-required quality gate checklist items aren't checked off
 #
 # Only gates on ALWAYS-REQUIRED items (review, simplify, verify).
-# Conditional items like "E2E tested (if API changed)" are NOT gated —
+# Conditional items like "E2E use cases tested (if user-facing)" are NOT gated —
 # the model decides if they apply.
 #
 # Input (JSON via stdin): {session_id, cwd, tool_name, tool_input: {command}}

--- a/rules/critical-rules.md
+++ b/rules/critical-rules.md
@@ -5,7 +5,7 @@
 - **SYSTEMATIC DEBUGGING** - Use `/superpowers:systematic-debugging` for bugs
 - **DESIGN REVIEW** - Get a second opinion (Codex or user) on the plan BEFORE implementing
 - **TDD MANDATORY** - Red-Green-Refactor via Superpowers
-- **E2E TESTING** - Playwright MCP for UI/API changes
+- **E2E TESTING** - User use cases via Playwright MCP for any user-facing changes
 - **UPDATE STATE** - CONTINUITY.md + CHANGELOG.md (Stop hook enforces)
 - **RESEARCH FIRST** - WebSearch/WebFetch/Context7 before implementing
 - **CHALLENGE ME** - Don't blindly agree

--- a/rules/critical-rules.md
+++ b/rules/critical-rules.md
@@ -5,7 +5,7 @@
 - **SYSTEMATIC DEBUGGING** - Use `/superpowers:systematic-debugging` for bugs
 - **DESIGN REVIEW** - Get a second opinion (Codex or user) on the plan BEFORE implementing
 - **TDD MANDATORY** - Red-Green-Refactor via Superpowers
-- **E2E TESTING** - User use cases via Playwright MCP for any user-facing changes
+- **E2E TESTING** - User use cases for any user-facing changes (Playwright for web, API/CLI verification for non-browser)
 - **UPDATE STATE** - CONTINUITY.md + CHANGELOG.md (Stop hook enforces)
 - **RESEARCH FIRST** - WebSearch/WebFetch/Context7 before implementing
 - **CHALLENGE ME** - Don't blindly agree

--- a/rules/testing.md
+++ b/rules/testing.md
@@ -1,6 +1,7 @@
 # Testing
 
 ## Structure
+
 ```
 tests/
 ├── conftest.py      # Shared fixtures
@@ -10,6 +11,7 @@ tests/
 ```
 
 ## Naming
+
 - Files: `test_{module}.py`
 - Functions: `test_{action}_{scenario}_{expected}`
 
@@ -19,6 +21,7 @@ def test_create_user_with_duplicate_email_raises_conflict(): ...
 ```
 
 ## Arrange-Act-Assert Pattern
+
 ALWAYS structure tests with clear AAA separation:
 
 ```python
@@ -26,16 +29,17 @@ async def test_create_user_with_valid_data(session):
     # Arrange
     repo = UserRepository(session)
     data = UserCreate(email="test@example.com", name="Test")
-    
+
     # Act
     result = await repo.create(data)
-    
+
     # Assert
     assert result.id is not None
     assert result.email == "test@example.com"
 ```
 
 ## Fixtures
+
 Use factories over hard-coded data:
 
 ```python
@@ -52,12 +56,13 @@ async def test_get_user(session, make_user):
 ```
 
 ## Mocking Rules
-| Mock | Don't Mock |
-|------|------------|
-| External APIs (Stripe, OpenAI) | Your own code |
-| Email/SMS services | Database in integration tests |
-| Network requests | Business logic |
-| Time (`datetime.now`) | Repository methods |
+
+| Mock                           | Don't Mock                    |
+| ------------------------------ | ----------------------------- |
+| External APIs (Stripe, OpenAI) | Your own code                 |
+| Email/SMS services             | Database in integration tests |
+| Network requests               | Business logic                |
+| Time (`datetime.now`)          | Repository methods            |
 
 ```python
 # Mock external services
@@ -68,22 +73,25 @@ async def test_signup_sends_welcome_email(mock_send, client):
 ```
 
 ## E2E Tests (Playwright)
+
 Use stable selectors:
+
 ```typescript
 // CORRECT: data-testid or role
-await page.getByTestId('submit-btn').click();
-await page.getByRole('button', { name: 'Submit' }).click();
+await page.getByTestId("submit-btn").click();
+await page.getByRole("button", { name: "Submit" }).click();
 
 // WRONG: fragile CSS selectors
-await page.locator('.btn-primary').click();
+await page.locator(".btn-primary").click();
 ```
 
 Verify persistence:
+
 ```typescript
-await page.getByLabel('Name').fill('Test');
-await page.getByRole('button', { name: 'Save' }).click();
+await page.getByLabel("Name").fill("Test");
+await page.getByRole("button", { name: "Save" }).click();
 await page.reload();
-await expect(page.getByText('Test')).toBeVisible();  // Still there?
+await expect(page.getByText("Test")).toBeVisible(); // Still there?
 ```
 
 ## E2E Use Case Design
@@ -118,10 +126,11 @@ Purely internal changes with zero user-facing impact: migrations, internal scrip
 Must write justification: `- [x] E2E use cases tested — N/A: [reason]`
 
 ## Rules
+
 1. ALWAYS follow Arrange-Act-Assert pattern
 2. ALWAYS test both success and error cases
 3. ALWAYS use factories/fixtures over hard-coded data
-4. ALWAYS design E2E as user use cases (intent → steps → verify → persist)
+4. ALWAYS design E2E as user use cases (Intent → Steps → Verification → Persistence)
 5. NEVER mock your own code in unit tests
 6. NEVER use fragile CSS selectors in E2E — use `data-testid` or roles
 7. NEVER commit with failing tests

--- a/rules/testing.md
+++ b/rules/testing.md
@@ -86,11 +86,42 @@ await page.reload();
 await expect(page.getByText('Test')).toBeVisible();  // Still there?
 ```
 
+## E2E Use Case Design
+
+E2E tests are **user use cases** — think like a person using the product, not a developer testing code.
+
+Each use case MUST include:
+
+1. **Intent** — What the user wants to accomplish
+   Example: "User creates a new project and invites a teammate"
+2. **Steps** — Specific UI interactions as user actions
+   Example: Navigate to /projects → Click "New Project" → Fill name → Click "Create"
+3. **Verification** — What the user should see after
+   Example: Project appears in list, success toast shows
+4. **Persistence** — Reload and confirm the action stuck
+   Example: Reload /projects → project still visible
+
+### What E2E is NOT
+
+- ❌ Testing a function returns the right value (unit test)
+- ❌ Testing an API endpoint returns 200 (integration test)
+- ❌ Testing a component renders correctly (component test)
+- ❌ Clicking one button and checking one element (too shallow)
+
+### When E2E is required
+
+Any change to **user-facing behavior**: API changes, UI changes, new pages, flow changes, form changes, navigation changes, permission changes — anything a user would notice.
+
+### When E2E can be skipped (N/A)
+
+Purely internal changes with zero user-facing impact: migrations, internal scripts, CI config, dev tooling, behavior-preserving refactors.
+Must write justification: `- [x] E2E use cases tested — N/A: [reason]`
+
 ## Rules
 1. ALWAYS follow Arrange-Act-Assert pattern
 2. ALWAYS test both success and error cases
 3. ALWAYS use factories/fixtures over hard-coded data
-4. ALWAYS verify persistence in E2E (create → reload → verify)
+4. ALWAYS design E2E as user use cases (intent → steps → verify → persist)
 5. NEVER mock your own code in unit tests
 6. NEVER use fragile CSS selectors in E2E — use `data-testid` or roles
 7. NEVER commit with failing tests


### PR DESCRIPTION
## Summary

- **Reframes E2E testing** from "test affected routes when API changes" to "execute user use cases when any user-facing behavior changes"
- **4-part use case template** (Intent, Steps, Verification, Persistence) added to `rules/testing.md`
- **Upfront design** (Phase 3.2b) — E2E use cases designed in the plan, not improvised after implementation
- **Tracked execution** (Phase 5.4) — use cases added to CONTINUITY.md, checked off with Playwright MCP
- **Wider trigger** — "user-facing" replaces "API changed" (covers UI, flows, forms, navigation, permissions)
- **Non-browser support** — API/CLI/mobile projects can use curl/CLI commands instead of Playwright
- **N/A path** requires written justification

## Files changed (8)

| File | Change |
|------|--------|
| `rules/testing.md` | New "E2E Use Case Design" section with template + "What E2E is NOT" |
| `commands/new-feature.md` | Phase 3.2b (design upfront) + rewritten Phase 5.4 + checklist update |
| `commands/fix-bug.md` | Same + simple-fix inline design fallback |
| `rules/critical-rules.md` | E2E rule updated for web + non-browser |
| `hooks/check-workflow-gates.sh` | Comment update (stale reference) |
| `hooks/check-workflow-gates.ps1` | Comment update (stale reference) |
| `agents/verify-app.md` | Updated reminder text |
| `README.md` | Problem table + diagram box updated |

## Review process

- 2 code review iterations (Codex + PR Review Toolkit in parallel)
- Iteration 1: 4 P1s + 4 P2s found and fixed
- Iteration 2: 3 P2s (non-browser contradictions) found and fixed

## Test plan

- [x] No code changes — documentation/config only
- [x] Hook behavior unchanged (comments only)
- [x] Checklist item wording verified compatible with hook regex
- [x] Consistent terminology across all 8 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)