### PR TITLE
feat: research-first agent for pre-design library research enforcement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ claude-codex-forge/
 ├── agents/                     # Subagent definitions (copied to .claude/agents/)
 │   ├── verify-app.md           # Full verification: tests + lint + types
 │   ├── verify-e2e.md           # E2E user-journey testing: API + UI + CLI
+│   ├── research-first.md       # Pre-design library/API research
 │   └── council-advisor.md      # Generic council advisor (persona via prompt)
 │
 ├── settings/                   # Settings templates
@@ -152,6 +153,7 @@ Templates in the root are **source of truth**. `setup.sh` copies them to target 
 | `skills/council/references/*.md`          | `.claude/skills/council/references/*.md`                                                           |
 | `agents/verify-app.md`                    | `.claude/agents/verify-app.md` in target project                                                   |
 | `agents/verify-e2e.md`                    | `.claude/agents/verify-e2e.md` in target project                                                   |
+| `agents/research-first.md`                | `.claude/agents/research-first.md` in target project                                               |
 | `agents/council-advisor.md`               | `.claude/agents/council-advisor.md` in target                                                      |
 | `templates/playwright/*.ts`               | `playwright.config.ts`, `tests/e2e/fixtures/auth.ts` (only with `--with-playwright`)               |
 | `templates/ci-workflows/*`                | `docs/ci-templates/*` (only with `--with-playwright` — NOT auto-activated to `.github/workflows/`) |

--- a/CLAUDE.template.md
+++ b/CLAUDE.template.md
@@ -89,6 +89,12 @@ If you enabled Playwright via `setup.sh --with-playwright`, this project has:
 
 Run specs locally: `pnpm exec playwright test`
 
+### Research Enforcement
+
+The `research-first` agent runs in Phase 2 of `/new-feature` (before design begins). It queries Context7, WebSearch, and WebFetch for every external library this feature touches and produces a brief at `docs/research/YYYY-MM-DD-<feature>.md`. The design phase reads this brief to avoid building on stale assumptions.
+
+For bug fixes, targeted research runs after root-cause isolation (Phase 2.5 of `/fix-bug`).
+
 ### Key Commands
 
 **Replace the examples below with your project's actual commands:**

--- a/README.md
+++ b/README.md
@@ -729,14 +729,19 @@ All slash commands available after setup.
 
 ### Quality Gates (Pre-PR — in this order)
 
-| Command / Agent                | Purpose                                                        | Notes                                       |
-| ------------------------------ | -------------------------------------------------------------- | ------------------------------------------- |
-| `/codex review`                | First review after implementation — independent second opinion | Codex CLI (uncommitted/base/commit options) |
-| `/codex {instruction}`         | General second opinion                                         | Runs `codex exec` in read-only sandbox      |
-| `/pr-review-toolkit:review-pr` | Deep multi-analyzer review (6 agents)                          | Silent failures, test coverage, type design |
-| `/simplify`                    | Clean up modified files                                        | Built-in command, no plugin needed          |
-| `verify-app` agent             | Unit tests, migration check, lint, types                       | "Use the verify-app agent"                  |
-| `verify-e2e` agent             | User-journey E2E (API / UI / CLI) + regression suite replay    | "Use the verify-e2e agent"                  |
+| Command / Agent                | Purpose                                                          | Notes                                       |
+| ------------------------------ | ---------------------------------------------------------------- | ------------------------------------------- |
+| `/codex review`                | First review after implementation — independent second opinion   | Codex CLI (uncommitted/base/commit options) |
+| `/codex {instruction}`         | General second opinion                                           | Runs `codex exec` in read-only sandbox      |
+| `/pr-review-toolkit:review-pr` | Deep multi-analyzer review (6 agents)                            | Silent failures, test coverage, type design |
+| `/simplify`                    | Clean up modified files                                          | Built-in command, no plugin needed          |
+| `verify-app` agent             | Unit tests, migration check, lint, types                         | "Use the verify-app agent"                  |
+| `verify-e2e` agent             | User-journey E2E (API / UI / CLI) + regression suite replay      | "Use the verify-e2e agent"                  |
+| `research-first` agent         | Pre-design library/API research — current docs, breaking changes | "Use the research-first agent"              |
+
+### Research Enforcement
+
+Your AI assistant's knowledge has a cutoff. Libraries ship breaking changes weekly. The `research-first` agent runs before every design — querying Context7, official docs, and changelogs for each dependency your feature touches. It produces a structured brief in `docs/research/` that the design phase reads. No more building on stale docs.
 
 ### Optional: Playwright CI Bridge
 

