### PR TITLE
docs(codex-skill): add flag reference + powerful -c config overrides

### DIFF
--- a/commands/codex.md
+++ b/commands/codex.md
@@ -178,3 +178,45 @@ Display Codex's output verbatim to the user. Do not summarize or edit it.
 | Review a specific commit   | `codex exec review --ephemeral --commit SHA`                      |
 | Review a design plan       | `codex exec --sandbox read-only --ephemeral "Review the plan..."` |
 | General second opinion     | `codex exec --sandbox read-only --ephemeral "Your question..."`   |
+
+---
+
+## Flag Reference — What Works Where
+
+**`codex exec review` (subcommand) flags:**
+`-c key=value`, `--uncommitted`, `--base <BRANCH>`, `--commit <SHA>`, `-m/--model`, `--title`, `--ephemeral`, `--json`, `-o/--output-last-message`, `--full-auto`, `--skip-git-repo-check`, `--enable/--disable <FEATURE>`.
+
+**NOT valid on `exec review`** (but valid on plain `codex exec`):
+`--sandbox`, `--color`, `-i/--image`, `-C/--cd`, `--add-dir`, `--output-schema`, `-p/--profile`, `--oss`.
+
+**Mutually exclusive on `exec review`:** preset flags (`--uncommitted`, `--base`, `--commit`) cannot be combined with a positional `[PROMPT]`. Pick one:
+
+- **Preset scope + focus via config**: `codex exec review --uncommitted -c developer_instructions="Focus on auth flows"`
+- **Custom prompt only** (reviewer picks scope from your wording): `codex exec review "Audit the recent auth middleware changes for token leakage"`
+
+## Powerful `-c` Config Overrides
+
+These work on **both** `codex exec` and `codex exec review`:
+
+| Config key                | Purpose                                                    | Example                                                                 |
+| ------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `model`                   | Override the session model                                 | `-c model="gpt-5.4"`                                                    |
+| `model_reasoning_effort`  | Depth of reasoning                                         | `-c model_reasoning_effort="xhigh"` (minimal\|low\|medium\|high\|xhigh) |
+| `model_reasoning_summary` | Reasoning output detail                                    | `-c model_reasoning_summary="detailed"` (auto\|concise\|detailed\|none) |
+| `developer_instructions`  | Inject guidance (works WITH preset review flags)           | `-c developer_instructions="Focus on SQL injection"`                    |
+| `review_model`            | Model override just for `/review`                          | `-c review_model="gpt-5.4"`                                             |
+| `web_search`              | Allow live docs lookup during review                       | `-c web_search=live` (disabled\|cached\|live)                           |
+| `service_tier`            | Processing tier                                            | `-c service_tier="fast"` (flex\|fast)                                   |
+| `approval_policy`         | When to pause for confirmation (plain `exec` only)         | `-c approval_policy="on-request"` (untrusted\|on-request\|never)        |
+| `sandbox_mode`            | Sandbox policy as config (alternative to `--sandbox` flag) | `-c sandbox_mode="read-only"`                                           |
+
+## Other Useful Flags
+
+| Flag                              | Purpose                                                        |
+| --------------------------------- | -------------------------------------------------------------- |
+| `--ephemeral`                     | Don't persist session files (use for one-shot reviews)         |
+| `-o/--output-last-message <FILE>` | Write just the final message to a file — great for scripting   |
+| `--json`                          | Emit JSONL events for downstream automation                    |
+| `--full-auto`                     | Low-friction preset: `-a on-request --sandbox workspace-write` |
+| `--title "description"`           | Label the review in the summary (review subcommand only)       |
+| `--skip-git-repo-check`           | Allow running outside a Git repository                         |


### PR DESCRIPTION
## Summary

- **Not a bug fix in the template** — investigation showed the tracked \`commands/codex.md\` was already correct (no \`--sandbox\`/\`--color\` on \`codex exec review\`, correct note about \`--uncommitted\`+prompt mutual exclusion). The earlier failure came from a stale installed copy at \`.claude/commands/codex.md\` (gitignored).
- **Docs addition** — after researching the current Codex CLI surface (local \`--help\` + OpenAI developer docs), adds a reference section at the bottom of the skill covering flag validity per subcommand, mutual-exclusion rules, and powerful \`-c\` config overrides that weren't documented.

## What's new in the skill

- **Flag Reference** table showing which flags are valid on \`codex exec review\` vs plain \`codex exec\` and which are review-incompatible
- **Mutual-exclusion note** — \`--uncommitted\`/\`--base\`/\`--commit\` can't combine with a positional \`[PROMPT]\`; two legal patterns shown (preset + \`-c developer_instructions=\` vs custom-prompt-only)
- **Powerful \`-c\` config overrides** — \`model_reasoning_effort\`, \`developer_instructions\`, \`review_model\`, \`web_search=live\`, \`service_tier\`, \`sandbox_mode\`, \`approval_policy\`, etc.
- **Other useful flags** — \`--output-last-message\` (scriptable), \`--json\`, \`--full-auto\`, \`--title\`, \`--skip-git-repo-check\`

## Test plan

- [ ] Render \`commands/codex.md\` on GitHub and confirm the new tables display correctly
- [ ] After \`setup.sh --upgrade\` on an existing project, verify \`.claude/commands/codex.md\` picks up the new reference section
- [ ] Spot check: run \`codex exec review --uncommitted -c developer_instructions=\"Focus on X\"\` to confirm the preset + config pattern works

## Follow-up (not in this PR)

The stale \`.claude/commands/codex.md\` in this repo was hand-refreshed locally. Users on older installs should run \`setup.sh --upgrade\` to propagate the template updates (including this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)