### PR TITLE
feat(setup): warn-only interpreter preflight + multi-project isolation guide

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to claude-codex-forge.
 
+## 5.8 — 2026-04-18 · Multi-project interpreter preflight + isolation guide
+
+Handles the "I work on 5 projects with different Python/Node versions" case. Recommendation came from a 5-advisor Engineering Council session with Codex chairman synthesis.
+
+- **`docs/guides/multi-project-isolation.md`** — canonical doc explaining the `uv` + `pnpm` dependency-isolation model, why the harness does NOT switch interpreter binaries for you, and which version managers to use (`uv python install`, `pyenv`, `fnm`, `nvm`, `volta`). Linked from `docs/getting-started.md` and `docs/guides/parallel-sessions.md`.
+- **Warn-only preflight in `setup.sh` + `setup.ps1`** (before `Prerequisites OK`). Reads repo-root `.python-version`, `.nvmrc`, and root `package.json` `engines.node`. Prints a warning with install guidance if the declared runtime is unavailable. **Never changes exit code.** Silent when no pins exist. Detection checks in order: `uv python list` → `pyenv versions` → `python3.MAJOR.MINOR` → `python3 --version` match for Python; `node --version` major match → `fnm`/`nvm`/`volta` listings for Node.
+- **Explicitly NOT shipped** per Council minority-report resolution: no session-start hook check (wrong layer), no `verify-app` preamble (another policy surface before installer/doc contract is settled), no subdir detection (monorepo pattern deferred), no silence flag (remove pin file to disable per-project).
+- **Test suite grows 119 → 143 assertions.** `test-setup.sh` adds 4 scenarios (impossible Python version, impossible Node version, no pins → silent, matching version → green). `test-contracts.sh` adds a shell/PowerShell parity contract asserting both installers reference the same files and canonical guide.
+
 ## 5.7 — 2026-04-18 · Template self-test suite
 
 Fast local regression protection for template changes — avoids the prior commit-push-merge-install-in-downstream-repo loop.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -172,4 +172,5 @@ This updates all hooks, commands, and rules while safely merging new settings in
 - [Setup scenarios](guides/setup-scenarios.md) — New project, existing project, or upgrading
 - [Customize your project](guides/customize-project.md) — CLAUDE.md, CONTINUITY.md, optional MCP add-ons
 - [Parallel development](guides/parallel-sessions.md) — Multiple sessions via git worktrees
+- [Multi-project isolation](guides/multi-project-isolation.md) — How `uv` / `pnpm` / worktrees keep projects separate, and why `setup.sh` does a warn-only interpreter preflight
 - [Troubleshooting](troubleshooting.md) — If something's not working

