### PR TITLE
chore: add 5.7 changelog entry + gitignore user-runtime tests/e2e/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,10 @@ docs/solutions/
 docs/research/
 docs/ci-templates/
 .worktrees/
+
+# tests/e2e/ is the user-runtime convention scaffolded by
+# `setup.sh --with-playwright` into downstream projects. If this template
+# repo ever gets run through its own setup.sh (e.g. while dogfooding),
+# we don't want the scaffolded dir tracked. The template's own regression
+# suite lives in tests/template/, which IS tracked.
+tests/e2e/

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to claude-codex-forge.
 
+## 5.7 — 2026-04-18 · Template self-test suite
+
+Fast local regression protection for template changes — avoids the prior commit-push-merge-install-in-downstream-repo loop.
+
+- **`tests/template/`** — 4 bash suites, 111 assertions, runs in ~5 seconds via `bash tests/template/run-all.sh`. Zero external dependencies beyond bash + jq.
+- **test-setup.sh** (39 assertions) exercises `setup.sh --with-playwright` against flat, monorepo (`frontend/`), multi-candidate, `--playwright-dir` override, and `apps/r&d` metachar layouts. Covers idempotency (hash-based), `-f` force-refresh, and `--upgrade` smoke. The metachar test confirms PR #482's bash-parameter-expansion fix for the `&`-substitution bug.
+- **test-fixtures.sh** (23 assertions) fingerprints template content: branding leak, trace/video CI security default, cookie-auth default with block-comment-aware check for the insecure `localStorage` pattern, verify-e2e response header, post-tool-format monorepo walk-up, prd/create.md fence balance.
+- **test-contracts.sh** (23 assertions) cross-file consistency: every VERDICT value in `verify-e2e.md` is consumed by `new-feature.md` + `fix-bug.md` and vice versa, SUGGESTED_PATH is honored, `.claude/playwright-dir` marker has both a writer (setup.sh / setup.ps1) and readers (command docs), `__PLAYWRIGHT_DIR__` placeholder is handled in both shell and PowerShell.
+- **test-lint.sh** (26 assertions) `bash -n` on every shell script, `pwsh` parse on `.ps1` files (skipped without pwsh), `jq empty` on JSON templates, placeholder-coverage check.
+
 ## 5.6 — 2026-04-17 · Template monorepo support + Playwright security fixes
 
 Batch fix for 9 Copilot findings surfaced in a downstream user project (mcpgateway) plus 4 related "missed" items from a Codex review. All are template-level bugs — downstream users pick them up via `setup.sh --upgrade`.


### PR DESCRIPTION
## Summary

Two small post-merge cleanups:

- **CHANGELOG 5.7** documents PR #483 (template self-test suite). The 5.6 entry covered the template fixes batch; the test suite needed its own entry.
- **.gitignore** adds \`tests/e2e/\` so scaffolded user-runtime directories don't show up as untracked when anyone runs \`setup.sh --with-playwright\` on this template repo itself while dogfooding. The tracked regression suite in \`tests/template/\` is unaffected.

Diff: +17 / -0 across 2 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)