### PR TITLE
feat(hooks): evidence-based E2E gate — Phase 2 (closes Contrarian P0)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to claude-codex-forge.
 
+## 5.10 — 2026-04-18 · Evidence-based E2E gate (Phase 2 of the enforcement cycle)
+
+Closes the Contrarian's deferred P0 from the 5.9 Council session: the paperwork-only gate let a bad-faith operator type `[x] E2E verified` without actually running the verify-e2e agent. Phase 2 binds the checkbox claim to a real filesystem artifact.
+
+Motivation: user observed downstream sessions attempting `gh pr create` before code reviews, simplify, or E2E were actually done — Claude was checking boxes prematurely and the 5.9 checklist-only gate couldn't catch it.
+
+- **Evidence check in `check-workflow-gates.sh` + `.ps1`**. When `- [x] E2E verified` is present WITHOUT an `N/A:` suffix, the hook now requires a file in `tests/e2e/reports/` whose mtime is later than the branch-off commit (`git merge-base HEAD main`, falling back to `master`). Without a fresh report: exit 2 with a specific "checkbox is typed but no report was produced" error. The N/A escape (`- [x] E2E verified — N/A: <reason>`) still bypasses the check.
+- **Cross-platform mtime**: `stat -c %Y` for GNU, `stat -f %m` for BSD/macOS. PowerShell uses `LastWriteTime` against a UnixTime-derived `DateTimeOffset`. Detected at runtime.
+- **Graceful degradation**: user on `main`, repo with neither `main` nor `master`, or missing git history → evidence check skipped. The checklist check still fires. Documented as degraded env, not policy violation.
+- **`rules/testing.md`**: new "Evidence-based gate" subsection under "Canonical E2E gate vocabulary" explaining the two-phase check + degradation behavior.
+- **`tests/template/test-hooks.sh`**: 8 new assertions (5 scenarios) exercising the evidence check — fresh report → 0, no report → 2 + stderr, stale report only → 2, N/A bypass → 0, degraded env (no main/master) → 0. Each scenario builds a real scratch git repo with a branch-off point to give the hook something to compare against.
+
+Suite: 170 → 178 assertions, all pass.
+
+Explicitly still NOT covered by evidence check:
+
+- **Code review loop**, **Simplified**, **Verified (tests)** — these gates still use the paperwork-only check. They have no natural filesystem artifact convention yet. Adding them would require agents/commands to persist status files, which is a separate design pass.
+- Report quality — only file existence + freshness is verified. A trivial report that claims PASS on no actual UCs still passes. Human reviewer catches this.
+
 ## 5.9 — 2026-04-18 · E2E verified gate — close the silent-skip loophole
 
 Closes the loophole the Engineering Council flagged: before this release, `check-workflow-gates.sh` blocked commit/push/PR on `Code review loop` / `Simplified` / `Verified (tests`, but NOT on `E2E verified`. A downstream project (msai-v2) shipped 155 commits with every E2E checklist item unchecked. Council verdict (5 advisors + Codex chairman): ship narrow enforcement, canonicalize marker vocabulary in the same PR, defer operator-verification redesign.

--- a/hooks/check-workflow-gates.ps1
+++ b/hooks/check-workflow-gates.ps1
@@ -86,4 +86,61 @@ if ($unchecked.Count -gt 0) {
     exit 2
 }
 
