### PR TITLE
docs: fix broken README Quick Start — add Superpowers + Codex steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,24 +43,34 @@ Claude Codex Forge combines **Claude Code** and **OpenAI's Codex** into a single
 
 ## Quick start
 
+**Prerequisites:** [Claude Code](https://code.claude.com/docs) · [Node.js 22+](https://nodejs.org) · Git 2.23+ · a [ChatGPT Plus/Pro/Business plan or OpenAI API key](https://developers.openai.com/codex/) for Codex CLI.
+
 ```bash
-# 1. Clone once per machine
+# 1. Clone this harness repo (once per machine)
 git clone https://github.com/pablomarin/claude-codex-forge.git ~/claude-codex-forge
 chmod +x ~/claude-codex-forge/setup.sh
 
-# 2. Global setup once per machine (installs memory system)
+# 2. Global setup once per machine (installs the memory system)
 ~/claude-codex-forge/setup.sh --global
 
-# 3. Per-project setup
+# 3. Install Codex CLI + authenticate (required for dual-agent review)
+npm install -g @openai/codex   # or: brew install --cask codex
+codex login
+
+# 4. Per-project setup
 cd /path/to/your/project
 ~/claude-codex-forge/setup.sh -p "My Project"
 
-# 4. Start Claude Code and kick off your first workflow
+# 5. Start Claude Code, install the Superpowers plugin, restart
 claude
+> /plugin marketplace add obra/superpowers-marketplace
+> /plugin install superpowers@superpowers-marketplace
+
+# 6. Restart Claude Code, then kick off your first workflow
 > /new-feature my-feature
 ```
 
-Full walkthrough with prerequisites, plugin install, and Codex CLI setup: **[Getting Started →](docs/getting-started.md)**
+Full walkthrough with platform-specific (Windows/macOS/Linux) instructions, the "no Codex" fallback, and troubleshooting: **[Getting Started →](docs/getting-started.md)**
 
 Windows users: [PowerShell instructions](docs/getting-started.md#windows).
 


### PR DESCRIPTION
## Summary

The previous 4-step Quick Start ended with \`> /new-feature my-feature\`, but that command invokes \`/superpowers:brainstorming\` and \`/superpowers:writing-plans\`, which fail with "Unknown skill" if the Superpowers plugin isn't installed. It also assumed Codex CLI was available — never told the user to install it.

New 6-step Quick Start adds the two missing prerequisites so a first-time visitor copy-pasting the block actually reaches a working \`/new-feature\`:

- **Step 3 (new):** Install Codex CLI (npm or Homebrew) + \`codex login\`
- **Step 5 (new):** \`/plugin install superpowers@superpowers-marketplace\`

Also added a one-line **Prerequisites** callout above the code block (Claude Code · Node.js 22+ · Git 2.23+ · ChatGPT Plus/Pro or OpenAI API key for Codex).

## Why

README is the first thing visitors see. Truncated-but-broken is worse than slightly-longer-but-working. Going from 4 → 6 steps is a small cost for a working happy path.

## Test plan

- [ ] On a clean machine, paste the Quick Start block sequentially and verify \`/new-feature demo\` reaches the brainstorming phase without any "Unknown skill" errors
- [ ] Verify the \`docs/getting-started.md\` link still resolves and contains the platform-specific / fallback / troubleshooting detail
- [ ] Render on GitHub and confirm the block formats correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)