--- a/docs/guides/multi-project-isolation.md
+++ b/docs/guides/multi-project-isolation.md
@@ -1,0 +1,88 @@
+# Multi-Project Isolation
+
+If you use Claude Codex Forge across several projects at once, each with its own Python / Node / library versions, here is what the harness isolates for you automatically — and what you still have to arrange yourself.
+
+## TL;DR
+
+- **Dependencies** are isolated per project by `uv` (Python) and `pnpm` (Node). You get this for free.
+- **Interpreter binaries** (`python3.10` vs `python3.12`, `node 18` vs `node 22`) are NOT switched for you. Use a version manager — `uv python install`, `pyenv`, `nvm`, `fnm`, or `volta`.
+- **`setup.sh` runs a warn-only preflight** at install/upgrade time that reads `.python-version`, `.nvmrc`, and root `package.json` `engines.node` and tells you if the declared runtime is missing. It never blocks — setup always completes with exit 0.
+
+## What the harness isolates automatically
+
+### Python dependencies — via `uv`
+
+When you run `uv sync` in a project, `uv` creates a project-local `.venv/` directory with exactly the interpreter version and packages `pyproject.toml` specifies. `uv run pytest` uses that venv automatically. No manual `source .venv/bin/activate` is needed.
+
+The `post-tool-format.sh` hook that ships with this harness walks up from any edited `.py` file to find the nearest `pyproject.toml`, then runs `uv run ruff check --fix` and `uv run ruff format` from that directory — so monorepos with `backend/src/`, `apps/api/`, or similar layouts all get the right per-project lint/format config.
+
+### Node dependencies — via `pnpm`
+
+`pnpm install` populates a project-local `node_modules/` directory. `pnpm exec playwright test` uses the local install. Nothing global is touched.
+
+### Worktrees for parallel work — via `/new-feature` and `/fix-bug`
+
+Each active feature gets its own worktree under `.worktrees/<name>/` with its own filesystem state. Running three Claude sessions on three features in parallel works without cross-contamination. Each worktree reuses the same `.venv/` / `node_modules/` via symlinks from the main worktree, so you don't pay the dependency-install cost every time.
+
+## What the harness does NOT switch for you
+
+Interpreter binaries. If project A's `pyproject.toml` declares `requires-python = ">=3.10,<3.11"` and project B declares `">=3.12"`, the harness does not install either version or route your calls to the right one. You need a version manager.
+
+Recommended:
+
+| Language | Primary recommendation                   | Alternatives                   |
+| -------- | ---------------------------------------- | ------------------------------ |
+| Python   | `uv python install <version>`            | `pyenv`, `mise`, `asdf`, Conda |
+| Node     | `fnm` (fast, auto-switches via `.nvmrc`) | `volta`, `nvm`, `mise`, `asdf` |
+
+Once installed, `uv sync` and `pnpm install` respect the active version. For Python, if the exact version `pyproject.toml` requires is missing, `uv` will usually fetch it on demand — so `uv python install` may not even be needed as a separate step. Node doesn't auto-fetch; you install versions explicitly.
+
+## How the `setup.sh` preflight helps
+
+Before printing `Prerequisites OK`, `setup.sh` checks whether repo-root version declarations can be satisfied:
+
+| File scanned                       | What's checked                                                                                                                                                     |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `.python-version`                  | Pinned Python version (e.g. `3.12.5`). Preflight verifies a matching interpreter is discoverable via `uv python list`, `pyenv versions`, or `python3.X --version`. |
+| `.nvmrc`                           | Pinned Node version (e.g. `20.11.0` or `20`). Preflight verifies `node --version` matches, or that `fnm`/`nvm`/`volta` can provide it.                             |
+| root `package.json` `engines.node` | Declared constraint (e.g. `">=20"`). Preflight checks `node --version` satisfies the minimum; warns otherwise.                                                     |
+
+**If a declared runtime is missing or mismatched, preflight prints a warning with install guidance and continues.** It does NOT set a non-zero exit code. It does NOT stop `setup.sh`. `--upgrade` works exactly the same as a fresh install.
+
+**If neither `.python-version` / `.nvmrc` / root `package.json` exists, preflight is silent** — the check doesn't run, so there's no noise for projects that don't pin versions.
+
+**If the required version manager isn't installed** (no `pyenv` / no `fnm` / no `uv`), preflight falls back to checking the system interpreter. If the system interpreter doesn't match, you see a warning telling you to install one of the recommended version managers.
+
+## Scope and limitations of the preflight
+
+Intentionally narrow for v1:
+
+- **Repo root only.** Sub-directory `.python-version` files (monorepo patterns like `backend/.python-version`) are NOT checked. The `uv` walk-up in the post-tool-format hook handles those at runtime; pre-flight doesn't duplicate it.
+- **Warning only.** No exit codes change. No session blocking. If you're mid-upgrade on a project whose pinned versions are stale, you still get to finish the upgrade.
+- **No interpreter switching.** Preflight diagnoses; you fix. A well-written message will tell you which command to run (`uv python install 3.12`, `fnm install 20`, etc.).
+- **No `verify-app` integration.** The `verify-app` agent already runs `uv run pytest`, which fails loudly on interpreter issues. We don't layer a second check there — Codex's Scalability Hawk advisor argued for it, Council deferred.
+- **No session-start hook.** Hooks fire on every session, every worktree, for every tech stack. Running an interpreter probe there would mean N shell-outs per startup and a support matrix covering pyenv/conda/poetry/nix/asdf/mise/volta/fnm/nvm. Not worth it.
+
+## Troubleshooting
+
+### `setup.sh` says my Python version is missing but I just installed it
+
+Some version managers require a shell restart before their shims are on `PATH`. Close and reopen the terminal, then rerun `setup.sh --upgrade`. If you use `uv`, run `uv python install <version>` — it's immediate.
+
+### I don't use version managers and setup.sh warns anyway
+
+If you have system `python3` that satisfies `.python-version` but no version manager, preflight should detect it via `python3 --version`. If you're still seeing warnings, the declared version likely doesn't exactly match what `python3` provides (e.g., `.python-version: 3.12.5` but system has `3.12.3`). Either update `.python-version` to allow the installed patch, or install the exact version.
+
+### I use Conda / Docker / Nix and your warnings are wrong for me
+
+Preflight's heuristic can't cover every version-manager pattern in the ecosystem. For exotic setups, the warning is informational; dismiss it. We err toward under-enforcement to avoid false positives.
+
+### Can I silence the preflight entirely?
+
+Not via a flag — the warning is useful most of the time and silent when you have no version pins. If you want to suppress it for a project, remove or empty the `.python-version` / `.nvmrc` files. If you want to suppress it for a CI run, redirect stdout/stderr appropriately.
+
+## Related guides
+
+- [Parallel Development](parallel-sessions.md) — worktree isolation for multiple Claude sessions on the same project
+- [Getting Started](../getting-started.md) — overall install steps with prerequisites
+- [Upgrading](upgrading.md) — `setup.sh --upgrade` mechanics

--- a/docs/guides/parallel-sessions.md
+++ b/docs/guides/parallel-sessions.md
@@ -2,6 +2,8 @@
 
 Run multiple Claude Code sessions simultaneously on the same project — each working on a different feature without conflicts.
 
+> **Working across multiple projects with different Python/Node versions?** Worktree isolation only covers one project. For per-project interpreter isolation see [Multi-Project Isolation](multi-project-isolation.md).
+
 ## How It Works
 
 When you run `/new-feature` or `/fix-bug` from the `main` branch, the workflow automatically:

