### PR TITLE
fix(hooks): PreCompact templates must exit 0, not exit 2

### DIFF
--- a/settings/global-settings.template.json
+++ b/settings/global-settings.template.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo 'COMPACTION IMMINENT. Save any valuable learnings from this session to auto memory (MEMORY.md or topic files): patterns, bug root causes, architecture insights, user preferences. NOT session-specific state.' >&2; exit 2",
+            "command": "echo 'COMPACTION IMMINENT. Save any valuable learnings from this session to auto memory (MEMORY.md or topic files): patterns, bug root causes, architecture insights, user preferences. NOT session-specific state.' >&2; exit 0",
             "timeout": 10
           }
         ]

--- a/settings/settings-windows.template.json
+++ b/settings/settings-windows.template.json
@@ -78,7 +78,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "powershell -Command \"Write-Error 'COMPACTION IMMINENT. Save learnings to auto memory: bug root causes, patterns, architecture insights, user preferences. NOT session state (that goes in CONTINUITY.md).'; exit 2\"",
+            "command": "powershell -Command \"Write-Error 'COMPACTION IMMINENT. Save learnings to auto memory: bug root causes, patterns, architecture insights, user preferences. NOT session state (that goes in CONTINUITY.md).'; exit 0\"",
             "timeout": 10
           },
           {

--- a/settings/settings.template.json
+++ b/settings/settings.template.json
@@ -75,7 +75,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo 'COMPACTION IMMINENT. Save learnings to auto memory: bug root causes, patterns, architecture insights, user preferences. NOT session state (that goes in CONTINUITY.md).' >&2; exit 2",
+            "command": "echo 'COMPACTION IMMINENT. Save learnings to auto memory: bug root causes, patterns, architecture insights, user preferences. NOT session state (that goes in CONTINUITY.md).' >&2; exit 0",
             "timeout": 10
           },
           {


### PR DESCRIPTION
## Summary
- All three settings templates (`settings.template.json`, `global-settings.template.json`, `settings-windows.template.json`) used `exit 2` in inline PreCompact hooks.
- Claude Code treats `exit 2` as BLOCK on PreCompact, so `/compact` was refused in every repo installed from the harness.
- Flipped to `exit 0` so the stderr echo still reaches Claude as a reminder without blocking the action.
- Matches the project's own `CLAUDE.md` spec: _"PreCompact hooks: Use exit 0 (non-blocking) — just reminders"_.

## Why this slipped through
The templates self-contradicted the documented contract, and the test suite doesn't exercise PreCompact exit codes (hook tests focus on workflow gates). Field-discovered when `/compact` failed in a harness-installed repo.

## Test plan
- [x] `bash tests/template/run-all.sh` — 179/179 assertions pass
- [x] All three modified JSON files parse cleanly (test-lint suite)
- [ ] After merge: existing harness installations need `./setup.sh -f` to refresh `.claude/settings.json` with the corrected template

🤖 Generated with [Claude Code](https://claude.com/claude-code)