### PR TITLE
feat: Playwright CI bridge for verify-e2e agent (PR #1 of 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,10 +94,20 @@ claude-codex-forge/
 │   ├── verify-e2e.md           # E2E user-journey testing: API + UI + CLI
 │   └── council-advisor.md      # Generic council advisor (persona via prompt)
 │
-└── settings/                   # Settings templates
-    ├── settings.template.json          # Project-level (plugins, permissions, hooks)
-    ├── global-settings.template.json   # Global-level (hooks only, merged)
-    └── settings-windows.template.json  # Windows variant
+├── settings/                   # Settings templates
+│   ├── settings.template.json          # Project-level (plugins, permissions, hooks)
+│   ├── global-settings.template.json   # Global-level (hooks only, merged)
+│   └── settings-windows.template.json  # Windows variant
+│
+└── templates/
+    ├── playwright/
+    │   ├── playwright.config.template.ts    # Playwright framework config
+    │   ├── auth.fixture.template.ts         # Auth bypass pattern
+    │   ├── example.spec.template.ts         # Reference spec scaffold (Phase 6.2c)
+    │   └── README.md
+    └── ci-workflows/
+        ├── e2e.yml                          # GitHub Actions workflow (reference, not auto-activated)
+        └── README.md
 ```
 
 ### Key Commands
@@ -124,25 +134,27 @@ claude-codex-forge/
 
 Templates in the root are **source of truth**. `setup.sh` copies them to target projects:
 
-| Template (edit this)                      | Generated file (never edit directly)             |
-| ----------------------------------------- | ------------------------------------------------ |
-| `CLAUDE.template.md`                      | `CLAUDE.md` in target project                    |
-| `CONTINUITY.template.md`                  | `CONTINUITY.md` in target project                |
-| `GLOBAL-CLAUDE.template.md`               | `~/.claude/CLAUDE.md`                            |
-| `mcp.template.json`                       | `.mcp.json` in target project                    |
-| `settings/settings.template.json`         | `.claude/settings.json` in target project        |
-| `commands/*.md`                           | `.claude/commands/*.md` in target project        |
-| `rules/*.md`                              | `.claude/rules/*.md` in target project           |
-| `hooks/*`                                 | `.claude/hooks/*` in target project              |
-| `skills/ui-design/SKILL.template.md`      | `.claude/skills/ui-design/SKILL.md` in target    |
-| `skills/ui-design/references/*.md`        | `.claude/skills/ui-design/references/*.md`       |
-| `skills/generate-image/SKILL.template.md` | `.claude/skills/generate-image/SKILL.md`         |
-| `skills/release/SKILL.template.md`        | `.claude/skills/release/SKILL.md` in target      |
-| `skills/council/SKILL.template.md`        | `.claude/skills/council/SKILL.md` in target      |
-| `skills/council/references/*.md`          | `.claude/skills/council/references/*.md`         |
-| `agents/verify-app.md`                    | `.claude/agents/verify-app.md` in target project |
-| `agents/verify-e2e.md`                    | `.claude/agents/verify-e2e.md` in target project |
-| `agents/council-advisor.md`               | `.claude/agents/council-advisor.md` in target    |
+| Template (edit this)                      | Generated file (never edit directly)                                                               |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `CLAUDE.template.md`                      | `CLAUDE.md` in target project                                                                      |
+| `CONTINUITY.template.md`                  | `CONTINUITY.md` in target project                                                                  |
+| `GLOBAL-CLAUDE.template.md`               | `~/.claude/CLAUDE.md`                                                                              |
+| `mcp.template.json`                       | `.mcp.json` in target project                                                                      |
+| `settings/settings.template.json`         | `.claude/settings.json` in target project                                                          |
+| `commands/*.md`                           | `.claude/commands/*.md` in target project                                                          |
+| `rules/*.md`                              | `.claude/rules/*.md` in target project                                                             |
+| `hooks/*`                                 | `.claude/hooks/*` in target project                                                                |
+| `skills/ui-design/SKILL.template.md`      | `.claude/skills/ui-design/SKILL.md` in target                                                      |
+| `skills/ui-design/references/*.md`        | `.claude/skills/ui-design/references/*.md`                                                         |
+| `skills/generate-image/SKILL.template.md` | `.claude/skills/generate-image/SKILL.md`                                                           |
+| `skills/release/SKILL.template.md`        | `.claude/skills/release/SKILL.md` in target                                                        |
+| `skills/council/SKILL.template.md`        | `.claude/skills/council/SKILL.md` in target                                                        |
+| `skills/council/references/*.md`          | `.claude/skills/council/references/*.md`                                                           |
+| `agents/verify-app.md`                    | `.claude/agents/verify-app.md` in target project                                                   |
+| `agents/verify-e2e.md`                    | `.claude/agents/verify-e2e.md` in target project                                                   |
+| `agents/council-advisor.md`               | `.claude/agents/council-advisor.md` in target                                                      |
+| `templates/playwright/*.ts`               | `playwright.config.ts`, `tests/e2e/fixtures/auth.ts` (only with `--with-playwright`)               |
+| `templates/ci-workflows/*`                | `docs/ci-templates/*` (only with `--with-playwright` — NOT auto-activated to `.github/workflows/`) |
 
 ### Platform Parity
 

--- a/CLAUDE.template.md
+++ b/CLAUDE.template.md
@@ -78,6 +78,17 @@ The `verify-e2e` agent adapts to this project's interfaces. Declare the interfac
 
 See `.claude/rules/testing.md` for the full interface capability matrix.
 
+### Playwright Framework (optional)
+
+If you enabled Playwright via `setup.sh --with-playwright`, this project has:
+
+- `playwright.config.ts` at root
+- `tests/e2e/specs/` — generated spec files (via Phase 6.2c)
+- `tests/e2e/fixtures/auth.ts` — auth bypass pattern
+- `docs/ci-templates/e2e.yml` — CI workflow template (copy to `.github/workflows/` to activate)
+
+Run specs locally: `pnpm exec playwright test`
+
 ### Key Commands
 
 **Replace the examples below with your project's actual commands:**

--- a/CONTINUITY.template.md
+++ b/CONTINUITY.template.md
@@ -54,6 +54,7 @@ Ready for first task
 - [ ] E2E verified via verify-e2e agent (Phase 5.4)
 - [ ] E2E regression passed (Phase 5.4b)
 - [ ] E2E use cases graduated to tests/e2e/use-cases/ (Phase 6.2b)
+- [ ] E2E specs graduated to tests/e2e/specs/ (Phase 6.2c — if Playwright framework installed)
 -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -740,15 +740,36 @@ All slash commands available after setup.
 
 ### Optional: Playwright CI Bridge
 
-For teams with external contributors or CI requirements, opt into the Playwright framework to get deterministic, headless regression coverage that runs on every PR without requiring a Claude session.
+**Monday, 9 AM.** A first-time contributor opens a PR touching `/api/auth/login`. No Claude session, so your `verify-e2e` agent doesn't run. Their PR goes green, merges, and breaks login for a thousand users by Wednesday.
+
+The bridge fixes that. Every passing use case the agent explores becomes a deterministic `.spec.ts` file that CI replays in ~90 seconds, on every PR, zero LLM cost.
 
 ```bash
 ./setup.sh -p "My App" -t fullstack --with-playwright
 ```
 
-This installs `playwright.config.ts`, an auth fixture template, and a GitHub Actions workflow template (in `docs/ci-templates/`, NOT auto-activated). During Phase 6.2c of each workflow, the main implementation agent generates deterministic `.spec.ts` files from the verify-e2e agent's report — you get the exploratory-authoring of the read-only agent AND the CI-enforced regression of a spec framework.
+**What you get:** `playwright.config.ts`, auth fixture (`tests/e2e/fixtures/auth.ts`), empty `tests/e2e/specs/`, credential-safe `tests/e2e/.auth/.gitignore`, and a reference GitHub Actions workflow in `docs/ci-templates/e2e.yml` (copy to `.github/workflows/` when you're ready — never auto-activated).
 
-See `.claude/rules/testing.md` for the full two-layer model explanation.
+**What you run once** (setup.sh prints this):
+
+```bash
+pnpm add -D @playwright/test && pnpm exec playwright install
+# set TEST_API_KEY, or TEST_USER_EMAIL + TEST_USER_PASSWORD
+# review playwright.config.ts — set baseURL, uncomment the "setup" project
+```
+
+**How your workflow changes — two touchpoints:**
+
+| Phase               | What happens                                                                                                                                               |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **5.4b regression** | Runs `pnpm exec playwright test` when every UC has a matching spec; falls through to the `verify-e2e` agent during partial migration — safe at every point |
+| **6.2c (new)**      | **Main** implementation agent reads the `verify-e2e` report + markdown UC, writes `tests/e2e/specs/<feature>.spec.ts` using selectors the agent observed   |
+
+The `verify-e2e` agent stays read-only. Only the main agent writes specs. This is a hard invariant.
+
+**The two layers.** `tests/e2e/use-cases/*.md` is intent — lives with your plan. `tests/e2e/specs/*.spec.ts` is deterministic replay — runs everywhere (local, CI, cron, contributor PRs).
+
+See `.claude/rules/testing.md` for the full model.
 
 ### PR Review Comments (Post-PR)
 

--- a/README.md
+++ b/README.md
@@ -738,6 +738,18 @@ All slash commands available after setup.
 | `verify-app` agent             | Unit tests, migration check, lint, types                       | "Use the verify-app agent"                  |
 | `verify-e2e` agent             | User-journey E2E (API / UI / CLI) + regression suite replay    | "Use the verify-e2e agent"                  |
 
+### Optional: Playwright CI Bridge
+
+For teams with external contributors or CI requirements, opt into the Playwright framework to get deterministic, headless regression coverage that runs on every PR without requiring a Claude session.
+
+```bash
+./setup.sh -p "My App" -t fullstack --with-playwright
+```
+
+This installs `playwright.config.ts`, an auth fixture template, and a GitHub Actions workflow template (in `docs/ci-templates/`, NOT auto-activated). During Phase 6.2c of each workflow, the main implementation agent generates deterministic `.spec.ts` files from the verify-e2e agent's report — you get the exploratory-authoring of the read-only agent AND the CI-enforced regression of a spec framework.
+
+See `.claude/rules/testing.md` for the full two-layer model explanation.
+
 ### PR Review Comments (Post-PR)
 
 | Command               | Purpose                              | Notes                                                           |

--- a/agents/verify-e2e.md
+++ b/agents/verify-e2e.md
@@ -99,6 +99,24 @@ Write markdown to `tests/e2e/reports/YYYY-MM-DD-HH-MM-<feature-or-mode>.md`:
 | --- | ------ | --------- | ------------ | ------ | -------- |
 | UC1 | ...    | ...       | ...          | PASS   | 12s      |
 
+## Per-UC Details
+
+### UC1: User creates a todo — PASS
+
+**Interface used:** UI (via Playwright MCP)
+**Setup:** API register + login
+
+**Observed selectors (for spec generation):**
+
+- Navigate: `/todos`
+- Input: `getByLabel('Title')`
+- Submit: `getByRole('button', { name: 'Create' })`
+- Verify: `getByText('Buy milk')` visible
+- Persist: reload `/todos`, `getByText('Buy milk')` still visible
+
+**Duration:** 12s
+**Evidence:** [screenshots paths if any]
+
 ## Failures
 
 ### UC2: [Intent] — FAIL_BUG
@@ -141,6 +159,19 @@ UC3 (User deletes a todo) → FAIL_BUG: DELETE /api/v1/todos/1 returned 500 inst
 ## Use Case Graduation (not your responsibility)
 
 When this report returns PASS for feature mode, the workflow (Phase 6.2b) will graduate the use cases from the plan file to `tests/e2e/use-cases/[feature].md`. You do not perform this graduation — the implementation agent does.
+
+## Phase 6.2c Spec Generation (you assist, do not write)
+
+When the Playwright framework is installed, the main implementation agent will generate `.spec.ts` files from your PASSED use cases in Phase 6.2c. You do NOT write these files.
+
+**Your contribution:** the structured "Observed selectors" section in your report (see Step 5). The main agent reads:
+
+1. The markdown UC file (intent of truth — Interface, Setup, Steps, Verify, Persist)
+2. Your verification report (observed selectors, outcome, durations)
+
+It writes the spec from those two sources. You remain read-only.
+
+If selectors are ambiguous or you couldn't determine stable locators, note that in the report under the UC (e.g., "Selector ambiguity: 'Submit' button matched 3 candidates — need data-testid or clearer role").
 
 ## What You Do NOT Do
 

--- a/commands/fix-bug.md
+++ b/commands/fix-bug.md
@@ -548,7 +548,7 @@ If no files (empty directory, or directory missing): check the box with `- [x] E
 - **FAIL_STALE (agent only):** Update stale use case file and re-run.
 - **FAIL_INFRA / flake (both paths):** Retry once. If still failing, report to user for decision.
 
-**Note:** `pnpm exec playwright test` runs without requiring a package.json script entry. setup.sh intentionally does not modify package.json — the user can optionally add a `"test:e2e": "playwright test"` script for convenience, but it's not required.
+**Note:** `pnpm exec playwright test` runs the binary directly — no `package.json` script is required. setup.sh does not modify `package.json`; use the binary invocation above.
 
 ---
 

--- a/commands/fix-bug.md
+++ b/commands/fix-bug.md
@@ -518,15 +518,25 @@ ls tests/e2e/use-cases/*.md 2>/dev/null | head -1
 
 If no files (empty directory, or directory missing): check the box with `- [x] E2E regression — N/A: no accumulated use cases yet`.
 
-**Detect which regression path to use:**
+**Detect which regression path to use.** The framework path is only safe when every markdown UC has a matching spec — otherwise un-spec'd UCs would silently drop out of regression coverage during partial Playwright adoption.
 
-1. **Check if the Playwright framework is installed AND has specs:**
+1. **Count unspecced use cases:**
 
    ```bash
-   [ -f playwright.config.ts ] && ls tests/e2e/specs/*.spec.ts >/dev/null 2>&1 && echo FRAMEWORK || echo AGENT
+   unspecced=0
+   for md in tests/e2e/use-cases/*.md; do
+     [ -f "$md" ] || continue
+     name=$(basename "$md" .md)
+     [ -f "tests/e2e/specs/$name.spec.ts" ] || unspecced=$((unspecced+1))
+   done
+   if [ -f playwright.config.ts ] && [ "$unspecced" -eq 0 ] && ls tests/e2e/specs/*.spec.ts >/dev/null 2>&1; then
+     echo FRAMEWORK
+   else
+     echo AGENT
+   fi
    ```
 
-2. **If FRAMEWORK path (`playwright.config.ts` exists AND specs exist):**
+2. **If FRAMEWORK path** (framework installed AND every UC has a matching spec):
    - Run specs directly (no package.json script needed):
      ```bash
      pnpm exec playwright test
@@ -536,7 +546,8 @@ If no files (empty directory, or directory missing): check the box with `- [x] E
    - Review the HTML report: `pnpm exec playwright show-report`
    - Trace viewer for failures: `pnpm exec playwright show-trace <trace.zip>`
 
-3. **If AGENT path (no framework or no specs yet):** Invoke the verify-e2e agent in regression mode:
+3. **If AGENT path** (no framework, no specs yet, OR partial spec coverage):
+   Invoke the verify-e2e agent in regression mode — it runs every markdown UC, guaranteeing no un-spec'd UC is missed during migration:
    ```
    Task tool → subagent_type: "verify-e2e", prompt: "Mode: regression. Execute all use cases from tests/e2e/use-cases/. Project type: [fullstack|api|cli|hybrid from CLAUDE.md]."
    ```

--- a/commands/fix-bug.md
+++ b/commands/fix-bug.md
@@ -629,7 +629,7 @@ If this project has opted into the Playwright framework (`playwright.config.ts` 
    - The markdown use case file: `tests/e2e/use-cases/<bug-name>.md` (intent of truth — just moved in 6.2b)
    - The verify-e2e report from Phase 5.4: `tests/e2e/reports/<latest>.md` (contains observed selectors, outcomes per UC)
 
-2. **Reference the example template:** `.claude/templates/playwright/example.spec.template.ts` (if copied to target, otherwise the source at `templates/playwright/example.spec.template.ts` in the claude-codex-forge checkout)
+2. **Reference the example template:** `templates/playwright/example.spec.template.ts` in the claude-codex-forge checkout — this is a skeleton for spec file structure.
 
 3. **Write `tests/e2e/specs/<bug-name>.spec.ts`:**
    - One `test.describe('Fix: <bug-name>', () => {...})` block

--- a/commands/fix-bug.md
+++ b/commands/fix-bug.md
@@ -141,6 +141,7 @@ Write the `## Workflow` section in CONTINUITY.md (create the file if it doesn't 
 - [ ] E2E verified via verify-e2e agent (Phase 5.4)
 - [ ] E2E regression passed (Phase 5.4b)
 - [ ] E2E use cases graduated to tests/e2e/use-cases/ (Phase 6.2b)
+- [ ] E2E specs graduated to tests/e2e/specs/ (Phase 6.2c — if Playwright framework installed)
 - [ ] Learning documented
 - [ ] State files updated
 - [ ] Committed and pushed
@@ -517,15 +518,37 @@ ls tests/e2e/use-cases/*.md 2>/dev/null | head -1
 
 If no files (empty directory, or directory missing): check the box with `- [x] E2E regression — N/A: no accumulated use cases yet`.
 
-**If files exist, invoke verify-e2e in regression mode:**
+**Detect which regression path to use:**
 
-```
-Task tool → subagent_type: "verify-e2e", prompt: "Mode: regression. Execute all use cases from tests/e2e/use-cases/. Project type: [fullstack|api|cli|hybrid]."
-```
+1. **Check if the Playwright framework is installed AND has specs:**
 
-**If any regression FAIL_BUG:** This fix broke something that previously worked. Fix it, then re-run 5.4b (and 5.4 as well if this fix has its own user-facing E2E scope).
+   ```bash
+   [ -f playwright.config.ts ] && ls tests/e2e/specs/*.spec.ts >/dev/null 2>&1 && echo FRAMEWORK || echo AGENT
+   ```
 
-**If FAIL_STALE or FAIL_INFRA:** Same actions as Phase 5.4 (update stale use case files; retry-once then report for infra).
+2. **If FRAMEWORK path (`playwright.config.ts` exists AND specs exist):**
+   - Run specs directly (no package.json script needed):
+     ```bash
+     pnpm exec playwright test
+     ```
+     If pnpm is not the project's package manager, use `npm exec playwright test` or `yarn playwright test`.
+   - Exit code 0 = all pass. Non-zero = failures.
+   - Review the HTML report: `pnpm exec playwright show-report`
+   - Trace viewer for failures: `pnpm exec playwright show-trace <trace.zip>`
+
+3. **If AGENT path (no framework or no specs yet):** Invoke the verify-e2e agent in regression mode:
+   ```
+   Task tool → subagent_type: "verify-e2e", prompt: "Mode: regression. Execute all use cases from tests/e2e/use-cases/. Project type: [fullstack|api|cli|hybrid from CLAUDE.md]."
+   ```
+
+**Verdict handling (both paths):**
+
+- **Regression passes:** Check off the box. Proceed to Phase 6.
+- **FAIL_BUG (framework: spec failure; agent: FAIL_BUG verdict):** This fix broke something that previously worked. Fix it, then re-run 5.4b (and 5.4 if this fix has its own user-facing E2E scope).
+- **FAIL_STALE (agent only):** Update stale use case file and re-run.
+- **FAIL_INFRA / flake (both paths):** Retry once. If still failing, report to user for decision.
+
+**Note:** `pnpm exec playwright test` runs without requiring a package.json script entry. setup.sh intentionally does not modify package.json — the user can optionally add a `"test:e2e": "playwright test"` script for convenience, but it's not required.
 
 ---
 
@@ -576,6 +599,53 @@ Both paths:
 - Optionally tag critical paths with `@smoke` for fast regression checks
 
 **Skip this step if:** No user-facing changes (Phase 5.4 was N/A).
+
+### 6.2c Graduate to Playwright Specs (OPTIONAL — if framework installed)
+
+If this project has opted into the Playwright framework (`playwright.config.ts` exists at project root), also graduate each passing use case to a deterministic `.spec.ts` file. The graduated spec lives alongside the moved use case file (complex-fix: from the plan; simple-fix: from the staging file moved in 6.2b).
+
+**Check if framework is installed:**
+
+```bash
+[ -f playwright.config.ts ] && echo FRAMEWORK || echo SKIP
+```
+
+**If SKIP (no framework):** Skip this step entirely. Proceed to 6.3.
+
+**If FRAMEWORK is installed, YOU (the main implementation agent) write the spec file.** The verify-e2e agent does NOT have Write tools and cannot do this. Here's how:
+
+1. **Read the source inputs:**
+   - The markdown use case file: `tests/e2e/use-cases/<bug-name>.md` (intent of truth — just moved in 6.2b)
+   - The verify-e2e report from Phase 5.4: `tests/e2e/reports/<latest>.md` (contains observed selectors, outcomes per UC)
+
+2. **Reference the example template:** `.claude/templates/playwright/example.spec.template.ts` (if copied to target, otherwise the source at `templates/playwright/example.spec.template.ts` in the claude-codex-forge checkout)
+
+3. **Write `tests/e2e/specs/<bug-name>.spec.ts`:**
+   - One `test.describe('Fix: <bug-name>', () => {...})` block
+   - One `test(...)` per UC that passed verification (at minimum: the regression reproducer)
+   - Use selectors from the verify-e2e report's "Observed selectors" section
+   - Prefer `getByRole`, `getByLabel`, `getByTestId` over CSS class selectors
+   - Tag the reproducer as `@smoke` in the test name so it runs in fast regression checks
+   - Do NOT inline auth — use the fixture pattern (see `tests/e2e/fixtures/auth.ts`)
+   - Do NOT generate specs for UCs that were FAIL_BUG or FAIL_STALE — skip them
+
+4. **Skip UCs where the verify-e2e report flagged "Selector ambiguity":** Note this in CONTINUITY.md for follow-up; the user can add `data-testid` attributes and regenerate.
+
+5. **Run the spec once locally to verify it's green:**
+
+   ```bash
+   pnpm exec playwright test tests/e2e/specs/<bug-name>.spec.ts
+   ```
+
+   If it fails, fix the selector ambiguity rather than committing a broken spec.
+
+**Commit the generated spec:** It becomes part of the regression suite and runs in CI for every future PR — locking in the fix so this bug cannot recur.
+
+**Skip this step entirely if:**
+
+- Project doesn't have Playwright framework installed (no `playwright.config.ts`)
+- No user-facing changes (Phase 5.4 was N/A)
+- All UCs had selector ambiguity (note this and defer until testids are added)
 
 ### 6.3 Commit and push
 

--- a/commands/new-feature.md
+++ b/commands/new-feature.md
@@ -141,6 +141,7 @@ Write the `## Workflow` section in CONTINUITY.md (create the file if it doesn't 
 - [ ] E2E verified via verify-e2e agent (Phase 5.4)
 - [ ] E2E regression passed (Phase 5.4b)
 - [ ] E2E use cases graduated to tests/e2e/use-cases/ (Phase 6.2b)
+- [ ] E2E specs graduated to tests/e2e/specs/ (Phase 6.2c — if Playwright framework installed)
 - [ ] Learnings documented (if any)
 - [ ] State files updated
 - [ ] Committed and pushed
@@ -531,15 +532,37 @@ ls tests/e2e/use-cases/*.md 2>/dev/null | head -1
 
 If no files (empty directory, or directory missing): check the box with `- [x] E2E regression — N/A: no accumulated use cases yet`.
 
-**If files exist, invoke verify-e2e in regression mode:**
+**Detect which regression path to use:**
 
-```
-Task tool → subagent_type: "verify-e2e", prompt: "Mode: regression. Execute all use cases from tests/e2e/use-cases/. Project type: [fullstack|api|cli|hybrid]."
-```
+1. **Check if the Playwright framework is installed AND has specs:**
 
-**If any regression FAIL_BUG:** This feature broke something that previously worked. Fix it, then re-run 5.4b (and 5.4 as well if this feature has its own user-facing E2E scope).
+   ```bash
+   [ -f playwright.config.ts ] && ls tests/e2e/specs/*.spec.ts >/dev/null 2>&1 && echo FRAMEWORK || echo AGENT
+   ```
 
-**If FAIL_STALE or FAIL_INFRA:** Same actions as Phase 5.4 (update stale use case files; retry-once then report for infra).
+2. **If FRAMEWORK path (`playwright.config.ts` exists AND specs exist):**
+   - Run specs directly (no package.json script needed):
+     ```bash
+     pnpm exec playwright test
+     ```
+     If pnpm is not the project's package manager, use `npm exec playwright test` or `yarn playwright test`.
+   - Exit code 0 = all pass. Non-zero = failures.
+   - Review the HTML report: `pnpm exec playwright show-report`
+   - Trace viewer for failures: `pnpm exec playwright show-trace <trace.zip>`
+
+3. **If AGENT path (no framework or no specs yet):** Invoke the verify-e2e agent in regression mode:
+   ```
+   Task tool → subagent_type: "verify-e2e", prompt: "Mode: regression. Execute all use cases from tests/e2e/use-cases/. Project type: [fullstack|api|cli|hybrid from CLAUDE.md]."
+   ```
+
+**Verdict handling (both paths):**
+
+- **Regression passes:** Check off the box. Proceed to Phase 6.
+- **FAIL_BUG (framework: spec failure; agent: FAIL_BUG verdict):** This feature broke something that previously worked. Fix it, then re-run 5.4b (and 5.4 if this feature has its own user-facing E2E scope).
+- **FAIL_STALE (agent only):** Update stale use case file and re-run.
+- **FAIL_INFRA / flake (both paths):** Retry once. If still failing, report to user for decision.
+
+**Note:** `pnpm exec playwright test` runs without requiring a package.json script entry. setup.sh intentionally does not modify package.json — the user can optionally add a `"test:e2e": "playwright test"` script for convenience, but it's not required.
 
 ---
 
@@ -582,6 +605,53 @@ mkdir -p tests/e2e/use-cases
 Optionally tag critical paths with `@smoke` for fast regression checks.
 
 **If no user-facing changes:** Skip this step.
+
+### 6.2c Graduate to Playwright Specs (OPTIONAL — if framework installed)
+
+If this project has opted into the Playwright framework (`playwright.config.ts` exists at project root), also graduate each passing use case to a deterministic `.spec.ts` file.
+
+**Check if framework is installed:**
+
+```bash
+[ -f playwright.config.ts ] && echo FRAMEWORK || echo SKIP
+```
+
+**If SKIP (no framework):** Skip this step entirely. Proceed to 6.3.
+
+**If FRAMEWORK is installed, YOU (the main implementation agent) write the spec file.** The verify-e2e agent does NOT have Write tools and cannot do this. Here's how:
+
+1. **Read the source inputs:**
+   - The markdown use case file: `tests/e2e/use-cases/<feature-name>.md` (intent of truth)
+   - The verify-e2e report from Phase 5.4: `tests/e2e/reports/<latest>.md` (contains observed selectors, outcomes per UC)
+
+2. **Reference the example template:** `.claude/templates/playwright/example.spec.template.ts` (if copied to target, otherwise the source at `templates/playwright/example.spec.template.ts` in the claude-codex-forge checkout)
+
+3. **Write `tests/e2e/specs/<feature-name>.spec.ts`:**
+   - One `test.describe('Feature: <feature-name>', () => {...})` block
+   - One `test(...)` per UC that passed verification
+   - Use selectors from the verify-e2e report's "Observed selectors" section
+   - Prefer `getByRole`, `getByLabel`, `getByTestId` over CSS class selectors
+   - Tag critical happy-paths with `@smoke` in the test name (e.g., `test('UC1: User creates a todo @smoke', ...)`)
+   - Do NOT inline auth — use the fixture pattern (see `tests/e2e/fixtures/auth.ts`)
+   - Do NOT generate specs for UCs that were FAIL_BUG or FAIL_STALE — skip them
+
+4. **Skip UCs where the verify-e2e report flagged "Selector ambiguity":** Note this in CONTINUITY.md for follow-up; the user can add `data-testid` attributes and regenerate.
+
+5. **Run the spec once locally to verify it's green:**
+
+   ```bash
+   pnpm exec playwright test tests/e2e/specs/<feature-name>.spec.ts
+   ```
+
+   If it fails, fix the selector ambiguity rather than committing a broken spec.
+
+**Commit the generated spec:** It becomes part of the regression suite and runs in CI for every future PR.
+
+**Skip this step entirely if:**
+
+- Project doesn't have Playwright framework installed (no `playwright.config.ts`)
+- No user-facing changes (Phase 5.4 was N/A)
+- All UCs had selector ambiguity (note this and defer until testids are added)
 
 ### 6.3 Commit and push
 

--- a/commands/new-feature.md
+++ b/commands/new-feature.md
@@ -635,7 +635,7 @@ If this project has opted into the Playwright framework (`playwright.config.ts` 
    - The markdown use case file: `tests/e2e/use-cases/<feature-name>.md` (intent of truth)
    - The verify-e2e report from Phase 5.4: `tests/e2e/reports/<latest>.md` (contains observed selectors, outcomes per UC)
 
-2. **Reference the example template:** `.claude/templates/playwright/example.spec.template.ts` (if copied to target, otherwise the source at `templates/playwright/example.spec.template.ts` in the claude-codex-forge checkout)
+2. **Reference the example template:** `templates/playwright/example.spec.template.ts` in the claude-codex-forge checkout — this is a skeleton for spec file structure.
 
 3. **Write `tests/e2e/specs/<feature-name>.spec.ts`:**
    - One `test.describe('Feature: <feature-name>', () => {...})` block

--- a/commands/new-feature.md
+++ b/commands/new-feature.md
@@ -532,15 +532,25 @@ ls tests/e2e/use-cases/*.md 2>/dev/null | head -1
 
 If no files (empty directory, or directory missing): check the box with `- [x] E2E regression — N/A: no accumulated use cases yet`.
 
-**Detect which regression path to use:**
+**Detect which regression path to use.** The framework path is only safe when every markdown UC has a matching spec — otherwise un-spec'd UCs would silently drop out of regression coverage during partial Playwright adoption.
 
-1. **Check if the Playwright framework is installed AND has specs:**
+1. **Count unspecced use cases:**
 
    ```bash
-   [ -f playwright.config.ts ] && ls tests/e2e/specs/*.spec.ts >/dev/null 2>&1 && echo FRAMEWORK || echo AGENT
+   unspecced=0
+   for md in tests/e2e/use-cases/*.md; do
+     [ -f "$md" ] || continue
+     name=$(basename "$md" .md)
+     [ -f "tests/e2e/specs/$name.spec.ts" ] || unspecced=$((unspecced+1))
+   done
+   if [ -f playwright.config.ts ] && [ "$unspecced" -eq 0 ] && ls tests/e2e/specs/*.spec.ts >/dev/null 2>&1; then
+     echo FRAMEWORK
+   else
+     echo AGENT
+   fi
    ```
 
-2. **If FRAMEWORK path (`playwright.config.ts` exists AND specs exist):**
+2. **If FRAMEWORK path** (framework installed AND every UC has a matching spec):
    - Run specs directly (no package.json script needed):
      ```bash
      pnpm exec playwright test
@@ -550,7 +560,8 @@ If no files (empty directory, or directory missing): check the box with `- [x] E
    - Review the HTML report: `pnpm exec playwright show-report`
    - Trace viewer for failures: `pnpm exec playwright show-trace <trace.zip>`
 
-3. **If AGENT path (no framework or no specs yet):** Invoke the verify-e2e agent in regression mode:
+3. **If AGENT path** (no framework, no specs yet, OR partial spec coverage):
+   Invoke the verify-e2e agent in regression mode — it runs every markdown UC, guaranteeing no un-spec'd UC is missed during migration:
    ```
    Task tool → subagent_type: "verify-e2e", prompt: "Mode: regression. Execute all use cases from tests/e2e/use-cases/. Project type: [fullstack|api|cli|hybrid from CLAUDE.md]."
    ```

--- a/commands/new-feature.md
+++ b/commands/new-feature.md
@@ -562,7 +562,7 @@ If no files (empty directory, or directory missing): check the box with `- [x] E
 - **FAIL_STALE (agent only):** Update stale use case file and re-run.
 - **FAIL_INFRA / flake (both paths):** Retry once. If still failing, report to user for decision.
 
-**Note:** `pnpm exec playwright test` runs without requiring a package.json script entry. setup.sh intentionally does not modify package.json — the user can optionally add a `"test:e2e": "playwright test"` script for convenience, but it's not required.
+**Note:** `pnpm exec playwright test` runs the binary directly — no `package.json` script is required. setup.sh does not modify `package.json`; use the binary invocation above.
 
 ---
 

--- a/rules/testing.md
+++ b/rules/testing.md
@@ -192,6 +192,74 @@ The verify-e2e agent produces a structured markdown report with four classificat
 | **FAIL_STALE** | Use case references changed interface — needs update | No (maintenance flag) |
 | **FAIL_INFRA** | Server down, timeout, flaky selector                 | Retry once, then warn |
 
+## Playwright Framework Bridge (Optional)
+
+Projects can opt into the Playwright test framework to add CI-enforced regression coverage on top of the markdown use cases + verify-e2e agent.
+
+### When to use
+
+Enable if:
+
+- External contributors will open PRs (no Claude session runs on their PRs)
+- You want nightly regression or pre-deploy smoke
+- You want zero-LLM-cost regression runs (after the initial spec generation)
+
+Skip if:
+
+- Solo project with every PR opened by someone who runs `/new-feature`
+- Project has no web UI (API-only, CLI, Python-only — framework doesn't apply)
+- You're comfortable with agent-only regression (session-bound)
+
+### How to enable
+
+```bash
+./setup.sh -p "My App" -t fullstack --with-playwright
+```
+
+This installs:
+
+- `playwright.config.ts` at project root
+- `tests/e2e/fixtures/auth.ts` (auth bypass pattern)
+- `tests/e2e/specs/` directory for generated spec files
+- `docs/ci-templates/e2e.yml` — GitHub Actions workflow as a reference (not auto-activated)
+
+Then:
+
+```bash
+pnpm add -D @playwright/test
+pnpm exec playwright install
+# Optional: activate CI
+cp docs/ci-templates/e2e.yml .github/workflows/e2e.yml
+```
+
+### The two-layer model
+
+| Layer                                              | Source of truth                    | When it runs                                                    | Cost                  |
+| -------------------------------------------------- | ---------------------------------- | --------------------------------------------------------------- | --------------------- |
+| **Markdown use case** (`tests/e2e/use-cases/*.md`) | Intent — what a user wants         | Phase 5.4/5.4b during `/new-feature` or `/fix-bug`              | LLM tokens per run    |
+| **Spec file** (`tests/e2e/specs/*.spec.ts`)        | Deterministic replay of the intent | CI on every PR, nightly cron, local `pnpm exec playwright test` | Free after generation |
+
+The verify-e2e agent explores the UI once during Phase 5.4 (authoring) and records observed selectors in its report. Then in Phase 6.2c the main implementation agent reads that report and writes a stable spec file using the recorded selectors. The verify-e2e agent stays read-only throughout; only the main agent has Write/Edit tools.
+
+### Auth fixture pattern
+
+E2E tests should authenticate ONCE per run, not per test. The auth fixture stores browser state after login and reuses it across specs. Configure via env vars:
+
+- `TEST_API_KEY` (preferred — fastest) OR
+- `TEST_USER_EMAIL` + `TEST_USER_PASSWORD` (fallback)
+
+See `tests/e2e/fixtures/auth.ts` for the template.
+
+### CI integration
+
+The ships-as-reference CI template runs:
+
+- **On PR:** smoke-tagged specs only (~2 min)
+- **Nightly:** full suite
+- **Manual:** workflow_dispatch for ad-hoc runs
+
+Uploads HTML report + traces as artifacts on failure.
+
 ## Rules
 
 1. ALWAYS follow Arrange-Act-Assert pattern

--- a/setup.ps1
+++ b/setup.ps1
@@ -504,6 +504,21 @@ if ($WithPlaywright) {
     }
     Copy-TemplateFile (Join-Path $pwTemplateDir "auth.fixture.template.ts") "tests\e2e\fixtures\auth.ts" "tests\e2e\fixtures\auth.ts"
 
+    # Auth storage directory - gitignored because it contains credentials
+    if (-not (Test-Path "tests\e2e\.auth")) {
+        New-Item -ItemType Directory -Path "tests\e2e\.auth" -Force | Out-Null
+    }
+    if (-not (Test-Path "tests\e2e\.auth\.gitignore")) {
+        @"
+# Auth storage state contains credentials - never commit
+*
+!.gitignore
+"@ | Set-Content -Path "tests\e2e\.auth\.gitignore" -NoNewline
+        Write-Host "  " -NoNewline
+        Write-Color "+" "Green"
+        Write-Host " Created tests\e2e\.auth\.gitignore (credentials protected)"
+    }
+
     # CI workflow reference (NOT auto-activated)
     if (-not (Test-Path "docs\ci-templates")) {
         New-Item -ItemType Directory -Path "docs\ci-templates" -Force | Out-Null

--- a/setup.ps1
+++ b/setup.ps1
@@ -529,10 +529,8 @@ if ($WithPlaywright) {
     Write-Color "mkdir .github\workflows; cp docs\ci-templates\e2e.yml .github\workflows\e2e.yml" "Blue"
     Write-Host "     Note: CI template uses pnpm - adjust for npm/yarn in .github\workflows\e2e.yml if needed"
     Write-Host "  5. Configure auth via env vars: TEST_API_KEY or TEST_USER_EMAIL + TEST_USER_PASSWORD"
-    Write-Host "  6. (Optional) Add package.json script for convenience:"
-    Write-Host "     " -NoNewline
-    Write-Color "`"test:e2e`": `"playwright test`"" "Blue"
-    Write-Host "     (Not required - Phase 5.4b uses 'pnpm exec playwright test' which works without a script.)"
+    Write-Host "  6. Run tests: " -NoNewline
+    Write-Color "pnpm exec playwright test" "Blue"
 }
 
 Write-Host ""

--- a/setup.ps1
+++ b/setup.ps1
@@ -513,7 +513,7 @@ if ($WithPlaywright) {
 # Auth storage state contains credentials - never commit
 *
 !.gitignore
-"@ | Set-Content -Path "tests\e2e\.auth\.gitignore" -NoNewline
+"@ | Set-Content -Path "tests\e2e\.auth\.gitignore" -NoNewline -Encoding UTF8
         Write-Host "  " -NoNewline
         Write-Color "+" "Green"
         Write-Host " Created tests\e2e\.auth\.gitignore (credentials protected)"

--- a/setup.ps1
+++ b/setup.ps1
@@ -21,7 +21,10 @@ param(
     [switch]$Upgrade,
 
     [Alias("g")]
-    [switch]$Global
+    [switch]$Global,
+
+    [Alias("w")]
+    [switch]$WithPlaywright
 )
 
 # Upgrade implies force for hooks/commands/rules
@@ -51,6 +54,7 @@ function Show-Usage {
     Write-Host "  -t, -Tech STACK     Tech stack: python, typescript, fullstack (default: fullstack)"
     Write-Host "  -f, -Force          Overwrite existing files"
     Write-Host "  -g, -Global         Set up global memory system (~/.claude/)"
+    Write-Host "  -w, -WithPlaywright Install Playwright framework templates (requires -Tech fullstack or typescript)"
     Write-Host ""
     Write-Host "Examples:"
     Write-Host "  .\setup.ps1                          # Setup with defaults"
@@ -59,6 +63,7 @@ function Show-Usage {
     Write-Host "  .\setup.ps1 -f                       # Force overwrite existing files"
     Write-Host "  .\setup.ps1 -Global                  # Set up global memory (run once per machine)"
     Write-Host "  .\setup.ps1 -Global -f               # Force overwrite global settings"
+    Write-Host "  .\setup.ps1 -Tech fullstack -WithPlaywright  # Install Playwright framework templates"
 }
 
 # Show help if requested
@@ -203,6 +208,15 @@ if ($Global) {
 # ============================================================================
 # PROJECT SETUP (default, no -Global flag)
 # ============================================================================
+
+# Validate -WithPlaywright flag
+if ($WithPlaywright) {
+    if ($Tech -ne "fullstack" -and $Tech -ne "typescript") {
+        Write-Color "ERROR: -WithPlaywright requires -Tech fullstack or -Tech typescript." "Red"
+        Write-Color "Playwright framework only applies to web/TS projects." "Yellow"
+        exit 1
+    }
+}
 
 # Default project name to directory name
 if ([string]::IsNullOrEmpty($Project)) {
@@ -462,6 +476,63 @@ switch ($Tech) {
         $genImgDir = Join-Path (Join-Path (Join-Path $ScriptDir "skills") "generate-image")
         Copy-TemplateFile (Join-Path $genImgDir "SKILL.template.md") ".claude\skills\generate-image\SKILL.md" ".claude\skills\generate-image\SKILL.md"
     }
+}
+
+# Playwright framework templates (opt-in via -WithPlaywright)
+if ($WithPlaywright) {
+    Write-Host ""
+    Write-Color "Installing Playwright framework templates..." "Yellow"
+
+    # Create the specs/ directory (not in the default directories array —
+    # only relevant when framework is installed)
+    if (-not (Test-Path "tests\e2e\specs")) {
+        New-Item -ItemType Directory -Path "tests\e2e\specs" -Force | Out-Null
+        Write-Host "  " -NoNewline
+        Write-Color "+" "Green"
+        Write-Host " Created tests\e2e\specs (for graduated .spec.ts files)"
+    }
+
+    $pwTemplateDir = Join-Path (Join-Path $ScriptDir "templates") "playwright"
+    $ciTemplateDir = Join-Path (Join-Path $ScriptDir "templates") "ci-workflows"
+
+    # Playwright config
+    Copy-TemplateFile (Join-Path $pwTemplateDir "playwright.config.template.ts") "playwright.config.ts" "playwright.config.ts"
+
+    # Auth fixture
+    if (-not (Test-Path "tests\e2e\fixtures")) {
+        New-Item -ItemType Directory -Path "tests\e2e\fixtures" -Force | Out-Null
+    }
+    Copy-TemplateFile (Join-Path $pwTemplateDir "auth.fixture.template.ts") "tests\e2e\fixtures\auth.ts" "tests\e2e\fixtures\auth.ts"
+
+    # CI workflow reference (NOT auto-activated)
+    if (-not (Test-Path "docs\ci-templates")) {
+        New-Item -ItemType Directory -Path "docs\ci-templates" -Force | Out-Null
+    }
+    Copy-TemplateFile (Join-Path $ciTemplateDir "e2e.yml") "docs\ci-templates\e2e.yml" "docs\ci-templates\e2e.yml (reference - NOT auto-activated)"
+    Copy-TemplateFile (Join-Path $ciTemplateDir "README.md") "docs\ci-templates\README.md" "docs\ci-templates\README.md"
+
+    Write-Host ""
+    Write-Color "Playwright templates installed." "Green"
+    Write-Color "Next steps to complete Playwright setup:" "Yellow"
+    Write-Host "  1. Install the framework: " -NoNewline
+    Write-Color "pnpm add -D @playwright/test" "Blue"
+    Write-Host "     (or npm: " -NoNewline
+    Write-Color "npm install --save-dev @playwright/test" "Blue"
+    Write-Host ")"
+    Write-Host "  2. Install browsers:      " -NoNewline
+    Write-Color "pnpm exec playwright install" "Blue"
+    Write-Host "  3. Review " -NoNewline
+    Write-Color "playwright.config.ts" "Blue"
+    Write-Host " - set baseURL and uncomment webServer if needed"
+    Write-Host "  4. (Optional) Activate CI:"
+    Write-Host "     " -NoNewline
+    Write-Color "mkdir .github\workflows; cp docs\ci-templates\e2e.yml .github\workflows\e2e.yml" "Blue"
+    Write-Host "     Note: CI template uses pnpm - adjust for npm/yarn in .github\workflows\e2e.yml if needed"
+    Write-Host "  5. Configure auth via env vars: TEST_API_KEY or TEST_USER_EMAIL + TEST_USER_PASSWORD"
+    Write-Host "  6. (Optional) Add package.json script for convenience:"
+    Write-Host "     " -NoNewline
+    Write-Color "`"test:e2e`": `"playwright test`"" "Blue"
+    Write-Host "     (Not required - Phase 5.4b uses 'pnpm exec playwright test' which works without a script.)"
 }
 
 Write-Host ""

--- a/setup.sh
+++ b/setup.sh
@@ -458,6 +458,17 @@ if [[ "$WITH_PLAYWRIGHT" == true ]]; then
     mkdir -p tests/e2e/fixtures
     copy_file "$SCRIPT_DIR/templates/playwright/auth.fixture.template.ts" "tests/e2e/fixtures/auth.ts" "tests/e2e/fixtures/auth.ts"
 
+    # Auth storage directory — gitignored because it contains credentials
+    mkdir -p tests/e2e/.auth
+    if [[ ! -f "tests/e2e/.auth/.gitignore" ]]; then
+        cat > tests/e2e/.auth/.gitignore << 'EOF'
+# Auth storage state contains credentials - never commit
+*
+!.gitignore
+EOF
+        echo -e "  ${GREEN}✓${NC} Created tests/e2e/.auth/.gitignore (credentials protected)"
+    fi
+
     # CI workflow reference (NOT auto-activated)
     mkdir -p docs/ci-templates
     copy_file "$SCRIPT_DIR/templates/ci-workflows/e2e.yml" "docs/ci-templates/e2e.yml" "docs/ci-templates/e2e.yml (reference — NOT auto-activated)"

--- a/setup.sh
+++ b/setup.sh
@@ -29,6 +29,7 @@ usage() {
     echo "  -f, --force         Overwrite existing files (destructive)"
     echo "  -u, --upgrade       Smart upgrade: merge new hooks/permissions into existing settings"
     echo "  -g, --global        Set up global memory system (~/.claude/)"
+    echo "  -w, --with-playwright  Install Playwright framework templates (requires -t fullstack or typescript)"
     echo ""
     echo "Examples:"
     echo "  $0                          # Setup with defaults"
@@ -38,6 +39,7 @@ usage() {
     echo "  $0 --upgrade                # Upgrade: add new hooks/rules, merge settings"
     echo "  $0 --global                 # Set up global memory (run once per machine)"
     echo "  $0 --global -f              # Force overwrite global settings"
+    echo "  $0 -t fullstack --with-playwright  # Install Playwright framework templates"
 }
 
 # Parse arguments
@@ -46,6 +48,7 @@ TECH_STACK="fullstack"
 FORCE=false
 UPGRADE=false
 GLOBAL=false
+WITH_PLAYWRIGHT=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -72,6 +75,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         -g|--global)
             GLOBAL=true
+            shift
+            ;;
+        -w|--with-playwright)
+            WITH_PLAYWRIGHT=true
             shift
             ;;
         *)
@@ -209,6 +216,15 @@ fi
 # ============================================================================
 # PROJECT SETUP (default, no --global flag)
 # ============================================================================
+
+# Validate --with-playwright flag
+if [[ "$WITH_PLAYWRIGHT" == true ]]; then
+    if [[ "$TECH_STACK" != "fullstack" && "$TECH_STACK" != "typescript" ]]; then
+        echo -e "${RED}ERROR: --with-playwright requires -t fullstack or -t typescript.${NC}"
+        echo -e "${YELLOW}Playwright framework only applies to web/TS projects.${NC}"
+        exit 1
+    fi
+fi
 
 # Default project name to directory name
 if [[ -z "$PROJECT_NAME" ]]; then
@@ -422,6 +438,46 @@ case $TECH_STACK in
         copy_file "$SCRIPT_DIR/skills/generate-image/SKILL.template.md" ".claude/skills/generate-image/SKILL.md" ".claude/skills/generate-image/SKILL.md"
         ;;
 esac
+
+# Playwright framework templates (opt-in via --with-playwright)
+if [[ "$WITH_PLAYWRIGHT" == true ]]; then
+    echo ""
+    echo -e "${YELLOW}Installing Playwright framework templates...${NC}"
+
+    # Create the specs/ directory (not in the default directories array —
+    # only relevant when framework is installed)
+    if [[ ! -d "tests/e2e/specs" ]]; then
+        mkdir -p "tests/e2e/specs"
+        echo -e "  ${GREEN}✓${NC} Created tests/e2e/specs (for graduated .spec.ts files)"
+    fi
+
+    # Playwright config
+    copy_file "$SCRIPT_DIR/templates/playwright/playwright.config.template.ts" "playwright.config.ts" "playwright.config.ts"
+
+    # Auth fixture
+    mkdir -p tests/e2e/fixtures
+    copy_file "$SCRIPT_DIR/templates/playwright/auth.fixture.template.ts" "tests/e2e/fixtures/auth.ts" "tests/e2e/fixtures/auth.ts"
+
+    # CI workflow reference (NOT auto-activated)
+    mkdir -p docs/ci-templates
+    copy_file "$SCRIPT_DIR/templates/ci-workflows/e2e.yml" "docs/ci-templates/e2e.yml" "docs/ci-templates/e2e.yml (reference — NOT auto-activated)"
+    copy_file "$SCRIPT_DIR/templates/ci-workflows/README.md" "docs/ci-templates/README.md" "docs/ci-templates/README.md"
+
+    echo ""
+    echo -e "${GREEN}✓ Playwright templates installed.${NC}"
+    echo -e "${YELLOW}Next steps to complete Playwright setup:${NC}"
+    echo "  1. Install the framework: ${BLUE}pnpm add -D @playwright/test${NC}"
+    echo "     (or npm: ${BLUE}npm install --save-dev @playwright/test${NC})"
+    echo "  2. Install browsers:      ${BLUE}pnpm exec playwright install${NC}"
+    echo "  3. Review ${BLUE}playwright.config.ts${NC} — set baseURL and uncomment webServer if needed"
+    echo "  4. (Optional) Activate CI:"
+    echo "     ${BLUE}mkdir -p .github/workflows && cp docs/ci-templates/e2e.yml .github/workflows/e2e.yml${NC}"
+    echo "     Note: CI template uses pnpm — adjust for npm/yarn in .github/workflows/e2e.yml if needed"
+    echo "  5. Configure auth via env vars: TEST_API_KEY or TEST_USER_EMAIL + TEST_USER_PASSWORD"
+    echo "  6. (Optional) Add package.json script for convenience:"
+    echo "     ${BLUE}\"test:e2e\": \"playwright test\"${NC}"
+    echo "     (Not required — Phase 5.4b uses 'pnpm exec playwright test' which works without a script.)"
+fi
 
 echo ""
 

--- a/setup.sh
+++ b/setup.sh
@@ -474,9 +474,7 @@ if [[ "$WITH_PLAYWRIGHT" == true ]]; then
     echo "     ${BLUE}mkdir -p .github/workflows && cp docs/ci-templates/e2e.yml .github/workflows/e2e.yml${NC}"
     echo "     Note: CI template uses pnpm — adjust for npm/yarn in .github/workflows/e2e.yml if needed"
     echo "  5. Configure auth via env vars: TEST_API_KEY or TEST_USER_EMAIL + TEST_USER_PASSWORD"
-    echo "  6. (Optional) Add package.json script for convenience:"
-    echo "     ${BLUE}\"test:e2e\": \"playwright test\"${NC}"
-    echo "     (Not required — Phase 5.4b uses 'pnpm exec playwright test' which works without a script.)"
+    echo "  6. Run tests: ${BLUE}pnpm exec playwright test${NC}"
 fi
 
 echo ""

--- a/setup.sh
+++ b/setup.sh
@@ -444,8 +444,6 @@ if [[ "$WITH_PLAYWRIGHT" == true ]]; then
     echo ""
     echo -e "${YELLOW}Installing Playwright framework templates...${NC}"
 
-    # Create the specs/ directory (not in the default directories array —
-    # only relevant when framework is installed)
     if [[ ! -d "tests/e2e/specs" ]]; then
         mkdir -p "tests/e2e/specs"
         echo -e "  ${GREEN}✓${NC} Created tests/e2e/specs (for graduated .spec.ts files)"

--- a/templates/ci-workflows/README.md
+++ b/templates/ci-workflows/README.md
@@ -1,0 +1,23 @@
+# CI Workflow Templates
+
+Reference templates installed by `setup.sh` into `docs/ci-templates/`.
+
+**These are NOT auto-activated.** To enable a workflow, move it to `.github/workflows/`:
+
+```bash
+mkdir -p .github/workflows
+cp docs/ci-templates/e2e.yml .github/workflows/e2e.yml
+git add .github/workflows/e2e.yml
+git commit -m "ci: enable E2E regression workflow"
+```
+
+Available workflows:
+
+- `e2e.yml` — Playwright E2E tests (smoke on PRs, full suite nightly)
+
+Required GitHub secrets/vars:
+
+- `TEST_API_KEY` (secret) — for auth fixture
+- `PLAYWRIGHT_BASE_URL` (var) — staging/preview URL
+
+Customize per project. Non-GitHub CI (GitLab, Jenkins, CircleCI): port manually — the `pnpm exec playwright test` command is the same.

--- a/templates/ci-workflows/e2e.yml
+++ b/templates/ci-workflows/e2e.yml
@@ -1,0 +1,112 @@
+# E2E Tests — GitHub Actions workflow
+#
+# This template is installed by `setup.sh --with-playwright` to
+# `docs/ci-templates/e2e.yml`. To ACTIVATE it, move to `.github/workflows/e2e.yml`:
+#
+#   mkdir -p .github/workflows
+#   cp docs/ci-templates/e2e.yml .github/workflows/e2e.yml
+#   git add .github/workflows/e2e.yml && git commit -m "ci: enable E2E regression"
+#
+# Runs Playwright specs on every PR to main + nightly smoke cron.
+# Requires: @playwright/test installed, playwright.config.ts configured,
+# TEST_USER_EMAIL/TEST_USER_PASSWORD or TEST_API_KEY secrets configured.
+#
+# CUSTOMIZATION CHECKLIST before activating:
+#   1. Package manager: this template uses pnpm. For npm, replace:
+#        - `pnpm/action-setup@v4` → remove it; use setup-node's `cache: 'npm'`
+#        - `pnpm install --frozen-lockfile` → `npm ci`
+#        - `pnpm exec playwright test` → `npx playwright test`
+#      For yarn, similar substitutions with `yarn install --frozen-lockfile`.
+#   2. App startup: tests run against PLAYWRIGHT_BASE_URL. Your options:
+#        (a) Deploy a preview URL (Vercel, Railway, etc.) and point
+#            PLAYWRIGHT_BASE_URL at it — simplest and what most modern CI uses.
+#        (b) Run a local dev server in the workflow using a `services:` block,
+#            Docker Compose, or `pnpm dev &` as a backgrounded step.
+#        (c) Use the `webServer` config in playwright.config.ts to auto-start.
+#      Choose one. This template assumes (a) — adjust if using (b) or (c).
+#   3. Secrets: configure `TEST_API_KEY` as a GitHub repo secret.
+#      Configure `PLAYWRIGHT_BASE_URL` as a repo variable.
+
+name: E2E Tests
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 8 * * *'  # Daily at 08:00 UTC (smoke + full regression)
+  workflow_dispatch:     # Manual trigger
+
+jobs:
+  e2e-smoke:
+    name: Smoke (PRs)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with: { version: 9 }
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run smoke tests
+        run: pnpm exec playwright test --grep @smoke
+        env:
+          TEST_API_KEY: ${{ secrets.TEST_API_KEY }}
+          PLAYWRIGHT_BASE_URL: ${{ vars.PLAYWRIGHT_BASE_URL || 'http://localhost:3000' }}
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-smoke
+          path: playwright-report/
+          retention-days: 30
+
+  e2e-full:
+    name: Full suite (nightly + manual)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with: { version: 9 }
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps
+
+      - name: Run full suite
+        run: pnpm exec playwright test
+        env:
+          TEST_API_KEY: ${{ secrets.TEST_API_KEY }}
+          PLAYWRIGHT_BASE_URL: ${{ vars.PLAYWRIGHT_BASE_URL }}
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-full
+          path: playwright-report/
+          retention-days: 30

--- a/templates/ci-workflows/e2e.yml
+++ b/templates/ci-workflows/e2e.yml
@@ -64,6 +64,8 @@ jobs:
         run: pnpm exec playwright test --grep @smoke
         env:
           TEST_API_KEY: ${{ secrets.TEST_API_KEY }}
+          TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
+          TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
           PLAYWRIGHT_BASE_URL: ${{ vars.PLAYWRIGHT_BASE_URL || 'http://localhost:3000' }}
 
       - name: Upload Playwright report
@@ -101,6 +103,8 @@ jobs:
         run: pnpm exec playwright test
         env:
           TEST_API_KEY: ${{ secrets.TEST_API_KEY }}
+          TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
+          TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
           PLAYWRIGHT_BASE_URL: ${{ vars.PLAYWRIGHT_BASE_URL }}
 
       - name: Upload Playwright report

--- a/templates/playwright/README.md
+++ b/templates/playwright/README.md
@@ -1,0 +1,19 @@
+# Playwright Framework Templates
+
+Installed by `setup.sh --with-playwright` into fullstack/typescript projects.
+
+Files:
+
+- `playwright.config.template.ts` → `playwright.config.ts` at project root
+- `auth.fixture.template.ts` → `tests/e2e/fixtures/auth.ts`
+- `example.spec.template.ts` → reference for spec file structure (not auto-installed)
+
+After setup, the user must:
+
+1. `pnpm add -D @playwright/test` (or npm/yarn)
+2. `pnpm exec playwright install` (downloads browser binaries)
+3. Configure auth via env vars: `TEST_API_KEY` OR `TEST_USER_EMAIL` + `TEST_USER_PASSWORD`
+4. Review `playwright.config.ts` — set `baseURL` and uncomment `webServer` if needed
+5. Optionally activate CI: `cp docs/ci-templates/e2e.yml .github/workflows/e2e.yml`
+
+The main implementation agent generates `.spec.ts` files in `tests/e2e/specs/` during Phase 6.2c of `/new-feature` and `/fix-bug`, using the verify-e2e agent's report (which documents observed selectors). The verify-e2e agent itself stays read-only.

--- a/templates/playwright/auth.fixture.template.ts
+++ b/templates/playwright/auth.fixture.template.ts
@@ -1,0 +1,47 @@
+/**
+ * Auth fixture — shared setup for authenticated tests.
+ *
+ * Pattern: authenticate ONCE via API (fast, deterministic), save storage state,
+ * reuse across all specs. Avoids per-test UI login (slow, flaky).
+ *
+ * Usage:
+ *   1. Customize the login call below to match your API
+ *   2. In playwright.config.ts, set: storageState: 'tests/e2e/.auth/user.json'
+ *   3. Run `pnpm exec playwright test --project=setup` before your main suite,
+ *      OR use as a global setup (see https://playwright.dev/docs/auth)
+ *
+ * Env vars expected:
+ *   TEST_USER_EMAIL, TEST_USER_PASSWORD, or TEST_API_KEY
+ */
+import { test as setup, expect } from "@playwright/test";
+import path from "path";
+
+const authFile = path.join(__dirname, "../.auth/user.json");
+
+setup("authenticate", async ({ request, context }) => {
+  // Prefer API-key auth for speed. Falls back to email/password if not provided.
+  const apiKey = process.env.TEST_API_KEY;
+  const email = process.env.TEST_USER_EMAIL;
+  const password = process.env.TEST_USER_PASSWORD;
+
+  if (apiKey) {
+    // API key in header — adjust to your auth scheme (Bearer, X-API-Key, etc.)
+    await context.setExtraHTTPHeaders({ Authorization: `Bearer ${apiKey}` });
+    console.log("[auth] Using TEST_API_KEY for authentication");
+  } else if (email && password) {
+    // Example: POST to /api/auth/login and store session cookie
+    const response = await request.post("/api/auth/login", {
+      data: { email, password },
+    });
+    expect(response.ok()).toBeTruthy();
+    console.log("[auth] Authenticated via email/password");
+  } else {
+    throw new Error(
+      "[auth] No credentials found. Set TEST_API_KEY or TEST_USER_EMAIL + TEST_USER_PASSWORD.",
+    );
+  }
+
+  // Save the authenticated browser state (cookies, localStorage) for reuse.
+  await context.storageState({ path: authFile });
+  console.log(`[auth] State saved to ${authFile}`);
+});

--- a/templates/playwright/auth.fixture.template.ts
+++ b/templates/playwright/auth.fixture.template.ts
@@ -5,32 +5,43 @@
  * reuse across all specs. Avoids per-test UI login (slow, flaky).
  *
  * Usage:
- *   1. Customize the login call below to match your API
- *   2. In playwright.config.ts, set: storageState: 'tests/e2e/.auth/user.json'
- *   3. Run `pnpm exec playwright test --project=setup` before your main suite,
- *      OR use as a global setup (see https://playwright.dev/docs/auth)
+ *   1. Customize the login call below to match your API.
+ *   2. Wire up a `setup` project in playwright.config.ts so this fixture
+ *      runs before the main suite. See the commented block in the generated
+ *      playwright.config.ts (search for "setup project").
+ *   3. Set `storageState: 'tests/e2e/.auth/user.json'` on the main project's
+ *      `use` config (or per-test with `test.use({ storageState: ... })`).
+ *   4. See https://playwright.dev/docs/auth for patterns and options.
  *
  * Env vars expected:
- *   TEST_USER_EMAIL, TEST_USER_PASSWORD, or TEST_API_KEY
+ *   TEST_USER_EMAIL + TEST_USER_PASSWORD, or TEST_API_KEY
+ *
+ * IMPORTANT: storage state only persists cookies, localStorage, and
+ * sessionStorage — NOT extra HTTP headers. The API-key path below writes
+ * the token to localStorage so it survives into the storage state.
  */
 import { test as setup, expect } from "@playwright/test";
 import path from "path";
 
 const authFile = path.join(__dirname, "../.auth/user.json");
 
-setup("authenticate", async ({ request, context }) => {
-  // Prefer API-key auth for speed. Falls back to email/password if not provided.
+setup("authenticate", async ({ page, context }): Promise<void> => {
   const apiKey = process.env.TEST_API_KEY;
   const email = process.env.TEST_USER_EMAIL;
   const password = process.env.TEST_USER_PASSWORD;
 
   if (apiKey) {
-    // API key in header — adjust to your auth scheme (Bearer, X-API-Key, etc.)
-    await context.setExtraHTTPHeaders({ Authorization: `Bearer ${apiKey}` });
-    console.log("[auth] Using TEST_API_KEY for authentication");
+    // Persist API key via localStorage so it's captured in storage state.
+    // Adjust the storage key ("auth_token") to whatever your frontend reads.
+    await page.goto("/");
+    await page.evaluate((token) => {
+      window.localStorage.setItem("auth_token", token);
+    }, apiKey);
+    console.log("[auth] Using TEST_API_KEY (stored in localStorage)");
   } else if (email && password) {
-    // Example: POST to /api/auth/login and store session cookie
-    const response = await request.post("/api/auth/login", {
+    // Use context.request so session cookies land in the browser context
+    // (the top-level `request` fixture has a SEPARATE storage jar).
+    const response = await context.request.post("/api/auth/login", {
       data: { email, password },
     });
     expect(response.ok()).toBeTruthy();
@@ -41,7 +52,7 @@ setup("authenticate", async ({ request, context }) => {
     );
   }
 
-  // Save the authenticated browser state (cookies, localStorage) for reuse.
+  // Save authenticated browser state (cookies + localStorage) for reuse.
   await context.storageState({ path: authFile });
   console.log(`[auth] State saved to ${authFile}`);
 });

--- a/templates/playwright/example.spec.template.ts
+++ b/templates/playwright/example.spec.template.ts
@@ -1,0 +1,37 @@
+/**
+ * Example spec written by the main implementation agent in Phase 6.2c,
+ * using the observed selectors from the verify-e2e agent's report.
+ *
+ * Format: one test per use case (UC1, UC2, ...) from the plan file.
+ * Each test is a deterministic replay of the agent's exploratory run.
+ */
+import { test, expect } from "@playwright/test";
+
+test.describe("Feature: <feature-name>", () => {
+  // UC1: <Intent from plan file>
+  test("UC1: User creates a new item @smoke", async ({ page }) => {
+    // ARRANGE — setup path from use case (e.g., authenticated via fixture)
+    await page.goto("/items");
+
+    // ACT — steps from use case
+    await page.getByRole("button", { name: "New item" }).click();
+    await page.getByLabel("Name").fill("Test item");
+    await page.getByRole("button", { name: "Create" }).click();
+
+    // VERIFY — assertions from use case
+    await expect(page.getByText("Test item")).toBeVisible();
+
+    // PERSIST — reload and confirm
+    await page.reload();
+    await expect(page.getByText("Test item")).toBeVisible();
+  });
+
+  // UC2: <Edge case from plan file>
+  test("UC2: User cannot create item without required field", async ({
+    page,
+  }) => {
+    await page.goto("/items/new");
+    await page.getByRole("button", { name: "Create" }).click();
+    await expect(page.getByText(/name is required/i)).toBeVisible();
+  });
+});

--- a/templates/playwright/playwright.config.template.ts
+++ b/templates/playwright/playwright.config.template.ts
@@ -55,7 +55,8 @@ export default defineConfig({
   projects: [
     // {
     //   name: 'setup',
-    //   testMatch: /fixtures\/auth\.ts/,
+    //   testDir: './tests/e2e/fixtures',
+    //   testMatch: /auth\.ts$/,
     // },
     {
       name: "chromium",

--- a/templates/playwright/playwright.config.template.ts
+++ b/templates/playwright/playwright.config.template.ts
@@ -47,11 +47,7 @@ export default defineConfig({
   },
 
   // Browser projects. Chromium covers 80%+ of production bugs; enable Firefox/WebKit
-  // as needed per project.
-  //
-  // To enable auth via tests/e2e/fixtures/auth.ts, uncomment the "setup" project
-  // below and add `dependencies: ['setup']` + `storageState: 'tests/e2e/.auth/user.json'`
-  // to the chromium project. See https://playwright.dev/docs/auth.
+  // as needed. See tests/e2e/fixtures/auth.ts to enable authenticated tests.
   projects: [
     // {
     //   name: 'setup',

--- a/templates/playwright/playwright.config.template.ts
+++ b/templates/playwright/playwright.config.template.ts
@@ -48,8 +48,23 @@ export default defineConfig({
 
   // Browser projects. Chromium covers 80%+ of production bugs; enable Firefox/WebKit
   // as needed per project.
+  //
+  // To enable auth via tests/e2e/fixtures/auth.ts, uncomment the "setup" project
+  // below and add `dependencies: ['setup']` + `storageState: 'tests/e2e/.auth/user.json'`
+  // to the chromium project. See https://playwright.dev/docs/auth.
   projects: [
-    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+    // {
+    //   name: 'setup',
+    //   testMatch: /fixtures\/auth\.ts/,
+    // },
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        // storageState: 'tests/e2e/.auth/user.json',
+      },
+      // dependencies: ['setup'],
+    },
     // { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
     // { name: 'webkit',  use: { ...devices['Desktop Safari'] } },
   ],

--- a/templates/playwright/playwright.config.template.ts
+++ b/templates/playwright/playwright.config.template.ts
@@ -1,0 +1,64 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright configuration for claude-codex-forge E2E tests.
+ * See https://playwright.dev/docs/test-configuration for full options.
+ */
+export default defineConfig({
+  // Location of spec files (graduated from tests/e2e/use-cases/ via verify-e2e Phase 6.2c)
+  testDir: "./tests/e2e/specs",
+
+  // Parallelize tests in a single file. CI uses full parallelization.
+  fullyParallel: true,
+
+  // Fail build on CI if test.only is accidentally left in code
+  forbidOnly: !!process.env.CI,
+
+  // Retry on CI only — no retries locally for faster feedback
+  retries: process.env.CI ? 2 : 0,
+
+  // Workers: use all cores locally, limit on CI to avoid contention
+  workers: process.env.CI ? 2 : undefined,
+
+  // HTML reporter by default; JSON for CI artifact upload
+  reporter: process.env.CI
+    ? [
+        ["html", { open: "never" }],
+        ["json", { outputFile: "tests/e2e/reports/results.json" }],
+      ]
+    : "html",
+
+  use: {
+    // Base URL — override via PLAYWRIGHT_BASE_URL env var
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000",
+
+    // Collect trace on retry; full trace on first failure in CI
+    trace: process.env.CI ? "on-first-retry" : "retain-on-failure",
+
+    // Screenshots on failure
+    screenshot: "only-on-failure",
+
+    // Video on failure
+    video: "retain-on-failure",
+
+    // Reuse authenticated storage state from auth fixture
+    // Uncomment after running auth setup (see tests/e2e/fixtures/auth.ts):
+    // storageState: 'tests/e2e/.auth/user.json',
+  },
+
+  // Browser projects. Chromium covers 80%+ of production bugs; enable Firefox/WebKit
+  // as needed per project.
+  projects: [
+    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+    // { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+    // { name: 'webkit',  use: { ...devices['Desktop Safari'] } },
+  ],
+
+  // Dev server auto-start (optional — uncomment and adjust for your project)
+  // webServer: {
+  //   command: 'pnpm dev',
+  //   url: 'http://localhost:3000',
+  //   reuseExistingServer: !process.env.CI,
+  //   timeout: 120_000,
+  // },
+});


### PR DESCRIPTION
## Problem

Your `verify-e2e` agent catches regressions great — when there's a Claude session. The moment an external contributor opens a PR, a nightly cron fires, or a teammate on a machine without Claude pushes a fix, your E2E suite silently skips.

## Solution

Opt-in Playwright framework as a **CI bridge** for the existing `verify-e2e` agent. Every passing markdown UC graduates to a deterministic `.spec.ts` that CI replays in ~90 seconds, on every PR, with zero LLM cost.

```bash
./setup.sh -p "My App" -t fullstack --with-playwright
```

## Summary

- **Opt-in only.** Without the flag, `setup.sh` behaves exactly as today.
- **Gated.** `--with-playwright` requires `-t fullstack` or `-t typescript`; errors out for python/cli.
- **No package.json modification.** `setup.sh` prints install instructions; never runs `pnpm install`.
- **CI reference-only.** Ships to `docs/ci-templates/e2e.yml`; user copies to `.github/workflows/` when ready.
- **`verify-e2e` agent stays read-only.** Tools list unchanged (`Bash, Read, Glob, Grep, mcp__playwright` — NO Write/Edit). The **main** implementation agent writes `.spec.ts` files in Phase 6.2c using selectors the agent observed and documented.
- **Credential-safe.** Auto-creates `tests/e2e/.auth/.gitignore` (UTF-8 on Windows PS 5.1) so auth storage never leaks into commits.
- **Migration-safe.** Phase 5.4b falls through to the agent path unless every UC has a matching spec — un-spec'd UCs stay covered during partial adoption.

## Scope (per Codex consultation)

**IN scope (this PR):** Opt-in flag, templates, agent report enhancement (observed selectors), workflow integration (Phase 5.4b + 6.2c), CI reference template, cross-platform parity, gated rollout.

**OUT of scope (defer to PR #2):** Accessibility (`@axe-core/playwright`), visual regression, spec repair mode.

## Review history

5 rounds of Codex review → clean. Findings closed:
1. Auth fixture used top-level `request` (separate cookie jar) → switched to `context.request` + localStorage for API-key path
2. Setup project's `testMatch` couldn't discover auth.ts under `testDir: './tests/e2e/specs'` → scoped `testDir: './tests/e2e/fixtures'`
3. CI workflow only forwarded `TEST_API_KEY` → added `TEST_USER_EMAIL` + `TEST_USER_PASSWORD`
4. Windows PS 5.1 `Set-Content` defaulted to UTF-16LE → explicit `-Encoding UTF8`
5. Phase 5.4b switched to framework-only on any spec → require full parity, else agent path
6. Misleading `.claude/templates/...` fallback path → single source path

Plus simplifier pass and verify-app PASS.

## Files (16 changed, 21 commits)

**New (6):**
- `templates/playwright/{playwright.config.template.ts,auth.fixture.template.ts,example.spec.template.ts,README.md}`
- `templates/ci-workflows/{e2e.yml,README.md}`

**Modified (10):**
- `agents/verify-e2e.md` — Observed selectors section (read-only preserved)
- `rules/testing.md` — Playwright Framework Bridge section (two-layer model)
- `commands/{new-feature,fix-bug}.md` — Phase 5.4b detection + Phase 6.2c spec generation
- `setup.sh` / `setup.ps1` — `--with-playwright` flag + gating + credential gitignore
- `CLAUDE.md` / `CLAUDE.template.md` / `CONTINUITY.template.md` / `README.md` — docs

## Test plan

- [x] `bash -n setup.sh` — clean
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — CI template valid
- [x] Integration S1–S6 (default, flag-on, python gating, typescript, package.json invariant, force overwrite) — all PASS
- [x] verify-e2e `tools:` frontmatter unchanged (5 items, no Write/Edit)
- [x] verify-app — PASS
- [ ] External review (Copilot / Codex GH / peer)
- [ ] Windows `pwsh` verification — deferred to reviewer (no pwsh on local macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)