+# ---------------------------------------------------------------------------
+# Evidence-based gate for E2E verified. Mirrors the .sh logic:
+# a checked '[x] E2E verified' without 'N/A:' must have a fresh report file
+# in tests/e2e/reports/ whose LastWriteTime is later than the branch-off
+# commit. Skips gracefully if git state prevents determining branch-off.
+# ---------------------------------------------------------------------------
+$e2eCheckedLine = $null
+foreach ($line in ($content -split "`n")) {
+    if ($line -match '- \[x\]\s+E2E verified') {
+        $e2eCheckedLine = $line
+        break
+    }
+}
+
+if ($e2eCheckedLine -and ($e2eCheckedLine -notmatch 'N/A:')) {
+    # Find branch-off commit (try main, fall back to master, else skip)
+    $branchOff = git merge-base HEAD main 2>$null
+    if (-not $branchOff) { $branchOff = git merge-base HEAD master 2>$null }
+
+    if ($branchOff) {
+        $branchOffTsStr = git log -1 --format=%ct $branchOff 2>$null
+        $branchOffTs = 0
+        if ($branchOffTsStr) { $branchOffTs = [long]$branchOffTsStr }
+
+        $branchOffDate = [DateTimeOffset]::FromUnixTimeSeconds($branchOffTs).LocalDateTime
+
+        $freshReportFound = $false
+        if (Test-Path "tests/e2e/reports") {
+            $reports = Get-ChildItem "tests/e2e/reports" -Filter "*.md" -File -ErrorAction SilentlyContinue
+            foreach ($report in $reports) {
+                if ($report.LastWriteTime -gt $branchOffDate) {
+                    $freshReportFound = $true
+                    break
+                }
+            }
+        }
+
+        if (-not $freshReportFound) {
+            [Console]::Error.WriteLine("WORKFLOW GATE: E2E verified is checked, but no fresh report was found.")
+            [Console]::Error.WriteLine("")
+            [Console]::Error.WriteLine("The checklist says [x] E2E verified, but tests\e2e\reports\ has no")
+            [Console]::Error.WriteLine("report file newer than this branch's commit off main. That usually means")
+            [Console]::Error.WriteLine("the verify-e2e agent was never actually run on this branch.")
+            [Console]::Error.WriteLine("")
+            [Console]::Error.WriteLine("Either:")
+            [Console]::Error.WriteLine("  (a) Run the verify-e2e agent and have the main agent persist its")
+            [Console]::Error.WriteLine("      report to tests\e2e\reports\<YYYY-MM-DD-HH-MM>-<feature>.md,")
+            [Console]::Error.WriteLine("  (b) Mark the gate N/A with justification:")
+            [Console]::Error.WriteLine('        - [x] E2E verified — N/A: <specific reason>')
+            [Console]::Error.WriteLine("")
+            [Console]::Error.WriteLine("See .claude\rules\testing.md for the full policy.")
+            exit 2
+        }
+    }
+    # No branch-off (user on main / no main or master) → skip evidence check.
+}
+
 exit 0