--- a/setup.ps1
+++ b/setup.ps1
@@ -261,9 +261,11 @@ if (-not (Test-Path $globalClaude)) {
 # root package.json engines.node. Never changes exit code.
 # ---------------------------------------------------------------------------
 function Test-PythonVersion([string]$required) {
+    # NOTE: use `uv python find` (checks only installed interpreters), not
+    # `uv python list` (which includes downloadable ones and would false-positive).
     if (Get-Command uv -ErrorAction SilentlyContinue) {
-        $uvList = uv python list 2>$null
-        if ($uvList -and ($uvList -match [regex]::Escape($required))) { return $true }
+        uv python find $required *>$null 2>&1
+        if ($LASTEXITCODE -eq 0) { return $true }
     }
     if (Get-Command pyenv -ErrorAction SilentlyContinue) {
         $pyenvList = pyenv versions --bare 2>$null
@@ -287,16 +289,32 @@ function Test-PythonVersion([string]$required) {
 
 function Test-NodeVersion([string]$required) {
     $required = $required.TrimStart('v')
+    # Bare-major pin ('20') vs full version ('20.11.0'). Full versions require
+    # exact match; bare majors allow any patch under that major.
+    $isFullVersion = $required.Contains('.')
+
     if (Get-Command node -ErrorAction SilentlyContinue) {
         $current = ((node --version 2>$null) -replace '^v', '').Trim()
-        $reqMajor = ($required.Split('.'))[0]
-        $curMajor = ($current.Split('.'))[0]
-        if ($reqMajor -eq $curMajor) { return $true }
+        if ($isFullVersion) {
+            if ($required -eq $current) { return $true }
+        } else {
+            $reqMajor = ($required.Split('.'))[0]
+            $curMajor = ($current.Split('.'))[0]
+            if ($reqMajor -eq $curMajor) { return $true }
+        }
     }
     foreach ($vm in @('fnm', 'nvm', 'volta')) {
         if (Get-Command $vm -ErrorAction SilentlyContinue) {
-            $list = & $vm list 2>$null
-            if ($list -and ($list -match [regex]::Escape($required))) { return $true }
+            $list = (& $vm list 2>$null) -join "`n"
+            if (-not $list) { continue }
+            if ($isFullVersion) {
+                # Match bounded: v?20.11.0 followed by non-digit or EOL
+                $escaped = [regex]::Escape($required)
+                if ($list -match "v?$escaped(?:[^0-9]|$)") { return $true }
+            } else {
+                # Match v?20.<digit> — any patch under the major
+                if ($list -match "v?$required\.[0-9]") { return $true }
+            }
         }
     }
     return $false
@@ -316,7 +334,7 @@ Write-Color "Runtime version preflight..." "Yellow"
 $script:PreflightWarned = $false
 
 if (Test-Path ".python-version") {
-    $pyReq = (Get-Content ".python-version" -First 1).Trim()
+    $pyReq = (Get-Content ".python-version" -TotalCount 1).Trim()
     if ($pyReq) {
         if (Test-PythonVersion $pyReq) {
             Write-Host "  " -NoNewline
@@ -336,7 +354,7 @@ if (Test-Path ".python-version") {
 }
 
 if (Test-Path ".nvmrc") {
-    $nodeReq = (Get-Content ".nvmrc" -First 1).Trim()
+    $nodeReq = (Get-Content ".nvmrc" -TotalCount 1).Trim()
     if ($nodeReq) {
         if (Test-NodeVersion $nodeReq) {
             Write-Host "  " -NoNewline

--- a/setup.ps1
+++ b/setup.ps1
@@ -254,6 +254,135 @@ if (-not (Test-Path $globalClaude)) {
     Write-Color "Warning: Global memory not set up. Run: & $ScriptDir\setup.ps1 -Global" "Yellow"
 }
 
+# ---------------------------------------------------------------------------
+# Runtime version preflight (warn-only, never blocks).
+# Mirrors the POSIX logic in setup.sh. See docs/guides/multi-project-isolation.md
+# for the full policy. Scope for v1: repo-root .python-version, .nvmrc, and
+# root package.json engines.node. Never changes exit code.
+# ---------------------------------------------------------------------------
+function Test-PythonVersion([string]$required) {
+    if (Get-Command uv -ErrorAction SilentlyContinue) {
+        $uvList = uv python list 2>$null
+        if ($uvList -and ($uvList -match [regex]::Escape($required))) { return $true }
+    }
+    if (Get-Command pyenv -ErrorAction SilentlyContinue) {
+        $pyenvList = pyenv versions --bare 2>$null
+        if ($pyenvList -and ($pyenvList -match [regex]::Escape($required))) { return $true }
+    }
+    $parts = $required.Split('.')
+    if ($parts.Length -ge 2) {
+        $mm = "python$($parts[0]).$($parts[1])"
+        if (Get-Command $mm -ErrorAction SilentlyContinue) { return $true }
+    }
+    if (Get-Command python3 -ErrorAction SilentlyContinue) {
+        $v = (python3 --version 2>&1) -join ""
+        if ($v -match [regex]::Escape($required)) { return $true }
+    }
+    if (Get-Command python -ErrorAction SilentlyContinue) {
+        $v = (python --version 2>&1) -join ""
+        if ($v -match [regex]::Escape($required)) { return $true }
+    }
+    return $false
+}
+
+function Test-NodeVersion([string]$required) {
+    $required = $required.TrimStart('v')
+    if (Get-Command node -ErrorAction SilentlyContinue) {
+        $current = ((node --version 2>$null) -replace '^v', '').Trim()
+        $reqMajor = ($required.Split('.'))[0]
+        $curMajor = ($current.Split('.'))[0]
+        if ($reqMajor -eq $curMajor) { return $true }
+    }
+    foreach ($vm in @('fnm', 'nvm', 'volta')) {
+        if (Get-Command $vm -ErrorAction SilentlyContinue) {
+            $list = & $vm list 2>$null
+            if ($list -and ($list -match [regex]::Escape($required))) { return $true }
+        }
+    }
+    return $false
+}
+
+function Test-NodeEngines([string]$constraint) {
+    $minMajorMatch = [regex]::Match($constraint, '\d+')
+    if (-not $minMajorMatch.Success) { return $true }  # unparseable — skip
+    $minMajor = [int]$minMajorMatch.Value
+    if (-not (Get-Command node -ErrorAction SilentlyContinue)) { return $false }
+    $current = ((node --version 2>$null) -replace '^v', '').Trim()
+    $curMajor = [int]($current.Split('.'))[0]
+    return $curMajor -ge $minMajor
+}
+
+Write-Color "Runtime version preflight..." "Yellow"
+$script:PreflightWarned = $false
+
+if (Test-Path ".python-version") {
+    $pyReq = (Get-Content ".python-version" -First 1).Trim()
+    if ($pyReq) {
+        if (Test-PythonVersion $pyReq) {
+            Write-Host "  " -NoNewline
+            Write-Color "+" "Green"
+            Write-Host " Python $pyReq available (from .python-version)"
+        } else {
+            $script:PreflightWarned = $true
+            Write-Host "  " -NoNewline
+            Write-Color "!" "Yellow"
+            Write-Host " .python-version requires $pyReq, not detected on this machine."
+            Write-Host "    Install one of:"
+            Write-Host "      uv python install $pyReq       (fastest - uv-native)"
+            Write-Host "      pyenv install $pyReq           (classic)"
+            Write-Host "    Setup continues; uv sync will retry at project build time."
+        }
+    }
+}
+
+if (Test-Path ".nvmrc") {
+    $nodeReq = (Get-Content ".nvmrc" -First 1).Trim()
+    if ($nodeReq) {
+        if (Test-NodeVersion $nodeReq) {
+            Write-Host "  " -NoNewline
+            Write-Color "+" "Green"
+            Write-Host " Node $nodeReq available (from .nvmrc)"
+        } else {
+            $script:PreflightWarned = $true
+            Write-Host "  " -NoNewline
+            Write-Color "!" "Yellow"
+            Write-Host " .nvmrc requires Node $nodeReq, not detected on this machine."
+            Write-Host "    Install one of:"
+            Write-Host "      fnm install $nodeReq           (fastest - auto-switches)"
+            Write-Host "      nvm install $nodeReq           (classic)"
+            Write-Host "      volta install node@$nodeReq"
+        }
+    }
+}
+
+if (Test-Path "package.json") {
+    try {
+        $pkg = Get-Content "package.json" -Raw | ConvertFrom-Json
+        $enginesNode = $pkg.engines.node
+        if ($enginesNode) {
+            if (Test-NodeEngines $enginesNode) {
+                Write-Host "  " -NoNewline
+                Write-Color "+" "Green"
+                Write-Host " Node satisfies engines.node $enginesNode"
+            } else {
+                $script:PreflightWarned = $true
+                Write-Host "  " -NoNewline
+                Write-Color "!" "Yellow"
+                Write-Host " package.json engines.node requires $enginesNode, current Node does not match."
+                Write-Host "    Install a matching Node version via fnm / nvm / volta."
+            }
+        }
+    } catch {
+        # Unparseable package.json — skip rather than false-warn
+    }
+}
+
+if ($script:PreflightWarned) {
+    Write-Host "  " -NoNewline
+    Write-Color "i" "Blue"
+    Write-Host " See docs\guides\multi-project-isolation.md for the full policy."
+}
+
 Write-Host "  " -NoNewline
 Write-Color "+" "Green"
 Write-Host " Prerequisites OK"

--- a/setup.sh
+++ b/setup.sh
@@ -266,6 +266,135 @@ if [[ ! -f "$HOME/.claude/CLAUDE.md" ]]; then
     echo -e "${YELLOW}⚠ Global memory not set up. Run: $SCRIPT_DIR/setup.sh --global${NC}"
 fi
 
+# ---------------------------------------------------------------------------
+# Runtime version preflight (warn-only, never blocks).
+#
+# Scope (intentionally narrow for v1, per Engineering Council verdict):
+#   - Reads repo-root .python-version, .nvmrc, and root package.json:engines.node
+#   - Prints a warning with install guidance if the declared runtime is missing
+#   - NEVER sets a non-zero exit code — --upgrade must always complete
+#   - Silent if no pins exist
+#
+# Full rationale + troubleshooting: docs/guides/multi-project-isolation.md
+# ---------------------------------------------------------------------------
+preflight_python_version() {
+    local required="$1"
+    # Try version managers + system interpreter in order of reliability.
+    # If ANY of them can supply the required version, we're good.
+    if command -v uv &>/dev/null; then
+        uv python list 2>/dev/null | grep -qF "$required" && return 0
+    fi
+    if command -v pyenv &>/dev/null; then
+        pyenv versions --bare 2>/dev/null | grep -qF "$required" && return 0
+    fi
+    # System python3.X where X matches (e.g., python3.12 for .python-version=3.12.5)
+    local major_minor
+    major_minor=$(echo "$required" | awk -F. '{print $1"."$2}')
+    if [[ -n "$major_minor" ]] && command -v "python$major_minor" &>/dev/null; then
+        return 0
+    fi
+    # Fallback: exact match from plain python3 --version
+    if command -v python3 &>/dev/null; then
+        python3 --version 2>&1 | grep -qF "$required" && return 0
+    fi
+    return 1
+}
+
+preflight_node_version() {
+    local required="$1"
+    # Strip leading 'v' if present (.nvmrc sometimes has it)
+    required="${required#v}"
+    if command -v node &>/dev/null; then
+        local current
+        current=$(node --version 2>/dev/null | sed 's/^v//')
+        # Match major version (.nvmrc often says just "20" meaning any 20.x)
+        local req_major cur_major
+        req_major=$(echo "$required" | awk -F. '{print $1}')
+        cur_major=$(echo "$current" | awk -F. '{print $1}')
+        [[ "$req_major" == "$cur_major" ]] && return 0
+    fi
+    # Version managers
+    for vm in fnm nvm volta; do
+        if command -v "$vm" &>/dev/null; then
+            "$vm" list 2>/dev/null | grep -qF "$required" && return 0
+        fi
+    done
+    return 1
+}
+
+preflight_node_engines() {
+    # $1 = engines.node constraint (e.g., ">=20", "^18.0.0", "20")
+    local constraint="$1"
+    # Extract minimum major version from constraint for a rough check.
+    # Not a full semver solver — good enough for "is node the right major-ish?"
+    local min_major
+    min_major=$(echo "$constraint" | grep -oE '[0-9]+' | head -1)
+    [[ -z "$min_major" ]] && return 0  # Unparseable — skip rather than false-warn
+    if ! command -v node &>/dev/null; then
+        return 1
+    fi
+    local current_major
+    current_major=$(node --version 2>/dev/null | sed 's/^v//' | awk -F. '{print $1}')
+    [[ -z "$current_major" ]] && return 1
+    # Simple >= check; doesn't handle complex ranges but covers 95% of real engines fields
+    [[ "$current_major" -ge "$min_major" ]]
+}
+
+echo -e "${YELLOW}Runtime version preflight...${NC}"
+PREFLIGHT_WARNED=0
+
+# .python-version (strip whitespace/comments)
+if [[ -f ".python-version" ]]; then
+    PY_REQ=$(head -1 .python-version | tr -d '[:space:]')
+    if [[ -n "$PY_REQ" ]]; then
+        if preflight_python_version "$PY_REQ"; then
+            echo -e "  ${GREEN}✓${NC} Python $PY_REQ available (from .python-version)"
+        else
+            PREFLIGHT_WARNED=1
+            echo -e "  ${YELLOW}⚠${NC} .python-version requires ${YELLOW}$PY_REQ${NC}, not detected on this machine."
+            echo -e "    Install one of:"
+            echo -e "      ${BLUE}uv python install $PY_REQ${NC}       (fastest — uv-native)"
+            echo -e "      ${BLUE}pyenv install $PY_REQ${NC}          (classic)"
+            echo -e "    Setup continues; uv sync will retry at project build time."
+        fi
+    fi
+fi
+
+# .nvmrc
+if [[ -f ".nvmrc" ]]; then
+    NODE_REQ=$(head -1 .nvmrc | tr -d '[:space:]')
+    if [[ -n "$NODE_REQ" ]]; then
+        if preflight_node_version "$NODE_REQ"; then
+            echo -e "  ${GREEN}✓${NC} Node $NODE_REQ available (from .nvmrc)"
+        else
+            PREFLIGHT_WARNED=1
+            echo -e "  ${YELLOW}⚠${NC} .nvmrc requires Node ${YELLOW}$NODE_REQ${NC}, not detected on this machine."
+            echo -e "    Install one of:"
+            echo -e "      ${BLUE}fnm install $NODE_REQ${NC}           (fastest — auto-switches)"
+            echo -e "      ${BLUE}nvm install $NODE_REQ${NC}           (classic)"
+            echo -e "      ${BLUE}volta install node@$NODE_REQ${NC}"
+        fi
+    fi
+fi
+
+# Root package.json engines.node (only check root to keep v1 scope narrow)
+if [[ -f "package.json" ]] && command -v jq &>/dev/null; then
+    NODE_ENGINES=$(jq -r '.engines.node // empty' package.json 2>/dev/null)
+    if [[ -n "$NODE_ENGINES" ]]; then
+        if preflight_node_engines "$NODE_ENGINES"; then
+            echo -e "  ${GREEN}✓${NC} Node satisfies engines.node ${BLUE}$NODE_ENGINES${NC}"
+        else
+            PREFLIGHT_WARNED=1
+            echo -e "  ${YELLOW}⚠${NC} package.json engines.node requires ${YELLOW}$NODE_ENGINES${NC}, current Node does not match."
+            echo -e "    Install a matching Node version via fnm / nvm / volta."
+        fi
+    fi
+fi
+
+if [[ "$PREFLIGHT_WARNED" -eq 1 ]]; then
+    echo -e "  ${BLUE}ℹ${NC} See docs/guides/multi-project-isolation.md for the full policy."
+fi
+
 echo -e "${GREEN}✓ Prerequisites OK${NC}"
 echo ""
 

--- a/setup.sh
+++ b/setup.sh
@@ -281,8 +281,13 @@ preflight_python_version() {
     local required="$1"
     # Try version managers + system interpreter in order of reliability.
     # If ANY of them can supply the required version, we're good.
+    #
+    # NOTE: `uv python find` checks only *installed* interpreters (exits 0 if
+    # one satisfies the request, non-zero otherwise). `uv python list` shows
+    # downloadable versions too, which would cause false positives — don't
+    # use list here.
     if command -v uv &>/dev/null; then
-        uv python list 2>/dev/null | grep -qF "$required" && return 0
+        uv python find "$required" >/dev/null 2>&1 && return 0
     fi
     if command -v pyenv &>/dev/null; then
         pyenv versions --bare 2>/dev/null | grep -qF "$required" && return 0
@@ -304,19 +309,36 @@ preflight_node_version() {
     local required="$1"
     # Strip leading 'v' if present (.nvmrc sometimes has it)
     required="${required#v}"
+
+    # Distinguish bare-major pins ('20') from full versions ('20.11.0').
+    # Bare major ⇒ any patch under that major satisfies.
+    # Full version ⇒ require exact match.
+    local is_full_version=0
+    [[ "$required" == *.* ]] && is_full_version=1
+
     if command -v node &>/dev/null; then
         local current
         current=$(node --version 2>/dev/null | sed 's/^v//')
-        # Match major version (.nvmrc often says just "20" meaning any 20.x)
-        local req_major cur_major
-        req_major=$(echo "$required" | awk -F. '{print $1}')
-        cur_major=$(echo "$current" | awk -F. '{print $1}')
-        [[ "$req_major" == "$cur_major" ]] && return 0
+        if [[ "$is_full_version" == 1 ]]; then
+            [[ "$required" == "$current" ]] && return 0
+        else
+            local req_major cur_major
+            req_major=$(echo "$required" | awk -F. '{print $1}')
+            cur_major=$(echo "$current" | awk -F. '{print $1}')
+            [[ "$req_major" == "$cur_major" ]] && return 0
+        fi
     fi
-    # Version managers
+    # Version manager listings — match the version as a bounded token so
+    # '20.11.0' does NOT accidentally satisfy '20.11.01' and '18' does NOT
+    # accidentally match '20.18.x'.
     for vm in fnm nvm volta; do
-        if command -v "$vm" &>/dev/null; then
-            "$vm" list 2>/dev/null | grep -qF "$required" && return 0
+        command -v "$vm" &>/dev/null || continue
+        if [[ "$is_full_version" == 1 ]]; then
+            # Match "v?20.11.0" followed by end-of-line, whitespace, or non-digit
+            "$vm" list 2>/dev/null | grep -qE "v?${required//./\\.}([^0-9]|$)" && return 0
+        else
+            # Match "v?20.<digit>" — any patch under this major
+            "$vm" list 2>/dev/null | grep -qE "v?${required}\\.[0-9]" && return 0
         fi
     done
     return 1
@@ -377,17 +399,21 @@ if [[ -f ".nvmrc" ]]; then
     fi
 fi
 
-# Root package.json engines.node (only check root to keep v1 scope narrow)
+# Root package.json engines.node (only check root to keep v1 scope narrow).
+# `|| true` guards against `set -e` aborting setup if jq fails on malformed
+# JSON or if jq isn't installed at all. Missing jq / unparseable JSON just
+# silently skips the engines check — mirrors the PowerShell try/catch path.
+NODE_ENGINES=""
 if [[ -f "package.json" ]] && command -v jq &>/dev/null; then
-    NODE_ENGINES=$(jq -r '.engines.node // empty' package.json 2>/dev/null)
-    if [[ -n "$NODE_ENGINES" ]]; then
-        if preflight_node_engines "$NODE_ENGINES"; then
-            echo -e "  ${GREEN}✓${NC} Node satisfies engines.node ${BLUE}$NODE_ENGINES${NC}"
-        else
-            PREFLIGHT_WARNED=1
-            echo -e "  ${YELLOW}⚠${NC} package.json engines.node requires ${YELLOW}$NODE_ENGINES${NC}, current Node does not match."
-            echo -e "    Install a matching Node version via fnm / nvm / volta."
-        fi
+    NODE_ENGINES=$(jq -r '.engines.node // empty' package.json 2>/dev/null || true)
+fi
+if [[ -n "$NODE_ENGINES" ]]; then
+    if preflight_node_engines "$NODE_ENGINES"; then
+        echo -e "  ${GREEN}✓${NC} Node satisfies engines.node ${BLUE}$NODE_ENGINES${NC}"
+    else
+        PREFLIGHT_WARNED=1
+        echo -e "  ${YELLOW}⚠${NC} package.json engines.node requires ${YELLOW}$NODE_ENGINES${NC}, current Node does not match."
+        echo -e "    Install a matching Node version via fnm / nvm / volta."
     fi
 fi
 

--- a/tests/template/test-contracts.sh
+++ b/tests/template/test-contracts.sh
@@ -119,6 +119,24 @@ assert_contains "$FB" ".claude/playwright-dir" \
     "commands/fix-bug.md reads marker file"
 
 # ---------------------------------------------------------------------------
+# Contract 5: runtime preflight parity — both installers check the same files
+# and document the same canonical guide. Prevents one platform from silently
+# diverging.
+# ---------------------------------------------------------------------------
+start_test "Runtime preflight parity — setup.sh ↔ setup.ps1"
+
+for file in ".python-version" ".nvmrc" "package.json" "multi-project-isolation.md"; do
+    assert_contains "$REPO_ROOT/setup.sh" "$file" \
+        "setup.sh references $file"
+    assert_contains "$REPO_ROOT/setup.ps1" "$file" \
+        "setup.ps1 references $file"
+done
+
+# The guide itself must exist (warnings point to it)
+assert_file_exists "$REPO_ROOT/docs/guides/multi-project-isolation.md" \
+    "canonical isolation guide exists"
+
+# ---------------------------------------------------------------------------
 # Contract 4: CI template placeholder ↔ setup.sh substitution
 # ---------------------------------------------------------------------------
 start_test "__PLAYWRIGHT_DIR__ placeholder ↔ setup.sh substitution"

--- a/tests/template/test-setup.sh
+++ b/tests/template/test-setup.sh
@@ -338,6 +338,32 @@ else
     printf "  %s·%s skipped (python3 not installed): Case D\n" "$C_DIM" "$C_RESET"
 fi
 
+# Case E: .nvmrc with an EXACT version that can't possibly exist → warning
+# Regression guard for Codex's P2 finding: an exact version pin like
+# "20.11.0" must NOT be satisfied by ANY 20.x — check exact-match semantics.
+# Use "20.99999.0" which is guaranteed absent from any reasonable system.
+S9e=$(scratch_dir preflight-nvmrc-exact)
+make_project "$S9e" flat
+echo "20.99999.0" > "$S9e/.nvmrc"
+LOG9e="$S9e/.setup.log"
+
+run_setup "$S9e" "$LOG9e" -p "PreflightE" -t typescript
+assert_equals "$?" "0" "exact .nvmrc mismatch → setup exits 0"
+assert_matches "$LOG9e" ".nvmrc requires Node.*20\.99999\.0" \
+    "preflight warns when exact .nvmrc version is missing (even if major matches system)"
+
+# Case F: malformed package.json → preflight must NOT abort setup
+# Regression guard for Codex's P2 finding about set -e + jq.
+S9f=$(scratch_dir preflight-bad-json)
+make_project "$S9f" flat
+echo '{"name": "bad", this is not valid json' > "$S9f/package.json"
+LOG9f="$S9f/.setup.log"
+
+run_setup "$S9f" "$LOG9f" -p "PreflightF" -t typescript
+assert_equals "$?" "0" "malformed package.json → setup STILL exits 0 (no set -e abort)"
+assert_contains "$LOG9f" "Prerequisites OK" \
+    "setup reached Prerequisites OK despite malformed package.json"
+
 # ===========================================================================
 # Report
 # ===========================================================================

--- a/tests/template/test-setup.sh
+++ b/tests/template/test-setup.sh
@@ -270,6 +270,75 @@ assert_hash_equals "$S8/CLAUDE.md" "$HASH_CLAUDE" \
     "-f does not touch CLAUDE.md"
 
 # ===========================================================================
+# Test 9: runtime preflight — warns but never blocks
+# ===========================================================================
+start_test "Test 9: runtime preflight is warn-only"
+
+# Case A: .python-version pinned to an impossible version → warning + exit 0
+S9a=$(scratch_dir preflight-py)
+make_project "$S9a" flat
+echo "99.99.99" > "$S9a/.python-version"
+LOG9a="$S9a/.setup.log"
+
+run_setup "$S9a" "$LOG9a" -p "PreflightA" -t python
+assert_equals "$?" "0" "impossible .python-version → setup still exits 0"
+assert_matches "$LOG9a" ".python-version requires.*99\.99\.99" \
+    "preflight warns about missing Python version"
+assert_contains "$LOG9a" "uv python install 99.99.99" \
+    "warning includes install guidance"
+assert_contains "$LOG9a" "multi-project-isolation.md" \
+    "warning points to the canonical doc"
+assert_contains "$LOG9a" "Prerequisites OK" \
+    "setup proceeds past preflight to Prerequisites OK"
+
+# Case B: .nvmrc pinned to an impossible version → warning + exit 0
+S9b=$(scratch_dir preflight-node)
+make_project "$S9b" flat
+echo "999" > "$S9b/.nvmrc"
+LOG9b="$S9b/.setup.log"
+
+run_setup "$S9b" "$LOG9b" -p "PreflightB" -t typescript
+assert_equals "$?" "0" "impossible .nvmrc → setup still exits 0"
+assert_matches "$LOG9b" ".nvmrc requires Node.*999" \
+    "preflight warns about missing Node version"
+assert_contains "$LOG9b" "fnm install 999" \
+    "warning includes fnm install guidance"
+
+# Case C: no version pins at all → preflight silent (no warnings emitted)
+S9c=$(scratch_dir preflight-none)
+make_project "$S9c" flat
+LOG9c="$S9c/.setup.log"
+
+run_setup "$S9c" "$LOG9c" -p "PreflightC" -t fullstack
+assert_equals "$?" "0" "no pins → setup exits 0"
+assert_not_contains "$LOG9c" ".python-version requires" \
+    "no Python warning when no .python-version"
+assert_not_contains "$LOG9c" ".nvmrc requires" \
+    "no Node warning when no .nvmrc"
+assert_not_contains "$LOG9c" "multi-project-isolation.md" \
+    "no canonical-doc reference when no warnings fired"
+
+# Case D: .python-version matching the system interpreter → green check, no warning
+# Use the actual running python3 version so this is deterministic across CI machines.
+S9d=$(scratch_dir preflight-match)
+make_project "$S9d" flat
+if command -v python3 >/dev/null 2>&1; then
+    PY_CURRENT=$(python3 --version 2>&1 | awk '{print $2}')
+    if [[ -n "$PY_CURRENT" ]]; then
+        echo "$PY_CURRENT" > "$S9d/.python-version"
+        LOG9d="$S9d/.setup.log"
+        run_setup "$S9d" "$LOG9d" -p "PreflightD" -t python
+        assert_equals "$?" "0" "matching .python-version → setup exits 0"
+        assert_contains "$LOG9d" "Python $PY_CURRENT available" \
+            "preflight reports Python version as available"
+        assert_not_contains "$LOG9d" ".python-version requires" \
+            "no warning when version is available"
+    fi
+else
+    printf "  %s·%s skipped (python3 not installed): Case D\n" "$C_DIM" "$C_RESET"
+fi
+
+# ===========================================================================
 # Report
 # ===========================================================================
 report "test-setup.sh"


### PR DESCRIPTION
## Summary

Implements the **Engineering Council's scoped-hybrid recommendation** for handling multi-project Python/Node version drift (5 advisors + Codex xhigh chairman, see earlier council session). Targets "I work on 5 projects with different Python/Node versions" pain.

Codex then reviewed the initial implementation and flagged 4 bugs (1 P1 + 3 P2). All addressed in follow-up commit \`812a5c2\`. Suite grows from **119 → 147 assertions, all pass locally.**

## What ships

- **\`docs/guides/multi-project-isolation.md\`** — canonical policy doc explaining uv+pnpm isolation, interpreter version managers (uv, pyenv, fnm, nvm, volta), the warn-only preflight contract, troubleshooting, and explicit out-of-scope items.
- **Warn-only preflight in \`setup.sh\` + \`setup.ps1\`** (before \`Prerequisites OK\`). Reads repo-root \`.python-version\`, \`.nvmrc\`, and root \`package.json\` \`engines.node\`. Warns with install guidance if the declared runtime isn't available. **Never changes exit code.** Silent when no pins exist.
- **Links** from \`docs/getting-started.md\` and \`docs/guides/parallel-sessions.md\` so warnings point to the canonical guide.
- **Test coverage**: Test 9 in \`tests/template/test-setup.sh\` exercises 6 scenarios (impossible Python, impossible Node, no pins → silent, matching version, exact .nvmrc mismatch, malformed package.json under set -e). Contract 5 in \`test-contracts.sh\` asserts shell/PS parity.
- **CHANGELOG 5.8** documenting the feature.

## Codex review → fixes applied (commit \`812a5c2\`)

| Severity | Finding | Fix |
|---|---|---|
| **P1** | \`Get-Content -First\` is not a PowerShell parameter — would break Windows on pinned repos (hard failure, not warn-only) | → \`Get-Content -TotalCount 1\` |
| **P2** | \`jq\` under \`set -e\` aborted setup on malformed \`package.json\` | \`jq ... \\|\\| true\` + restructured control flow to mirror PowerShell try/catch |
| **P2** | \`uv python list\` shows *downloadable* versions, not installed → false positives | → \`uv python find <required>\` (exits 0 only for installed interpreters) |
| **P2** | \`.nvmrc=20.11.0\` falsely satisfied by any v20.x | Distinguish bare-major pins (major match OK) from full-version pins (exact match required). Bounded regex prevents substring misfires. |

Two new regression tests added (Case E for .nvmrc exact; Case F for malformed package.json).

## What's explicitly NOT in scope per Council

- No session-start hook version check (wrong layer — N shell-outs per session, cross-stack support matrix too wide)
- No \`verify-app\` agent preamble (\`uv run\` / \`pnpm\` already fail loudly)
- No subdir detection (monorepo pattern deferred; \`uv\` walk-up in \`post-tool-format.sh\` handles it at runtime)
- No silence flag (remove pin file to disable per-project)

## Test plan

- [x] \`bash tests/template/run-all.sh\` → All suites passed (147/147)
- [x] \`bash -n setup.sh\` parses clean
- [x] Verified bash-parameter-expansion literal substitution handles \`apps/r&d\` correctly
- [ ] Manual smoke on Windows via \`pwsh\` (needs reviewer; no pwsh locally)
- [ ] Manual smoke: \`setup.sh --upgrade\` in mcpgateway to verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)