### PR TITLE
fix(setup): preserve user's docs/CHANGELOG.md on -f / --upgrade

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -652,8 +652,11 @@ if ($WithPlaywright) {
 
 Write-Host ""
 
-# Create CHANGELOG if it doesn't exist
-if ((-not (Test-Path "docs\CHANGELOG.md")) -or $Force) {
+# Create CHANGELOG only if it doesn't exist — NEVER overwrite on -Force / -Upgrade.
+# docs\CHANGELOG.md is user content (each project's own release history). Same
+# policy as CLAUDE.md and CONTINUITY.md: templates initialize the file on first
+# install and never touch it afterward.
+if (-not (Test-Path "docs\CHANGELOG.md")) {
     Write-Color "Creating docs\CHANGELOG.md..." "Yellow"
 
     $changelogLines = @(

--- a/setup.sh
+++ b/setup.sh
@@ -587,8 +587,11 @@ fi
 
 echo ""
 
-# Create CHANGELOG if it doesn't exist
-if [[ ! -f "docs/CHANGELOG.md" ]] || [[ "$FORCE" == true ]]; then
+# Create CHANGELOG only if it doesn't exist — NEVER overwrite on -f / --upgrade.
+# docs/CHANGELOG.md is user content (each project's own release history). Same
+# policy as CLAUDE.md and CONTINUITY.md: templates initialize the file on first
+# install and never touch it afterward.
+if [[ ! -f "docs/CHANGELOG.md" ]]; then
     echo -e "${YELLOW}Creating docs/CHANGELOG.md...${NC}"
     cat > docs/CHANGELOG.md << EOF
 # Changelog

--- a/tests/template/test-setup.sh
+++ b/tests/template/test-setup.sh
@@ -214,6 +214,8 @@ assert_hash_equals "$S6/docs/ci-templates/e2e.yml" "$HASH_YML_BEFORE" \
 
 # ===========================================================================
 # Test 8: --upgrade smoke — the actual downstream pain path
+# Also exercises the "user content is never clobbered" invariant: CLAUDE.md,
+# CONTINUITY.md, AND docs/CHANGELOG.md must survive -f and --upgrade intact.
 # ===========================================================================
 start_test "Test 8: --upgrade smoke on existing install"
 
@@ -221,26 +223,51 @@ S8=$(scratch_dir upgrade)
 make_project "$S8" frontend
 LOG8a="$S8/.setup.install.log"
 LOG8b="$S8/.setup.upgrade.log"
+LOG8c="$S8/.setup.force.log"
 
 # Initial install
 run_setup "$S8" "$LOG8a" -p "UpgradeTest" -t fullstack --with-playwright
 assert_equals "$?" "0" "initial install exits 0"
 assert_file_exists "$S8/.claude/commands/new-feature.md" \
     "initial install populated .claude/commands"
+assert_file_exists "$S8/docs/CHANGELOG.md" \
+    "initial install created docs/CHANGELOG.md"
 
-# Simulate a user customization in settings.json
-if [[ -f "$S8/.claude/settings.json" ]]; then
-    # Run upgrade — should preserve CLAUDE.md, CONTINUITY.md, and the merge
-    # behavior for settings should keep our marker intact
-    run_setup "$S8" "$LOG8b" --upgrade
-    assert_equals "$?" "0" "--upgrade exits 0"
-    assert_file_exists "$S8/.claude/commands/new-feature.md" \
-        ".claude/commands still present after --upgrade"
-    assert_file_exists "$S8/CLAUDE.md" \
-        "CLAUDE.md preserved by --upgrade"
-else
-    fail "settings.json missing after initial install — cannot test --upgrade"
-fi
+# Simulate the user actually using CHANGELOG and CLAUDE.md — they add their
+# own release entries and project notes. This is the content that MUST NOT
+# be wiped on later upgrade/force.
+CHANGELOG_SENTINEL="## 1.2.3 — USER RELEASE ENTRY SENTINEL"
+echo "$CHANGELOG_SENTINEL" >> "$S8/docs/CHANGELOG.md"
+CLAUDE_SENTINEL="## USER-OWNED PROJECT NOTE SENTINEL"
+echo "$CLAUDE_SENTINEL" >> "$S8/CLAUDE.md"
+HASH_CHANGELOG=$(hash_file "$S8/docs/CHANGELOG.md")
+HASH_CLAUDE=$(hash_file "$S8/CLAUDE.md")
+
+# Run --upgrade — the downstream pain path
+run_setup "$S8" "$LOG8b" --upgrade
+assert_equals "$?" "0" "--upgrade exits 0"
+assert_file_exists "$S8/.claude/commands/new-feature.md" \
+    ".claude/commands still present after --upgrade"
+assert_file_exists "$S8/CLAUDE.md" \
+    "CLAUDE.md preserved by --upgrade"
+assert_contains "$S8/CLAUDE.md" "USER-OWNED PROJECT NOTE SENTINEL" \
+    "--upgrade preserves user content in CLAUDE.md"
+assert_contains "$S8/docs/CHANGELOG.md" "USER RELEASE ENTRY SENTINEL" \
+    "--upgrade preserves user entries in docs/CHANGELOG.md"
+assert_hash_equals "$S8/docs/CHANGELOG.md" "$HASH_CHANGELOG" \
+    "--upgrade does not touch CHANGELOG at all"
+assert_hash_equals "$S8/CLAUDE.md" "$HASH_CLAUDE" \
+    "--upgrade does not touch CLAUDE.md at all"
+
+# Also verify -f (force) preserves user content. -f is the big hammer that
+# SHOULD refresh .claude/* and CI templates, but MUST still leave CLAUDE.md,
+# CONTINUITY.md, and docs/CHANGELOG.md alone — they are user content.
+run_setup "$S8" "$LOG8c" -p "UpgradeTest" -t fullstack --with-playwright -f
+assert_equals "$?" "0" "-f exits 0"
+assert_hash_equals "$S8/docs/CHANGELOG.md" "$HASH_CHANGELOG" \
+    "-f does not touch CHANGELOG"
+assert_hash_equals "$S8/CLAUDE.md" "$HASH_CLAUDE" \
+    "-f does not touch CLAUDE.md"
 
 # ===========================================================================
 # Report


### PR DESCRIPTION
## Summary

**Bug:** \`setup.sh --upgrade\` (and plain \`-f\`) was silently overwriting the user's \`docs/CHANGELOG.md\` with the template default — erasing months or years of accumulated release history.

**Root cause:** the CHANGELOG-create block used \`if [[ ! -f docs/CHANGELOG.md ]] || [[ \$FORCE == true ]]; then …\`, so anytime \`FORCE\` was set (via \`-f\` OR by \`--upgrade\` which enables \`FORCE\` internally), the heredoc wrote the boilerplate template over whatever the user had accumulated. Same bug in \`setup.ps1\` with \`-or \$Force\`.

**Fix:** drop the \`FORCE\` clause. CHANGELOG is user content — same policy as \`CLAUDE.md\` and \`CONTINUITY.md\`, which are preserved on \`-f\` / \`--upgrade\`.

## Regression test

Extended \`tests/template/test-setup.sh\` Test 8:

1. Initial install creates CHANGELOG from template ✓
2. User appends a sentinel release entry + sentinel CLAUDE.md note; hashes captured
3. Run \`--upgrade\`: assert CHANGELOG hash unchanged, CLAUDE.md hash unchanged, sentinels still present
4. Run \`-f\` (the big hammer): same assertions — still unchanged

Test suite grows from 111 → 119 assertions, all pass on main with the fix applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)