--- a/hooks/check-workflow-gates.ps1
+++ b/hooks/check-workflow-gates.ps1
@@ -105,6 +105,15 @@ if ($e2eCheckedLine -and ($e2eCheckedLine -notmatch 'N/A:')) {
     $branchOff = git merge-base HEAD main 2>$null
     if (-not $branchOff) { $branchOff = git merge-base HEAD master 2>$null }
 
+    # If HEAD itself IS the branch-off point (user is on main/master, not a
+    # feature branch), there's no meaningful "produced on this branch"
+    # comparison. Skip the evidence check — matches the documented "on main
+    # → skip" contract in rules/testing.md.
+    $headSha = git rev-parse HEAD 2>$null
+    if ($branchOff -and $headSha -and ($branchOff.Trim() -eq $headSha.Trim())) {
+        $branchOff = $null  # Force the skip path below
+    }
+
     if ($branchOff) {
         $branchOffTsStr = git log -1 --format=%ct $branchOff 2>$null
         $branchOffTs = 0

--- a/hooks/check-workflow-gates.sh
+++ b/hooks/check-workflow-gates.sh
@@ -114,6 +114,15 @@ if [ -n "$E2E_CHECKED_LINE" ] && ! echo "$E2E_CHECKED_LINE" | grep -qE 'N/A:'; t
     # Find the branch-off commit (try main, fall back to master, else skip).
     BRANCH_OFF=$(git merge-base HEAD main 2>/dev/null || git merge-base HEAD master 2>/dev/null || true)
 
+    # If HEAD itself IS the branch-off point (i.e., user is on main/master
+    # directly, not a feature branch), there's no meaningful "produced on
+    # this branch" comparison to make. Skip the evidence check — matches
+    # the documented "on main → skip" contract in rules/testing.md.
+    HEAD_SHA=$(git rev-parse HEAD 2>/dev/null || true)
+    if [ -n "$BRANCH_OFF" ] && [ -n "$HEAD_SHA" ] && [ "$BRANCH_OFF" = "$HEAD_SHA" ]; then
+        BRANCH_OFF=""  # Force the skip path below
+    fi
+
     if [ -n "$BRANCH_OFF" ]; then
         BRANCH_OFF_TS=$(git log -1 --format=%ct "$BRANCH_OFF" 2>/dev/null || echo "")
     else

--- a/hooks/check-workflow-gates.sh
+++ b/hooks/check-workflow-gates.sh
@@ -89,4 +89,80 @@ if [ -n "$UNCHECKED" ]; then
     exit 2
 fi
 
+# ---------------------------------------------------------------------------
+# Evidence-based gate for E2E verified
+#
+# The checklist-only gate above is paperwork enforcement: a bad-faith actor
+# can type '[x] E2E verified ...' without actually running the verify-e2e
+# agent. This check binds the '[x] E2E verified' claim to a real filesystem
+# artifact — a report file in tests/e2e/reports/ with mtime later than the
+# branch-off point.
+#
+# Escape valve: the N/A form ('[x] E2E verified — N/A: <reason>') is trusted
+# and skips the evidence check. Human reviewers catch lazy N/A justifications.
+#
+# Failure modes intentionally accepted:
+#   - User on main (no branch) → can't compute merge-base → skip evidence
+#   - No git / no main or master branch → skip evidence
+#   - Report path writes fail → next commit-attempt catches it
+# ---------------------------------------------------------------------------
+E2E_CHECKED_LINE=$(echo "$CHECKLIST" | grep -E '^\s*- \[x\]\s+E2E verified' | head -1)
+
+if [ -n "$E2E_CHECKED_LINE" ] && ! echo "$E2E_CHECKED_LINE" | grep -qE 'N/A:'; then
+    # [x] E2E verified checked without N/A → require a fresh report file.
+
+    # Find the branch-off commit (try main, fall back to master, else skip).
+    BRANCH_OFF=$(git merge-base HEAD main 2>/dev/null || git merge-base HEAD master 2>/dev/null || true)
+
+    if [ -n "$BRANCH_OFF" ]; then
+        BRANCH_OFF_TS=$(git log -1 --format=%ct "$BRANCH_OFF" 2>/dev/null || echo "")
+    else
+        BRANCH_OFF_TS=""
+    fi
+
+    # Detect platform for stat syntax (GNU vs BSD/macOS)
+    if stat -c %Y /dev/null >/dev/null 2>&1; then
+        STAT_MTIME_CMD='stat -c %Y'
+    else
+        STAT_MTIME_CMD='stat -f %m'
+    fi
+
+    # Look for at least one fresh report. A "fresh" report has mtime greater
+    # than the branch-off commit's timestamp — meaning it was produced on
+    # THIS branch, not inherited from a previous feature.
+    FRESH_REPORT_FOUND=0
+    if [ -n "$BRANCH_OFF_TS" ] && [ -d "tests/e2e/reports" ]; then
+        for report in tests/e2e/reports/*.md; do
+            [ -f "$report" ] || continue
+            REPORT_MTIME=$($STAT_MTIME_CMD "$report" 2>/dev/null || echo "0")
+            if [ "$REPORT_MTIME" -gt "$BRANCH_OFF_TS" ] 2>/dev/null; then
+                FRESH_REPORT_FOUND=1
+                break
+            fi
+        done
+    elif [ -z "$BRANCH_OFF_TS" ]; then
+        # No merge-base (user on main, or no main/master branch).
+        # Skip evidence check rather than fail closed — this is a degraded
+        # environment, not a policy violation.
+        FRESH_REPORT_FOUND=1
+    fi
+
+    if [ "$FRESH_REPORT_FOUND" -eq 0 ]; then
+        echo "WORKFLOW GATE: E2E verified is checked, but no fresh report was found." >&2
+        echo "" >&2
+        echo "The checklist says [x] E2E verified, but tests/e2e/reports/ has no" >&2
+        echo "report file newer than this branch's commit off main. That usually means" >&2
+        echo "the verify-e2e agent was never actually run on this branch." >&2
+        echo "" >&2
+        echo "Either:" >&2
+        echo "  (a) Run the verify-e2e agent and have the main agent persist its" >&2
+        echo "      report to tests/e2e/reports/<YYYY-MM-DD-HH-MM>-<feature>.md," >&2
+        echo "  (b) Mark the gate N/A with justification:" >&2
+        echo '        - [x] E2E verified — N/A: <specific reason>' >&2
+        echo "" >&2
+        echo "See .claude/rules/testing.md for the full policy." >&2
+        exit 2
+    fi
+fi
+
 exit 0

--- a/rules/testing.md
+++ b/rules/testing.md
@@ -139,6 +139,25 @@ There is **one** gated marker name. The Stop hook (`check-workflow-gates.sh`/`.p
 
 Changing any of these strings in one place requires updating the hook + tests in the same PR. The `test-contracts.sh` cross-file contract asserts this.
 
+### Evidence-based gate
+
+The `check-workflow-gates.sh`/`.ps1` hook does TWO checks on the `E2E verified` marker:
+
+1. **Checklist check** — `- [ ] E2E verified ...` in an active workflow blocks the commit/push/PR.
+2. **Evidence check** — `- [x] E2E verified ...` **without** `N/A:` requires a real report file in `tests/e2e/reports/` whose mtime is later than the branch-off commit. If no such file exists, the hook blocks with a specific "checkbox is typed but no report was actually produced" error.
+
+Why: a bad-faith actor can type `[x]` without running the verify-e2e agent. The evidence check binds the checkbox claim to a filesystem artifact — the agent's report, persisted via Phase 5.4 Step 3 (`mkdir -p tests/e2e/reports && Write`).
+
+The N/A escape (`- [x] E2E verified — N/A: <reason>`) skips the evidence check. Human reviewers catch lazy N/A justifications at PR review time.
+
+Intentionally NOT covered by evidence check (gracefully skipped):
+
+- User is on `main` (no feature branch) → no merge-base → skip
+- Repo has neither `main` nor `master` → skip
+- Repo has no git history that reaches a branch point → skip
+
+These are degraded environments, not policy violations. The checklist check still fires.
+
 ## E2E Interface Capability Matrix
 
 The E2E scope depends on the project's user interfaces (declared in `CLAUDE.md` under `## E2E Configuration`):

--- a/tests/template/test-hooks.sh
+++ b/tests/template/test-hooks.sh
@@ -245,6 +245,111 @@ else
 fi
 
 # ===========================================================================
+# Evidence-gate scenarios (Phase 2 — closes the paperwork-not-evidence loophole)
+# These require a real git repo with a branch-off point, so each test sets up
+# a scratch repo with main + feature branch before invoking the hook.
+# ===========================================================================
+
+# Helper: build a scratch git repo with main + feature branch.
+# Feature branch's HEAD is where we're "at"; main's last commit is the
+# branch-off point whose timestamp the hook compares against.
+# Echoes the scratch dir path.
+setup_git_scratch() {
+    local dir
+    dir=$(scratch_dir e2e-evidence)
+    (
+        cd "$dir" || exit 1
+        git init -q --initial-branch=main
+        git -c user.email=test@test -c user.name=test commit -q --allow-empty -m "initial"
+        # Wait a second so branch-off timestamp is strictly less than
+        # any files we create post-checkout (avoids flaky == comparisons
+        # on fast CPUs).
+        sleep 1
+        git checkout -q -b feature/test
+    )
+    echo "$dir"
+}
+
+# Helper: inject an E2E verified [x] entry into the checklist template.
+CHECKLIST_E2E_CHECKED_NO_NA='- [x] Code review loop (1 iterations) — PASS
+- [x] Simplified
+- [x] Verified (tests/lint/types)
+- [x] E2E verified via verify-e2e agent (Phase 5.4)'
+
+CHECKLIST_E2E_CHECKED_NA='- [x] Code review loop (1 iterations) — PASS
+- [x] Simplified
+- [x] Verified (tests/lint/types)
+- [x] E2E verified — N/A: internal migration, no user-facing changes'
+
+# ===========================================================================
+# Test 9: [x] E2E verified without N/A + fresh report → exit 0
+# ===========================================================================
+start_test "[x] E2E verified + fresh report → exit 0 (evidence satisfied)"
+
+S9=$(setup_git_scratch)
+mkdir -p "$S9/tests/e2e/reports"
+# Create a report file AFTER branch-off (its mtime is > branch-off-ts)
+echo "# E2E report" > "$S9/tests/e2e/reports/2026-04-19-10-00-feature.md"
+rc=$(run_hook_sh "$S9" 'git commit -m x' "$CHECKLIST_E2E_CHECKED_NO_NA")
+assert_equals "$rc" "0" "fresh report present → hook passes"
+
+# ===========================================================================
+# Test 10: [x] E2E verified without N/A + no report → exit 2
+# ===========================================================================
+start_test "[x] E2E verified + no report → exit 2 (evidence missing)"
+
+S10=$(setup_git_scratch)
+# No tests/e2e/reports/ directory at all
+rc=$(run_hook_sh "$S10" 'git commit -m x' "$CHECKLIST_E2E_CHECKED_NO_NA")
+assert_equals "$rc" "2" "no reports dir → hook blocks"
+assert_contains "$S10/.hook-stderr" "no fresh report was found" \
+    "stderr explains the evidence gap"
+assert_contains "$S10/.hook-stderr" "verify-e2e agent was never actually run" \
+    "stderr explains the likely cause"
+assert_contains "$S10/.hook-stderr" "E2E verified — N/A:" \
+    "stderr shows the N/A escape syntax"
+
+# ===========================================================================
+# Test 11: [x] E2E verified without N/A + STALE report (pre-branch-off) → exit 2
+# ===========================================================================
+start_test "[x] E2E verified + only stale reports → exit 2"
+
+S11=$(setup_git_scratch)
+mkdir -p "$S11/tests/e2e/reports"
+echo "# old report" > "$S11/tests/e2e/reports/2024-01-01-old.md"
+# Force mtime to 2024-01-01 — definitely before any branch-off we just made
+touch -t 202401010000.00 "$S11/tests/e2e/reports/2024-01-01-old.md"
+rc=$(run_hook_sh "$S11" 'git commit -m x' "$CHECKLIST_E2E_CHECKED_NO_NA")
+assert_equals "$rc" "2" "only stale reports → hook blocks"
+
+# ===========================================================================
+# Test 12: [x] E2E verified — N/A: reason → exit 0 (no evidence needed)
+# ===========================================================================
+start_test "[x] E2E verified — N/A: reason → exit 0 (N/A bypasses evidence check)"
+
+S12=$(setup_git_scratch)
+# No reports directory — N/A should bypass the evidence check entirely
+rc=$(run_hook_sh "$S12" 'git commit -m x' "$CHECKLIST_E2E_CHECKED_NA")
+assert_equals "$rc" "0" "N/A form skips evidence check even without a report"
+
+# ===========================================================================
+# Test 13: No merge-base (repo without main) → skip evidence check gracefully
+# ===========================================================================
+start_test "no merge-base available → skip evidence check (degraded env)"
+
+S13=$(scratch_dir e2e-nomaster)
+(
+    cd "$S13" || exit 1
+    git init -q --initial-branch=weird
+    git -c user.email=test@test -c user.name=test commit -q --allow-empty -m "initial"
+)
+# No main, no master. Hook can't compute merge-base; should skip evidence
+# rather than fail. User gets no protection here — documented as a
+# degraded env, not a policy violation.
+rc=$(run_hook_sh "$S13" 'git commit -m x' "$CHECKLIST_E2E_CHECKED_NO_NA")
+assert_equals "$rc" "0" "degraded env (no main/master) → hook passes with warning"
+
+# ===========================================================================
 # Report
 # ===========================================================================
 report "test-hooks.sh"

--- a/tests/template/test-hooks.sh
+++ b/tests/template/test-hooks.sh
@@ -260,12 +260,17 @@ setup_git_scratch() {
     (
         cd "$dir" || exit 1
         git init -q --initial-branch=main
-        git -c user.email=test@test -c user.name=test commit -q --allow-empty -m "initial"
+        git -c user.email=test@test -c user.name=test commit -q --allow-empty -m "initial-on-main"
         # Wait a second so branch-off timestamp is strictly less than
         # any files we create post-checkout (avoids flaky == comparisons
         # on fast CPUs).
         sleep 1
         git checkout -q -b feature/test
+        # Real feature branches have at least one commit beyond the
+        # branch-off point. Without this, HEAD == merge-base and the
+        # evidence check would (correctly) skip as "on main directly"
+        # — making the feature-branch tests no-ops.
+        git -c user.email=test@test -c user.name=test commit -q --allow-empty -m "feature work"
     )
     echo "$dir"
 }
@@ -348,6 +353,27 @@ S13=$(scratch_dir e2e-nomaster)
 # degraded env, not a policy violation.
 rc=$(run_hook_sh "$S13" 'git commit -m x' "$CHECKLIST_E2E_CHECKED_NO_NA")
 assert_equals "$rc" "0" "degraded env (no main/master) → hook passes with warning"
+
+# ===========================================================================
+# Test 14: On main itself → skip evidence check (trunk-based workflow)
+# Regression guard for Codex's P1: git merge-base HEAD main returns HEAD
+# when on main, which is NOT empty. Without special-case handling, the
+# hook would require reports newer than HEAD — which is usually impossible
+# because reports are produced AFTER HEAD, not before.
+# ===========================================================================
+start_test "user on main → skip evidence check (trunk-based)"
+
+S14=$(scratch_dir e2e-on-main)
+(
+    cd "$S14" || exit 1
+    git init -q --initial-branch=main
+    git -c user.email=test@test -c user.name=test commit -q --allow-empty -m "initial"
+    # STAY on main — no feature branch checkout.
+)
+# [x] E2E verified without N/A + no reports. Without the HEAD==branch-off
+# fix, this would block. With the fix, it should pass (skip evidence).
+rc=$(run_hook_sh "$S14" 'git commit -m x' "$CHECKLIST_E2E_CHECKED_NO_NA")
+assert_equals "$rc" "0" "on main directly → evidence check skipped (trunk-based workflow supported)"
 
 # ===========================================================================
 # Report


### PR DESCRIPTION
## Summary

**Phase 2 of the E2E enforcement cycle.** Closes the Contrarian's deferred P0 from the 5.9 Council session: the paperwork-only gate (PR #494) let a bad-faith actor type \`[x] E2E verified\` without actually running the verify-e2e agent.

**Motivation:** user observed downstream sessions attempting \`gh pr create\` before code reviews, simplify, or E2E were actually done. Claude was checking boxes prematurely and the 5.9 checklist-only gate couldn't catch it.

**Codex-reviewed:** one P1 found (trunk-based workflow on \`main\` would have been bricked) and fixed in commit \`529cf64\` before this PR opened.

## Behavior

When \`- [x] E2E verified\` is present WITHOUT \`N/A:\`, hook now requires a file in \`tests/e2e/reports/\` with mtime > branch-off commit. Without a fresh report → exit 2 with specific "checkbox typed but no report" error.

Escape valve: \`- [x] E2E verified — N/A: <reason>\` still bypasses. Lazy justifications are a human-reviewer problem, not a hook one.

## Graceful degradation (all documented in \`rules/testing.md\`)

- User on \`main\` (HEAD IS the merge-base) → skip evidence check (trunk-based workflow support)
- Repo with neither \`main\` nor \`master\` → skip
- \`git merge-base\` fails for any reason → skip

In all of these, the checklist check still fires — this is about BINDING the checkbox to an artifact when the workflow makes sense, not about creating a new hard dependency.

## Implementation

- Cross-platform mtime: \`stat -c %Y\` (GNU) / \`stat -f %m\` (BSD/macOS) detected at runtime
- PowerShell uses \`LastWriteTime\` against UnixTime-derived \`DateTimeOffset\`
- HEAD == merge-base check correctly identifies trunk-based users

## Test coverage

\`tests/template/test-hooks.sh\` — 8 new assertions across 6 new scenarios:

- Case 9: \`[x]\` + fresh report → exit 0
- Case 10: \`[x]\` + no reports → exit 2 + specific stderr
- Case 11: \`[x]\` + only stale reports (pre-branch-off) → exit 2
- Case 12: \`[x] — N/A: reason\` → exit 0 (bypass)
- Case 13: no \`main\`/\`master\` branch → skip evidence
- Case 14: **on \`main\` directly → skip evidence** (Codex P1 regression guard)

Each scenario builds a real scratch git repo with a branch-off point so the hook has something to compare against.

**Suite: 170 → 179 assertions, all pass.**

## Codex review

Ran \`codex exec review --base main\` with xhigh reasoning. Verdict:

> "The new evidence gate is mostly coherent. I did not find a separate P1/P2 in the \`stat\` probe, the PowerShell empty-merge-base handling, or the added test timing. However, the merge-base logic does not honor the documented 'on main, skip' behavior, so the patch can incorrectly block trunk-based users."

One P1 found, fixed in commit \`529cf64\`, regression test added.

## Still NOT covered (documented in \`rules/testing.md\`)

- **Code review loop**, **Simplified**, **Verified (tests)** — no natural filesystem artifact convention yet. Would need agents/commands to persist status files. Separate design pass.
- Report quality — only file existence + freshness verified. Trivial report still passes. Human reviewer catches that at PR review.

## Test plan

- [x] \`bash tests/template/run-all.sh\` → 179/179 pass
- [x] \`bash -n\` clean on both hook files
- [x] Codex review clean (1 P1 addressed)
- [ ] Dogfood: copy new hooks to msai-v2, try commit with \`[x] E2E verified\` typed but empty reports dir → should block

🤖 Generated with [Claude Code](https://claude.com/claude-code)