--- a/README.md
+++ b/README.md
@@ -729,19 +729,20 @@ All slash commands available after setup.
 
 ### Quality Gates (Pre-PR — in this order)
 
-| Command / Agent                | Purpose                                                          | Notes                                       |
-| ------------------------------ | ---------------------------------------------------------------- | ------------------------------------------- |
-| `/codex review`                | First review after implementation — independent second opinion   | Codex CLI (uncommitted/base/commit options) |
-| `/codex {instruction}`         | General second opinion                                           | Runs `codex exec` in read-only sandbox      |
-| `/pr-review-toolkit:review-pr` | Deep multi-analyzer review (6 agents)                            | Silent failures, test coverage, type design |
-| `/simplify`                    | Clean up modified files                                          | Built-in command, no plugin needed          |
-| `verify-app` agent             | Unit tests, migration check, lint, types                         | "Use the verify-app agent"                  |
-| `verify-e2e` agent             | User-journey E2E (API / UI / CLI) + regression suite replay      | "Use the verify-e2e agent"                  |
-| `research-first` agent         | Pre-design library/API research — current docs, breaking changes | "Use the research-first agent"              |
+| Command / Agent                | Purpose                                                        | Notes                                       |
+| ------------------------------ | -------------------------------------------------------------- | ------------------------------------------- |
+| `/codex review`                | First review after implementation — independent second opinion | Codex CLI (uncommitted/base/commit options) |
+| `/codex {instruction}`         | General second opinion                                         | Runs `codex exec` in read-only sandbox      |
+| `/pr-review-toolkit:review-pr` | Deep multi-analyzer review (6 agents)                          | Silent failures, test coverage, type design |
+| `/simplify`                    | Clean up modified files                                        | Built-in command, no plugin needed          |
+| `verify-app` agent             | Unit tests, migration check, lint, types                       | "Use the verify-app agent"                  |
+| `verify-e2e` agent             | User-journey E2E (API / UI / CLI) + regression suite replay    | "Use the verify-e2e agent"                  |
 
-### Research Enforcement
+### Research Enforcement (Pre-Design — Phase 2)
 
-Your AI assistant's knowledge has a cutoff. Libraries ship breaking changes weekly. The `research-first` agent runs before every design — querying Context7, official docs, and changelogs for each dependency your feature touches. It produces a structured brief in `docs/research/` that the design phase reads. No more building on stale docs.
+Your AI assistant's knowledge has a cutoff. Libraries ship breaking changes weekly. The `research-first` agent runs in Phase 2 of `/new-feature` — before any design begins — querying Context7, official docs, and changelogs for each dependency your feature touches. It produces a structured brief in `docs/research/` that the design phase reads. No more building on stale docs.
+
+For bug fixes, targeted research runs after root-cause isolation (Phase 2.5 of `/fix-bug`).
 
 ### Optional: Playwright CI Bridge
 

--- a/agents/research-first.md
+++ b/agents/research-first.md
@@ -1,0 +1,128 @@
+---
+name: research-first
+description: Pre-design research — queries current docs for every library/API touched by a feature
+tools:
+  - Read
+  - Grep
+  - Glob
+  - WebSearch
+  - WebFetch
+  - mcp__context7
+  - Write
+---
+
+You are a research specialist. Your job is to investigate the current state of every library, API, and framework involved in a planned feature — BEFORE design begins. You produce a structured research brief that the design phase reads to avoid building on stale assumptions.
+
+**You are NOT a designer or implementer. You research; others design.**
+
+## Inputs
+
+The prompt you receive will specify:
+
+- **Feature name:** what is being built
+- **PRD or description:** the requirements
+- **Project manifest paths:** `package.json`, `pyproject.toml`, lockfiles, etc.
+
+## Research Process
+
+### Step 1: Identify research targets
+
+Scan the PRD/description and project manifests to build a list of external libraries and APIs this feature will touch. Include:
+
+- Direct dependencies named in the PRD (e.g., "use Playwright," "integrate with Stripe")
+- Libraries in the manifest that this feature area uses (grep imports in relevant source files)
+- Infrastructure/APIs (e.g., "OpenAI API," "Supabase," "Redis")
+
+If the feature is purely internal (no external libs/APIs), report "No external dependencies — research N/A" and STOP. Do not fabricate research targets.
+
+### Step 2: Research each target
+
+For each library/API, query in this order:
+
+1. **Context7** (`mcp__context7`): resolve the library, then query for API patterns, configuration, and migration guides relevant to the feature
+2. **WebFetch**: official changelog, migration guide, or release notes for the version delta (our pinned version → latest stable)
+3. **WebSearch**: "$library best practices $year", "$library breaking changes $version", known issues
+
+Collect per target:
+
+- **Our version** (from manifest/lockfile)
+- **Latest stable** (from the source above)
+- **Breaking changes** since our version (if any)
+- **Deprecations** relevant to this feature
+- **Recommended pattern** (current best practice for what we're doing)
+- **Sources** (min 2 URLs with access date)
+
+### Step 3: Assess impact on design
+
+For each researched target, answer:
+
+- **Design decision changed:** what should the design do differently because of this research? (If nothing, say "No impact — our current usage is aligned.")
+- **Test implication:** what should tests cover that they wouldn't without this research?
+
+### Step 4: Write the research brief
+
+Write to `docs/research/YYYY-MM-DD-<feature-name>.md`:
+
+```markdown
+# Research: <feature name>
+
+**Date:** YYYY-MM-DD
+**Feature:** <one-line description>
+**Researcher:** research-first agent
+
+## Libraries Touched
+
+| Library | Our Version | Latest Stable | Breaking Changes | Source                   |
+| ------- | ----------- | ------------- | ---------------- | ------------------------ |
+| ...     | ...         | ...           | ...              | [link](url) (YYYY-MM-DD) |
+
+## Per-Library Analysis
+
+### <library-name>
+
+**Versions:** ours=X.Y.Z, latest=A.B.C
+**Breaking changes since ours:** <list or "None">
+**Deprecations:** <list or "None relevant to this feature">
+**Recommended pattern:** <current best practice for what this feature does>
+**Sources:**
+
+1. [Official docs](url) — accessed YYYY-MM-DD
+2. [Changelog](url) — accessed YYYY-MM-DD
+
+**Design impact:** <concrete decision this research changes, or "No impact">
+**Test implication:** <what tests should cover, or "Standard coverage sufficient">
+
+## Not Researched (with justification)
+
+- <library>: not touched by this feature (only used in <other module>)
+
+## Open Risks
+
+- <any version conflicts, upcoming deprecations, or unknowns>
+```
+
+### Step 5: Return summary
+
+Return a brief summary to the caller:
+
+```
+Research complete.
+Brief: docs/research/YYYY-MM-DD-<feature>.md
+Libraries researched: N
+Design-changing findings: M
+Open risks: K
+
+Key finding: <most important discovery in one sentence>
+```
+
+## What You Do NOT Do
+
+- You do not design or propose architecture — you report facts
+- You do not implement code
+- You do not hallucinate versions or URLs — if you can't find it, say "Unable to verify — manual check needed"
+- You do not write to any path except `docs/research/*.md` — this is a behavioral constraint (the Write tool is unscoped, but you MUST only use it for `docs/research/` files)
+- You prioritize by risk when >8 libraries are involved: auth, payments, data access first; UI utilities last. Un-researched low-risk items go in the "Not Researched" section with justification.
+
+## Timebox
+
+Target 15–20 minutes per feature. Depth over breadth — research fewer libraries thoroughly rather than many shallowly.

--- a/agents/research-first.md
+++ b/agents/research-first.md
@@ -33,7 +33,7 @@ Scan the PRD/description and project manifests to build a list of external libra
 - Libraries in the manifest that this feature area uses (grep imports in relevant source files)
 - Infrastructure/APIs (e.g., "OpenAI API," "Supabase," "Redis")
 
-If the feature is purely internal (no external libs/APIs), report "No external dependencies — research N/A" and STOP. Do not fabricate research targets.
+If the feature is purely internal (no external libs/APIs), write a minimal N/A brief to `docs/research/YYYY-MM-DD-<feature-slug>.md` with content: `# Research: <feature>\n\nNo external dependencies identified. Research N/A.` Then return the summary. Do not fabricate research targets.
 
 ### Step 2: Research each target
 

--- a/commands/fix-bug.md
+++ b/commands/fix-bug.md
@@ -229,7 +229,7 @@ The agent writes to `docs/research/YYYY-MM-DD-<bug-name>.md` — a lighter brief
 
 ## Phase 3: Plan the Fix
 
-> **Checkpoint:** Update `## Workflow` in CONTINUITY.md — Phase: `3 — Plan`, check off "Systematic debugging complete".
+> **Checkpoint:** Update `## Workflow` in CONTINUITY.md — Phase: `3 — Plan`, check off "Systematic debugging complete" (and "Library research done" if Phase 2.5 was performed).
 
 ### For simple fixes (1-2 files):
 

--- a/commands/fix-bug.md
+++ b/commands/fix-bug.md
@@ -126,6 +126,7 @@ Write the `## Workflow` section in CONTINUITY.md (create the file if it doesn't 
 - [ ] Plugins verified
 - [ ] Searched existing solutions
 - [ ] Systematic debugging complete
+- [ ] Library research done (if external dep involved — via research-first agent)
 - [ ] Design guidance loaded (if UI fix)
 - [ ] Brainstorming complete (if complex)
 - [ ] Approach comparison filled (if complex)
@@ -211,6 +212,18 @@ This will guide you through:
 > 4. Verify your understanding before proposing ANY fix
 >
 > **NEVER skip this phase. NEVER guess at fixes.**
+
+### 2.5 Targeted Library Research (if external dependency involved)
+
+If the root cause involves an external library, API, or framework (not purely internal logic):
+
+```
+Task tool → subagent_type: "research-first", prompt: "Bug fix research. Library: <library-name>. Our version: <version from manifest>. Bug symptom: <what's happening>. Research: current best practices, known issues with our version, breaking changes, recommended migration path if relevant."
+```
+
+The agent writes to `docs/research/YYYY-MM-DD-<bug-name>.md` — a lighter brief focused on the specific library involved.
+
+**Skip this step if:** the root cause is purely internal logic (wrong conditional, missing null check, etc.) with no external dependency involvement.
 
 ---
 

--- a/commands/new-feature.md
+++ b/commands/new-feature.md
@@ -125,7 +125,7 @@ Write the `## Workflow` section in CONTINUITY.md (create the file if it doesn't 
 - [x] Project state read
 - [ ] Plugins verified
 - [ ] PRD created
-- [ ] Research done
+- [ ] Research artifact produced (`docs/research/` — via research-first agent)
 - [ ] Design guidance loaded (if UI)
 - [ ] Brainstorming complete
 - [ ] Approach comparison filled
@@ -188,24 +188,60 @@ Then create the PRD:
 
 ---
 
-## Phase 2: Research (DO NOT SKIP)
+## Phase 2: Research (MANDATORY — agent-enforced)
 
 > **Checkpoint:** Update `## Workflow` in CONTINUITY.md — Phase: `2 — Research`, check off "PRD created".
 
-Before writing ANY code, research the problem space:
+Before writing ANY design, research every external library and API this feature touches. This is enforced via the `research-first` agent — not optional guidance.
 
-1. **Search existing solutions**:
+### 2.1 Dispatch research-first agent
 
-   ```bash
-   grep -r "relevant keywords" docs/solutions/
-   ```
+```
+Task tool → subagent_type: "research-first", prompt: "Feature: <feature-name>. PRD: <path-to-PRD-or-inline-description>. Manifests: package.json, pyproject.toml (check which exist). Research all external libraries and APIs this feature will touch."
+```
 
-2. **Research current best practices**:
-   - Use `WebSearch` for current documentation
-   - Use `WebFetch` for specific library docs
-   - Use `Context7` MCP for framework-specific guidance
+The agent will:
 
-3. **Study competitors**: How do established products solve this problem?
+1. Scan the PRD + manifests to identify research targets
+2. Query Context7, WebFetch, and WebSearch for each (current docs, breaking changes, best practices)
+3. Write a structured brief to `docs/research/YYYY-MM-DD-<feature>.md`
+4. Return a summary with findings count and key discovery
+
+### 2.2 Review the brief
+
+Read `docs/research/YYYY-MM-DD-<feature>.md`. Verify:
+
+- Every library/API the feature touches is listed
+- Each has ≥ 2 sources with access dates
+- "Design impact" and "Test implication" fields are filled (not blank or "N/A" for all)
+- "Open Risks" section is present
+
+If the brief is shallow or missing targets, re-dispatch the agent with more specific instructions.
+
+### 2.3 Fallback: if agent dispatch or web tools fail
+
+If the `research-first` agent cannot be dispatched (Task tool unavailable) or web tools are down (Context7/WebSearch/WebFetch all failing):
+
+1. **You (the main agent) perform the research manually:**
+   - Query Context7 for each library (if available)
+   - Use WebSearch/WebFetch for changelogs and docs
+   - If all web tools are down, check lockfile versions + `node_modules/<lib>/CHANGELOG.md` locally
+2. **Fill out the research template yourself** and save to `docs/research/YYYY-MM-DD-<feature>.md`
+3. **Note in the brief:** "Fallback: main agent performed research (agent dispatch unavailable)"
+
+This is the degraded path, not the skip path. Research still happens — just without the dedicated agent.
+
+### 2.4 Gate: cannot proceed without research artifact
+
+**Phase 3 (Design) MUST NOT start until `docs/research/YYYY-MM-DD-<feature>.md` exists and passes the review above.**
+
+**Gate criteria:**
+
+- If libraries were identified → each must have ≥ 2 sources, a "Design impact" field, and a "Test implication" field
+- If no external libraries/APIs → the agent reports "No external dependencies — research N/A" and that counts as passing the gate (no per-library fields needed)
+- If fallback path was used → the brief must still meet the same criteria
+
+> **Checkpoint:** Update `## Workflow` in CONTINUITY.md — Phase: `3 — Design`, check off "Research done".
 
 ---
 

--- a/commands/new-feature.md
+++ b/commands/new-feature.md
@@ -241,8 +241,6 @@ This is the degraded path, not the skip path. Research still happens — just wi
 - If no external libraries/APIs → the agent writes a minimal N/A brief and that counts as passing the gate
 - If fallback path was used → the brief must still meet the same criteria
 
-> **Checkpoint:** Update `## Workflow` in CONTINUITY.md — Phase: `3 — Design`, check off "Research artifact produced".
-
 ---
 
 ## Phase 3: Design + Review Loop (iterates until no P0/P1/P2 issues)

--- a/commands/new-feature.md
+++ b/commands/new-feature.md
@@ -247,7 +247,7 @@ This is the degraded path, not the skip path. Research still happens — just wi
 
 ## Phase 3: Design + Review Loop (iterates until no P0/P1/P2 issues)
 
-> **Checkpoint:** Update `## Workflow` in CONTINUITY.md — Phase: `3 — Design`, check off "Research done".
+> **Checkpoint:** Update `## Workflow` in CONTINUITY.md — Phase: `3 — Design`, check off "Research artifact produced".
 
 ### 3.0 Load Design Guidance (if UI work)
 

--- a/commands/new-feature.md
+++ b/commands/new-feature.md
@@ -237,11 +237,11 @@ This is the degraded path, not the skip path. Research still happens — just wi
 
 **Gate criteria:**
 
-- If libraries were identified → each must have ≥ 2 sources, a "Design impact" field, and a "Test implication" field
-- If no external libraries/APIs → the agent reports "No external dependencies — research N/A" and that counts as passing the gate (no per-library fields needed)
+- If libraries were researched → each researched library must have ≥ 2 sources, a "Design impact" field, and a "Test implication" field. Items explicitly triaged to "Not Researched" (with justification) are exempt.
+- If no external libraries/APIs → the agent writes a minimal N/A brief and that counts as passing the gate
 - If fallback path was used → the brief must still meet the same criteria
 
-> **Checkpoint:** Update `## Workflow` in CONTINUITY.md — Phase: `3 — Design`, check off "Research done".
+> **Checkpoint:** Update `## Workflow` in CONTINUITY.md — Phase: `3 — Design`, check off "Research artifact produced".
 
 ---
 

--- a/commands/prd/create.md
+++ b/commands/prd/create.md
@@ -18,6 +18,8 @@ Before generating the PRD:
 2. Use WebFetch/Context7 to check current library documentation if specific tech is involved
 3. Ensure recommendations reflect up-to-date patterns, not outdated approaches
 
+> **Note:** This Step 0 is **discovery research** for the PRD. Implementation-specific research (library versions, breaking changes) happens later in Phase 2 of `/new-feature` via the `research-first` agent.
+
 ### Step 1: Load Context
 
 1. Read `docs/prds/{feature-name}-discussion.md`

--- a/commands/prd/discuss.md
+++ b/commands/prd/discuss.md
@@ -11,11 +11,20 @@ User stories are often incomplete. This command ensures we understand requiremen
 ### Phase 0: Research
 
 **Before analyzing user stories, research the problem space:**
+
 1. Use WebSearch to find industry best practices for this type of feature
 2. Use WebFetch to read relevant documentation if specific technologies are mentioned
 3. Look for competitor implementations or established patterns
 
 This research informs better questions and identifies requirements the user may not have considered.
+
+> **Note:** This Phase 0 is **discovery research** — understanding the problem space, competitors, and industry patterns before writing requirements. It is separate from Phase 2 **implementation research** (in `/new-feature`), where the `research-first` agent checks current library versions, breaking changes, and API patterns. Both phases are necessary: discovery shapes WHAT to build; implementation research shapes HOW to build it with current tools.
+
+**Tools for discovery research:**
+
+- `WebSearch` — industry best practices, competitor analysis
+- `WebFetch` — specific product pages, documentation sites
+- `Context7` — framework/library-specific guidance (also useful during discovery)
 
 ### Phase 1: Initial Analysis
 
@@ -25,16 +34,18 @@ This research informs better questions and identifies requirements the user may 
    - Existing file at `docs/prds/{feature-name}-stories.md`
 
 2. Create discussion file at `docs/prds/{feature-name}-discussion.md` with header:
+
    ```markdown
    # PRD Discussion: {Feature Name}
-   
+
    **Status:** In Progress
    **Started:** {date}
    **Participants:** User, Claude
-   
+
    ## Original User Stories
+
    {paste user's original input}
-   
+
    ## Discussion Log
    ```
 
@@ -43,32 +54,38 @@ This research informs better questions and identifies requirements the user may 
 Analyze the stories and ask **5-10 pointed questions** covering:
 
 #### Personas & Access
+
 - Who are ALL the users of this feature? (Don't assume just one persona)
 - What permissions/roles are required?
 - Are there read-only vs. edit personas?
 
 #### Scope Boundaries
+
 - What's explicitly IN scope for MVP?
 - What's explicitly OUT of scope (non-goals)?
 - If we could only ship 2 of N stories, which 2?
 
 #### Happy Path Gaps
+
 - What are the specific inputs/outputs?
 - What does "success" look like concretely?
 - Are there quantitative requirements? ("fast" = how fast?)
 
 #### Error Cases & Edge Cases
+
 - What happens when X fails?
 - What if user has no permissions?
 - What if data is malformed/missing?
 - What are the boundary conditions?
 
 #### Dependencies & Constraints
+
 - Does this require other features to exist first?
 - Are there technical constraints (API limits, database schema)?
 - Are there business constraints (compliance, legal)?
 
 #### Success Metrics
+
 - How will we know this feature is working?
 - What do we measure?
 - What's the acceptance threshold?
@@ -86,22 +103,28 @@ When user indicates readiness:
 
 1. Update discussion file status to "Complete"
 2. Add summary section:
+
    ```markdown
    ## Refined Understanding
-   
+
    ### Personas
+
    - {persona 1}: {description}
-   
+
    ### User Stories (Refined)
+
    - US-001: {refined story}
-   
+
    ### Non-Goals
+
    - {explicit exclusion}
-   
+
    ### Key Decisions
+
    - {decision from discussion}
-   
+
    ### Open Questions (Remaining)
+
    - [ ] {any unresolved questions}
    ```
 
@@ -110,12 +133,14 @@ When user indicates readiness:
 ## Question Style Guide
 
 **DO ask:**
+
 - Specific, targeted questions based on the actual stories
 - "What happens if..." scenarios
 - "Who else might..." persona expansions
 - "You mentioned X - does that mean Y or Z?"
 
 **DON'T ask:**
+
 - Generic checklist questions unrelated to the stories
 - Too many questions at once (max 10)
 - Questions the user clearly already answered
@@ -135,7 +160,7 @@ Claude: I've logged these stories to docs/prds/mcp-import-discussion.md.
 Before we write a PRD, let me understand these better:
 
 **Personas:**
-1. Is "admin" the only role that can import? What about project owners 
+1. Is "admin" the only role that can import? What about project owners
    or super-admins?
 
 **Story 1 - Import from URL:**
@@ -144,7 +169,7 @@ Before we write a PRD, let me understand these better:
    - npm package references (@org/package)
    - Direct JSON/YAML config files
    - OpenAPI/Swagger specs
-   
+
 3. What happens if the URL is unreachable or returns 404?
 
 4. What if the URL points to a valid file but invalid MCP config?

--- a/commands/quick-fix.md
+++ b/commands/quick-fix.md
@@ -34,6 +34,17 @@
 
 ---
 
+## Research Check
+
+Quick fixes skip the full research-first agent. However, if this change touches an external dependency or API (version bump, API call change, new library import):
+
+- Check the library's current docs via Context7 or WebSearch before implementing
+- Verify no breaking changes between your version and the one you're targeting
+
+If purely internal (typo fix, config change, style cleanup): no research needed.
+
+---
+
 ## The Fix
 
 1. Make the change

--- a/rules/principles.md
+++ b/rules/principles.md
@@ -8,7 +8,7 @@
 
 **Check your work.** Run code to verify it works. Check logs after starting processes.
 
-**Research first.** AI knowledge has a cutoff. Use WebSearch/WebFetch/Context7 for current docs.
+**Research first.** AI knowledge has a cutoff. The `research-first` agent runs in Phase 2 of `/new-feature` and produces a structured brief (`docs/research/`) before design begins. For bugs, targeted research runs after root-cause isolation. Use Context7 → WebFetch → WebSearch (in that order) for every external library.
 
 **Learn from competitors.** Before implementing features, research how established products solved it.
 

--- a/rules/principles.md
+++ b/rules/principles.md
@@ -8,7 +8,7 @@
 
 **Check your work.** Run code to verify it works. Check logs after starting processes.
 
-**Research first.** AI knowledge has a cutoff. The `research-first` agent runs in Phase 2 of `/new-feature` and produces a structured brief (`docs/research/`) before design begins. For bugs, targeted research runs after root-cause isolation. Use Context7 → WebFetch → WebSearch (in that order) for every external library.
+**Research first.** AI knowledge has a cutoff. Use the `research-first` agent (or Context7/WebFetch/WebSearch manually) to check current docs before design. See Phase 2 in `/new-feature` and Phase 2.5 in `/fix-bug`.
 
 **Learn from competitors.** Before implementing features, research how established products solved it.
 

--- a/setup.ps1
+++ b/setup.ps1
@@ -305,6 +305,7 @@ $directories = @(
     ".claude\skills\generate-image",
     ".claude\skills\release",
     ".claude\skills\council\references",
+    "docs\research",
     "tests\e2e\use-cases",
     "tests\e2e\reports"
 )
@@ -390,6 +391,7 @@ Copy-TemplateFile (Join-Path (Join-Path $ScriptDir "hooks") "check-workflow-gate
 Copy-TemplateFile (Join-Path (Join-Path $ScriptDir "agents") "verify-app.md") ".claude\agents\verify-app.md" ".claude\agents\verify-app.md"
 Copy-TemplateFile (Join-Path (Join-Path $ScriptDir "agents") "verify-e2e.md") ".claude\agents\verify-e2e.md" ".claude\agents\verify-e2e.md"
 Copy-TemplateFile (Join-Path (Join-Path $ScriptDir "agents") "council-advisor.md") ".claude\agents\council-advisor.md" ".claude\agents\council-advisor.md"
+Copy-TemplateFile (Join-Path (Join-Path $ScriptDir "agents") "research-first.md") ".claude\agents\research-first.md" ".claude\agents\research-first.md"
 
 # Skills (tech-agnostic)
 $releaseDir = Join-Path (Join-Path (Join-Path $ScriptDir "skills") "release")

--- a/setup.sh
+++ b/setup.sh
@@ -287,6 +287,7 @@ directories=(
     "docs/solutions/integration-issues"
     "docs/solutions/logic-errors"
     "docs/solutions/patterns"
+    "docs/research"
     "tests/e2e/use-cases"
     "tests/e2e/reports"
 )
@@ -361,6 +362,7 @@ chmod +x .claude/hooks/check-workflow-gates.sh 2>/dev/null || true
 copy_file "$SCRIPT_DIR/agents/verify-app.md" ".claude/agents/verify-app.md" ".claude/agents/verify-app.md"
 copy_file "$SCRIPT_DIR/agents/verify-e2e.md" ".claude/agents/verify-e2e.md" ".claude/agents/verify-e2e.md"
 copy_file "$SCRIPT_DIR/agents/council-advisor.md" ".claude/agents/council-advisor.md" ".claude/agents/council-advisor.md"
+copy_file "$SCRIPT_DIR/agents/research-first.md" ".claude/agents/research-first.md" ".claude/agents/research-first.md"
 
 # Skills (tech-agnostic)
 copy_file "$SCRIPT_DIR/skills/release/SKILL.template.md" ".claude/skills/release/SKILL.md" ".claude/skills/release/SKILL.md"


### PR DESCRIPTION
## Problem

"Research first" is in `rules/principles.md` and `rules/critical-rules.md`. It's advice — no artifact, no gate, no enforcement. Skipped 70-80% of the time. Libraries ship breaking changes weekly; AI knowledge has a cutoff. Designs get built on stale assumptions.

## Solution

Same enforcement pattern that fixed E2E testing: **agent + artifact + workflow gate**.

The `research-first` agent queries Context7, official docs, and changelogs for every dependency a feature touches. It produces a structured brief at `docs/research/YYYY-MM-DD-<feature>.md`. Phase 3 (Design) cannot start without this artifact.

## Summary

- **New agent:** `agents/research-first.md` — tools: Read/Grep/Glob/WebSearch/WebFetch/Context7/Write (Write instruction-scoped to `docs/research/` only)
- **`/new-feature` Phase 2 rewrite:** mandatory agent dispatch → structured brief → artifact gate. Fallback: main agent performs research manually if tools fail.
- **`/fix-bug` Phase 2.5:** targeted library research after root-cause isolation (not before)
- **`/quick-fix`:** lightweight manual check note if external deps touched
- **`/prd:discuss` + `/prd:create`:** clarified Phase 0 (discovery research — WHAT to build) vs Phase 2 (implementation research — HOW to build with current tools). Added Context7.
- **Anti-rubber-stamp:** min 2 sources/library, 1 design decision + 1 test implication each. Triaged "Not Researched" items are exempt from per-library gate.
- **Internal-only features:** agent writes minimal N/A brief — gate always has a file to check
- **`setup.sh`/`setup.ps1`:** copy agent + create `docs/research/` for all project types

## Review history

- 3 rounds Codex review → clean (fixed: N/A brief for internal features, triage-exempt gate, checkpoint label mismatch)
- pr-review-toolkit: code-reviewer (3 findings fixed: duplicate checkpoint, fix-bug checkpoint, README table placement) + code-simplifier (trimmed principles.md)
- verify-app: PASS

## Files (12 changed, 15 commits)

**New (1):** `agents/research-first.md`

**Modified (11):** `commands/new-feature.md`, `commands/fix-bug.md`, `commands/quick-fix.md`, `commands/prd/discuss.md`, `commands/prd/create.md`, `rules/principles.md`, `setup.sh`, `setup.ps1`, `CLAUDE.md`, `CLAUDE.template.md`, `README.md`

## Test plan

- [x] `bash -n setup.sh` — clean
- [x] setup.sh fresh install: agent + docs/research/ created
- [x] setup.sh upgrade: agent present after `--upgrade --force`
- [x] setup.sh python: agent installed (not tech-gated)
- [x] Command grep checks: research-first in new-feature (5), fix-bug (2), quick-fix (1), fallback (3)
- [x] Agent tools: 7 tools including Write; docs/research/ scope documented (3 refs)
- [x] verify-app — PASS
- [ ] External review
- [ ] Windows pwsh — deferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)