### PR TITLE
feat(workflow): Phase 4 task-DAG dispatch with file-conflict constraints

### DIFF
--- a/commands/fix-bug.md
+++ b/commands/fix-bug.md
@@ -7,10 +7,10 @@
 
 This workflow requires the following plugins to be **installed AND enabled**:
 
-| Plugin                                      | Skills/Commands Used                                                                                                            |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `superpowers@superpowers-marketplace`       | `/superpowers:systematic-debugging`, `/superpowers:brainstorming`, `/superpowers:writing-plans`, `/superpowers:executing-plans` |
-| `pr-review-toolkit@claude-plugins-official` | `code-simplifier` agent, `code-reviewer` agent, `/pr-review-toolkit:review-pr`                                                  |
+| Plugin                                      | Skills/Commands Used                                                                                                                                                                                           |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `superpowers@superpowers-marketplace`       | `/superpowers:systematic-debugging`, `/superpowers:brainstorming`, `/superpowers:writing-plans`, `/superpowers:subagent-driven-development` (default executor), `/superpowers:executing-plans` (headless mode) |
+| `pr-review-toolkit@claude-plugins-official` | `code-simplifier` agent, `code-reviewer` agent, `/pr-review-toolkit:review-pr`                                                                                                                                 |
 
 **To enable plugins**, add to `~/.claude/settings.json`:
 
@@ -392,22 +392,28 @@ Write a failing test first, then fix. Single-threaded — no dispatch plan neede
 
 ### Complex fixes (3+ files, Phase 3 complete)
 
-> **Optional before starting:** Run `/compact` if the session is heavy with debugging + plan-review discussion. Consolidates prior phases into a summary and frees budget for execution.
+> **Optional before starting:** Run `/compact` if the session is heavy with debugging + plan-review discussion.
 
 #### 4.0 Dispatch Plan (MANDATORY before dispatching any subagent)
 
-Produce a **task DAG** and append to the plan file under a `## Dispatch Plan` heading. Task-level `Depends on` + `Writes (files)` columns, continuous dispatch with file-conflict constraints, default 3 concurrent subagents (max 5), sequential override for tightly-coupled fixes.
+Append a `## Dispatch Plan` heading to the plan file with one row per task. Format, scheduling rules, and failure semantics are identical to `/new-feature` — see `new-feature.md` in this same `.claude/commands/` directory, Phase 4.0, for the full spec. Key points restated:
 
-Rules, format, and rationale are identical to `/new-feature` Phase 4.0 — see `commands/new-feature.md` §4.0 for the full rule set. Key points restated:
-
-- Ready set = tasks with all deps complete; dispatch rule = `Writes` disjoint from running tasks
-- Two tasks writing the same physical file cannot run concurrently
-- Shared types/imports go in `Depends on`, not in file-overlap
-- Sequential override is legitimate for tightly-coupled fixes
+- `Writes` lists **concrete file paths**, not directories or globs
+- Default concurrency cap: 3 concurrent subagents (max 5 for small, genuinely independent tasks)
+- Serial is the default; parallel requires proven independence (all `Depends on` resolved AND disjoint `Writes`)
+- **No append-only fast-path** — tasks modifying the same existing file always serialize via `Depends on`
+- Shared types/imports → encode as explicit `Depends on`
+- Sequential override for tightly-coupled fixes is legitimate (Cognition's counter-position)
 
 #### 4.1 Execute via subagent-driven-development
 
-Use `superpowers:subagent-driven-development`. Dispatch cycle: pick next eligible task → dispatch fresh subagent with TDD discipline → review diff on return → re-evaluate ready set → dispatch next.
+Use `superpowers:subagent-driven-development`. Per cycle: pick next eligible task → dispatch fresh subagent with TDD discipline → review diff on return → re-evaluate ready set → dispatch next.
+
+**Handling failures:**
+
+- Subagent failure OR diff-review reject → mark the task failed, cancel any in-flight dependents, surface to the user
+- Rate limit or timeout → retry once with a fresh subagent; second failure is a real failure
+- After each task completes, verify in-flight dependents' assumptions still hold; cancel and re-dispatch if a breaking change landed upstream
 
 **If you encounter bugs during implementation:**
 
@@ -415,9 +421,9 @@ Use `superpowers:subagent-driven-development`. Dispatch cycle: pick next eligibl
 /superpowers:systematic-debugging
 ```
 
-#### 4.2 Headless / Walk-Away Mode (OPT-IN ESCAPE)
+#### 4.2 Headless / Walk-Away Mode (OPT-IN)
 
-Say **"walk-away mode"** or **"headless"** to switch to `/superpowers:executing-plans` in a separate session. Headless loses live parallelism but gains context independence. Default is in-session subagent-driven.
+Say **"walk-away mode"** or **"headless"** to switch to `/superpowers:executing-plans` in a separate session. Default is in-session subagent-driven.
 
 ---
 

--- a/commands/fix-bug.md
+++ b/commands/fix-bug.md
@@ -386,13 +386,38 @@ Gather severity-tagged findings from all available reviewers. Use this rubric:
 
 > **Checkpoint:** Update `## Workflow` in CONTINUITY.md — Phase: `4 — Execute`, check off planning items.
 
-Implement using TDD (Red-Green-Refactor):
+### Simple fixes (1-2 files, Phase 3 skipped)
+
+Write a failing test first, then fix. Single-threaded — no dispatch plan needed.
+
+### Complex fixes (3+ files, Phase 3 complete)
+
+> **Optional before starting:** Run `/compact` if the session is heavy with debugging + plan-review discussion. Consolidates prior phases into a summary and frees budget for execution.
+
+#### 4.0 Dispatch Plan (MANDATORY before dispatching any subagent)
+
+Produce a **task DAG** and append to the plan file under a `## Dispatch Plan` heading. Task-level `Depends on` + `Writes (files)` columns, continuous dispatch with file-conflict constraints, default 3 concurrent subagents (max 5), sequential override for tightly-coupled fixes.
+
+Rules, format, and rationale are identical to `/new-feature` Phase 4.0 — see `commands/new-feature.md` §4.0 for the full rule set. Key points restated:
+
+- Ready set = tasks with all deps complete; dispatch rule = `Writes` disjoint from running tasks
+- Two tasks writing the same physical file cannot run concurrently
+- Shared types/imports go in `Depends on`, not in file-overlap
+- Sequential override is legitimate for tightly-coupled fixes
+
+#### 4.1 Execute via subagent-driven-development
+
+Use `superpowers:subagent-driven-development`. Dispatch cycle: pick next eligible task → dispatch fresh subagent with TDD discipline → review diff on return → re-evaluate ready set → dispatch next.
+
+**If you encounter bugs during implementation:**
 
 ```
-/superpowers:executing-plans
+/superpowers:systematic-debugging
 ```
 
-Or for simple fixes, write a failing test first, then fix.
+#### 4.2 Headless / Walk-Away Mode (OPT-IN ESCAPE)
+
+Say **"walk-away mode"** or **"headless"** to switch to `/superpowers:executing-plans` in a separate session. Headless loses live parallelism but gains context independence. Default is in-session subagent-driven.
 
 ---
 

--- a/commands/new-feature.md
+++ b/commands/new-feature.md
@@ -427,18 +427,52 @@ Gather severity-tagged findings from all available reviewers. Use this rubric:
 ## Phase 4: Execute
 
 > **Checkpoint:** Update `## Workflow` in CONTINUITY.md — Phase: `4 — Execute`, check off design items (brainstorming, plan, review).
+>
+> **Optional before starting:** Run `/compact` if the session is heavy with brainstorm + plan-review discussion. Consolidates prior phases into a structured summary and frees budget for execution. Reminder, not a gate — skip if context is still lean.
 
-Implement using TDD (Red-Green-Refactor):
+### 4.0 Dispatch Plan (MANDATORY before dispatching any subagent)
 
-```
-/superpowers:executing-plans
-```
+Produce a **task DAG** (not a static wave schedule) and append it to the plan file under a `## Dispatch Plan` heading so it travels with the plan. For each task in the implementation plan:
+
+| Task ID | Depends on | Writes (files)         |
+| ------- | ---------- | ---------------------- |
+| B1      | —          | `alembic/versions/...` |
+| B2      | B1         | `schemas/backtest.py`  |
+| B3      | —          | `analytics_math/...`   |
+
+**Scheduling — continuous dispatch with file-conflict constraints:**
+
+- **Ready set:** tasks whose `Depends on` entries are all completed
+- **Dispatch rule:** pick any ready task whose `Writes` set is disjoint from every currently-running task's `Writes`
+- **Concurrency cap:** **default 3 concurrent subagents** (Anthropic-tested ceiling before coordination cost dominates); raise to **5 max** only for genuinely independent small tasks
+- **Continuous, not wave-barrier:** when a subagent returns, re-evaluate the ready set and dispatch immediately — do NOT wait for a whole batch to finish before dispatching again
+
+**File-conflict rules:**
+
+- Two tasks writing the same physical file cannot run concurrently, even on different logical sections
+- Append-only additions (new test files, new exports, new-timestamp migrations) MAY run concurrently — brief the subagents on the append-only contract explicitly in their prompts
+- Shared types/imports/schemas: if task B needs a type defined by task A, encode as an explicit `Depends on`. Do NOT rely on file-disjointness alone — semantic coupling is the real constraint
+
+**Sequential override:** if the plan is tightly coupled (most tasks share files or types, or the feature reads as one logical change), note `"sequential mode"` in the dispatch plan and dispatch one subagent at a time. This is Cognition's documented counter-position on multi-agent orchestration and a legitimate choice for high-coupling work — parallelism is not always a win.
+
+### 4.1 Execute via subagent-driven-development
+
+Use `superpowers:subagent-driven-development`. Per dispatch cycle:
+
+1. Pick next eligible task per 4.0 rules
+2. Dispatch fresh subagent with TDD discipline (Red-Green-Refactor)
+3. Review diff on return before marking the task done
+4. Re-evaluate ready set, dispatch next
 
 **If you encounter bugs during implementation:**
 
 ```
 /superpowers:systematic-debugging
 ```
+
+### 4.2 Headless / Walk-Away Mode (OPT-IN ESCAPE)
+
+If you'd rather execute the plan in a separate terminal without your supervision — useful for long plans (15+ tasks), walking away, or producing a fresh-context execution pass — say **"walk-away mode"** or **"headless"** and the workflow switches to `/superpowers:executing-plans` in that session. Headless loses the live parallelism of 4.1 but gains context independence. Default path is in-session subagent-driven; escape to headless only when the scenario fits.
 
 ---
 

--- a/commands/new-feature.md
+++ b/commands/new-feature.md
@@ -7,10 +7,10 @@
 
 This workflow requires the following plugins to be **installed AND enabled**:
 
-| Plugin                                      | Skills/Commands Used                                                                                                            |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `superpowers@superpowers-marketplace`       | `/superpowers:brainstorming`, `/superpowers:writing-plans`, `/superpowers:executing-plans`, `/superpowers:systematic-debugging` |
-| `pr-review-toolkit@claude-plugins-official` | `code-simplifier` agent, `code-reviewer` agent, `/pr-review-toolkit:review-pr`                                                  |
+| Plugin                                      | Skills/Commands Used                                                                                                                                                                                           |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `superpowers@superpowers-marketplace`       | `/superpowers:brainstorming`, `/superpowers:writing-plans`, `/superpowers:subagent-driven-development` (default executor), `/superpowers:executing-plans` (headless mode), `/superpowers:systematic-debugging` |
+| `pr-review-toolkit@claude-plugins-official` | `code-simplifier` agent, `code-reviewer` agent, `/pr-review-toolkit:review-pr`                                                                                                                                 |
 
 **To enable plugins**, add to `~/.claude/settings.json`:
 
@@ -428,34 +428,39 @@ Gather severity-tagged findings from all available reviewers. Use this rubric:
 
 > **Checkpoint:** Update `## Workflow` in CONTINUITY.md — Phase: `4 — Execute`, check off design items (brainstorming, plan, review).
 >
-> **Optional before starting:** Run `/compact` if the session is heavy with brainstorm + plan-review discussion. Consolidates prior phases into a structured summary and frees budget for execution. Reminder, not a gate — skip if context is still lean.
+> **Optional before starting:** Run `/compact` if the session is heavy with brainstorm + plan-review discussion. Consolidates prior phases into a structured summary and frees budget for execution. Reminder, not a gate.
 
-### 4.0 Dispatch Plan (MANDATORY before dispatching any subagent)
+### Trivial plans (≤3 tasks)
 
-Produce a **task DAG** (not a static wave schedule) and append it to the plan file under a `## Dispatch Plan` heading so it travels with the plan. For each task in the implementation plan:
+No dispatch plan needed. Use `superpowers:subagent-driven-development` and execute the plan's tasks sequentially in order. Proceed to Phase 5 when done.
 
-| Task ID | Depends on | Writes (files)         |
-| ------- | ---------- | ---------------------- |
-| B1      | —          | `alembic/versions/...` |
-| B2      | B1         | `schemas/backtest.py`  |
-| B3      | —          | `analytics_math/...`   |
+### Full plans (4+ tasks)
 
-**Scheduling — continuous dispatch with file-conflict constraints:**
+#### 4.0 Dispatch Plan (MANDATORY before dispatching any subagent)
+
+Append a `## Dispatch Plan` heading to the plan file with one row per task:
+
+| Task ID | Depends on | Writes (concrete file paths)                           |
+| ------- | ---------- | ------------------------------------------------------ |
+| B1      | —          | `alembic/versions/2026_04_22_add_series.py`            |
+| B2      | B1         | `schemas/backtest.py`                                  |
+| B3      | —          | `analytics_math/deduplicate.py`, `tests/test_dedup.py` |
+
+**`Writes` must list concrete file paths** — not directories, not globs. New files use their final intended path. Conflict detection is per physical file.
+
+**Scheduling — serial is the default; parallel requires proven independence:**
 
 - **Ready set:** tasks whose `Depends on` entries are all completed
-- **Dispatch rule:** pick any ready task whose `Writes` set is disjoint from every currently-running task's `Writes`
-- **Concurrency cap:** **default 3 concurrent subagents** (Anthropic-tested ceiling before coordination cost dominates); raise to **5 max** only for genuinely independent small tasks
-- **Continuous, not wave-barrier:** when a subagent returns, re-evaluate the ready set and dispatch immediately — do NOT wait for a whole batch to finish before dispatching again
+- **Dispatch rule:** start any ready task whose `Writes` paths are disjoint from every currently-running task's `Writes`
+- **Concurrency cap:** default 3 concurrent subagents; raise to 5 only for small, genuinely independent tasks. (3 is practitioner guidance from Anthropic's [multi-agent research post](https://www.anthropic.com/engineering/multi-agent-research-system), not a hard protocol limit.)
+- **Continuous dispatch:** when a subagent returns, re-evaluate the ready set and dispatch immediately. Do not batch into waves.
+- **In doubt, serialize.** File-disjointness is necessary but not sufficient — if two tasks share types, schemas, or imports, encode as `Depends on` and serialize.
 
-**File-conflict rules:**
-
-- Two tasks writing the same physical file cannot run concurrently, even on different logical sections
-- Append-only additions (new test files, new exports, new-timestamp migrations) MAY run concurrently — brief the subagents on the append-only contract explicitly in their prompts
-- Shared types/imports/schemas: if task B needs a type defined by task A, encode as an explicit `Depends on`. Do NOT rely on file-disjointness alone — semantic coupling is the real constraint
+**No append-only fast-path.** Tasks that both modify the same existing file — barrel exports (`index.ts`, `__init__.py`), migration manifests, shared schemas, `pyproject.toml`, etc. — **must be serialized via `Depends on`**. Same-second timestamp migrations collide on filename and on `alembic_version` head; do not parallelize migration generation. The only case where two tasks may concurrently "add" to a shared space is when each creates a **distinct new file at a different path**, in which case the `Writes` column already lists disjoint paths and the standard dispatch rule applies.
 
 **Sequential override:** if the plan is tightly coupled (most tasks share files or types, or the feature reads as one logical change), note `"sequential mode"` in the dispatch plan and dispatch one subagent at a time. This is Cognition's documented counter-position on multi-agent orchestration and a legitimate choice for high-coupling work — parallelism is not always a win.
 
-### 4.1 Execute via subagent-driven-development
+#### 4.1 Execute via subagent-driven-development
 
 Use `superpowers:subagent-driven-development`. Per dispatch cycle:
 
@@ -464,15 +469,21 @@ Use `superpowers:subagent-driven-development`. Per dispatch cycle:
 3. Review diff on return before marking the task done
 4. Re-evaluate ready set, dispatch next
 
+**Handling failures:**
+
+- Subagent returns failure, OR diff-review rejects the result → mark the task failed in the dispatch plan, cancel any in-flight dependents, surface to the user before continuing
+- Rate limit or timeout → retry once with a fresh subagent; if it fails again, treat as a failure
+- After each task completes, verify in-flight dependents' assumptions still hold. If a completed task introduced a breaking change to shared code, cancel the dependent and re-dispatch with updated context
+
 **If you encounter bugs during implementation:**
 
 ```
 /superpowers:systematic-debugging
 ```
 
-### 4.2 Headless / Walk-Away Mode (OPT-IN ESCAPE)
+#### 4.2 Headless / Walk-Away Mode (OPT-IN)
 
-If you'd rather execute the plan in a separate terminal without your supervision — useful for long plans (15+ tasks), walking away, or producing a fresh-context execution pass — say **"walk-away mode"** or **"headless"** and the workflow switches to `/superpowers:executing-plans` in that session. Headless loses the live parallelism of 4.1 but gains context independence. Default path is in-session subagent-driven; escape to headless only when the scenario fits.
+Say **"walk-away mode"** or **"headless"** to switch to `/superpowers:executing-plans` in a separate session. Headless loses the live parallelism of 4.1 but gains context independence — useful for long plans (15+ tasks) or when you want to step away. Default is in-session subagent-driven.
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to claude-codex-forge.
 
+## 5.13 — 2026-04-21 · Phase 4 task-DAG dispatch with file-conflict constraints
+
+Replaces the previous Phase 4 one-liner (`/superpowers:executing-plans`) with a structured dispatch plan. Field evidence: user's msai-v2 run (19-task backtest feature) had the orchestrator hand-rolling a 16-wave table from scratch because the template gave no parallelism guidance. Research agent + Codex second-opinion both identified **DAG with continuous dispatch** as the correct primitive over static file-overlap waves; Anthropic's multi-agent research post cited for the `default 3 / max 5` concurrency ceiling.
+
+Council-reviewed (5 advisors, 2 `OBJECT`) and revised before merge. The initial draft shipped five spec-level bugs; all five fixed in the same branch.
+
+- **`commands/new-feature.md` Phase 4** — new structure: optional `/compact` banner, `Trivial plans (≤3 tasks)` carve-out (Pragmatist), mandatory `§4.0 Dispatch Plan` for 4+ tasks (task DAG appended to plan file under `## Dispatch Plan` heading), `§4.1 Execute via subagent-driven-development` with `Handling failures` bullets (Scalability Hawk), `§4.2 Headless / Walk-Away Mode` as opt-in phrase (not a menu item).
+- **`commands/fix-bug.md` Phase 4** — mirrored structure; simple fixes (1-2 files) keep single-threaded path; complex fixes (3+) reference `new-feature.md` in the same `.claude/commands/` directory (Maintainer: the initial draft said `commands/new-feature.md` literal, which fails post-install because `setup.sh` copies to `.claude/commands/`).
+- **Append-only exception deleted** — the initial draft allowed "new test files, new exports, new-timestamp migrations MAY run concurrently." Three advisors flagged this unsafe: two subagents appending to `__init__.py` or `index.ts` race under concurrent writers; same-second timestamp migrations collide on filename and `alembic_version` head. Same-file writes now always serialize via `Depends on`; the only "concurrent add" case is distinct new files at different paths, which are already disjoint under the standard `Writes` rule.
+- **`Writes` column requires concrete file paths** (Maintainer) — not directories, not globs. Example table updated from `alembic/versions/...` (directory-like, contradicted the "same physical file" conflict rule) to `alembic/versions/2026_04_22_add_series.py` (concrete).
+- **Scheduling principle now reads "serial is the default; parallel requires proven independence"** — Contrarian's reframe. File-disjointness is necessary but not sufficient; shared types/imports/schemas encode as `Depends on`, not parallel.
+- **Docs drift fixed** (Contrarian) — Required Plugins tables in both command files + `docs/reference/commands.md` + `docs/explanation/workflow.md` ASCII diagram now list `/superpowers:subagent-driven-development` as default Phase 4 executor with `/superpowers:executing-plans` demoted to headless mode.
+
+Explicitly NOT shipped (deferred per chairman synthesis):
+
+- **Status/Evidence columns + mid-plan context-budget checkpoint** (Scalability Hawk) — secondary. Would need hook enforcement (like the evidence-based E2E gate) to be load-bearing. Out of scope for this markdown-only revision; revisit if field evidence shows the DAG being ignored or silently failing mid-plan.
+- **Concurrency cap enforcement** — `default 3 / max 5` is prose. No hook prevents an over-eager orchestrator from dispatching 8. If this decays into a suggestion on week 3, add a `check-dispatch-plan.sh` gate patterned on `check-workflow-gates.sh`.
+- **Revert default to `/superpowers:executing-plans`** (Contrarian) — overruled. Executing-plans hid the same planning ambiguity with less control; subagent-driven-development is a first-class Superpowers skill.
+
+Suite: 233 assertions across 5 bash suites pass. 5 files changed across two commits on the branch (`4c37350` initial + `9d82af8` council revisions).
+
+**Remediation for existing installs:** `./setup.sh -f` to pick up the new Phase 4 content.
+
 ## 5.12 — 2026-04-21 · Template-drift notice on `setup.sh -f` / `--upgrade`
 
 Closes the downstream pain path the user surfaced directly: after bumping the harness repo, running `./setup.sh -f` in a pre-existing project didn't warn that `CLAUDE.template.md` had evolved since their `CLAUDE.md` was originally copied. The user only saw `Your CLAUDE.md and CONTINUITY.md were not modified` and had to manually ask Claude to reconcile the template against the local file.

--- a/docs/explanation/workflow.md
+++ b/docs/explanation/workflow.md
@@ -58,9 +58,9 @@ How a feature goes from idea to merged PR.
                             ▼
 ┌─────────────────────────────────────────────────────────────┐
 │ 5. EXECUTE (Superpowers Plugin)                             │
-│    /superpowers:executing-plans                             │
+│    /superpowers:subagent-driven-development                 │
 │    → TDD enforced (RED-GREEN-REFACTOR)                      │
-│    → Subagents handle individual tasks                      │
+│    → Dispatch Plan (DAG) controls parallelism               │
 │    → Auto-format on save (ruff/prettier)                    │
 └─────────────────────────────────────────────────────────────┘
                             │
@@ -166,9 +166,9 @@ Based on Boris Cherny's key insight:
 The harness operationalizes that insight across every phase:
 
 - **Research** gives Claude current docs (not stale training data)
-- **Plan review loop** gives Claude a second set of eyes *before* writing code
+- **Plan review loop** gives Claude a second set of eyes _before_ writing code
 - **TDD** gives Claude executable tests as its verification loop
-- **Code review loop** gives Claude parallel reviewers *after* writing code
+- **Code review loop** gives Claude parallel reviewers _after_ writing code
 - **Simplify + verify + E2E** give Claude three more verification passes before commit
-- **PR reviewers + `/review-pr-comments`** give Claude automated reviewers *after* the PR is open
+- **PR reviewers + `/review-pr-comments`** give Claude automated reviewers _after_ the PR is open
 - **`docs/solutions/` + auto-memory** give Claude learning feedback so the same bug is never debugged twice

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -29,13 +29,14 @@ All slash commands and subagents available after setup.
 
 ## Superpowers Commands (Design → Execute → Debug)
 
-| Command                                       | Purpose                             | Notes                        |
-| --------------------------------------------- | ----------------------------------- | ---------------------------- |
-| `/superpowers:brainstorming`                  | Interactive design refinement       | Uses PRD context             |
-| `/superpowers:writing-plans`                  | Create detailed implementation plan | TDD tasks                    |
-| `/superpowers:executing-plans`                | Execute plan with subagents         | TDD enforced                 |
-| `/superpowers:systematic-debugging`           | 4-phase root cause analysis         | Before ANY bug fix           |
-| `/superpowers:verification-before-completion` | Evidence-based completion check     | Catches "should work" claims |
+| Command                                       | Purpose                                                    | Notes                                    |
+| --------------------------------------------- | ---------------------------------------------------------- | ---------------------------------------- |
+| `/superpowers:brainstorming`                  | Interactive design refinement                              | Uses PRD context                         |
+| `/superpowers:writing-plans`                  | Create detailed implementation plan                        | TDD tasks                                |
+| `/superpowers:subagent-driven-development`    | Execute plan via dispatched subagents (default in Phase 4) | TDD enforced, parallel via Dispatch Plan |
+| `/superpowers:executing-plans`                | Execute plan in a separate session                         | Headless / walk-away mode                |
+| `/superpowers:systematic-debugging`           | 4-phase root cause analysis                                | Before ANY bug fix                       |
+| `/superpowers:verification-before-completion` | Evidence-based completion check                            | Catches "should work" claims             |
 
 ## Quality Gates (Pre-PR — in this order)
 
@@ -79,9 +80,9 @@ For bug fixes, targeted research runs after root-cause isolation (Phase 2.5 of `
 
 Custom subagents available via the Task tool.
 
-| Agent             | Purpose                                                                                           | Invocation                                                      |
-| ----------------- | ------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| `verify-app`      | Unit tests + lint + type checks + migrations                                                      | "Use the verify-app agent"                                      |
-| `verify-e2e`      | User-journey E2E through API / UI / CLI; produces markdown report at `tests/e2e/reports/`         | "Use the verify-e2e agent"                                      |
-| `research-first`  | Pre-design library/API research via Context7 + official docs; writes `docs/research/<feature>.md` | Phase 2 of `/new-feature`, Phase 2.5 of `/fix-bug`              |
-| `council-advisor` | Engineering Council advisor (persona via prompt)                                                  | Dispatched by `/council` skill — not invoked directly           |
+| Agent             | Purpose                                                                                           | Invocation                                            |
+| ----------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `verify-app`      | Unit tests + lint + type checks + migrations                                                      | "Use the verify-app agent"                            |
+| `verify-e2e`      | User-journey E2E through API / UI / CLI; produces markdown report at `tests/e2e/reports/`         | "Use the verify-e2e agent"                            |
+| `research-first`  | Pre-design library/API research via Context7 + official docs; writes `docs/research/<feature>.md` | Phase 2 of `/new-feature`, Phase 2.5 of `/fix-bug`    |
+| `council-advisor` | Engineering Council advisor (persona via prompt)                                                  | Dispatched by `/council` skill — not invoked directly |


### PR DESCRIPTION
## Summary

- Replaces Phase 4 one-liner (`/superpowers:executing-plans`) with a structured Dispatch Plan: task DAG, continuous dispatch, file-conflict constraints, default 3 / max 5 concurrent subagents
- Adds optional `/compact` banner at Phase 4 start, `Trivial plans (≤3 tasks)` carve-out, and `Handling failures` semantics
- Keeps headless/walk-away mode reachable via explicit opt-in phrase, not a menu item
- Fixes downstream docs drift: `subagent-driven-development` now documented as the default Phase 4 executor everywhere

## Motivation

Field evidence from msai-v2 (19-task backtest results feature): the orchestrator hand-rolled a 16-wave scheduling table because the old Phase 4 (`/superpowers:executing-plans`) gave no parallelism guidance. Research agent + Codex second-opinion both identified **DAG with continuous dispatch** as the correct primitive over static file-overlap waves. See CHANGELOG 5.13 for the full reasoning.

## Council review

Initial commit `4c37350` was reviewed by 5 advisors (Simplifier, Scalability Hawk, Pragmatist, Contrarian, Maintainer). Two returned `OBJECT`. Five blocking findings — all addressed in `9d82af8`:

1. **Cross-reference bug** in `fix-bug.md` — said `commands/new-feature.md` literal, but `setup.sh` copies to `.claude/commands/` in target projects. Now references the installed sibling path.
2. **Append-only exception unsafe** — 3-way consensus (Hawk, Contrarian, Maintainer). Two subagents appending to `__init__.py` or `index.ts` race; same-second timestamp migrations collide. Deleted entirely; same-file writes always serialize via \`Depends on\`.
3. **\`Writes\` examples contradicted own rule** — used directories (\`alembic/versions/...\`) while the rule said "same physical file." Fixed to require concrete paths.
4. **No failure semantics** — added fail/reject/rate-limit/retry/dep-recheck bullets.
5. **No trivial-plan carve-out** in new-feature — added, mirroring fix-bug's simple-fix split.

Plus Contrarian flagged docs drift: Required Plugins tables, `docs/reference/commands.md`, and `docs/explanation/workflow.md` ASCII diagram now consistently list `subagent-driven-development` as default with `executing-plans` as headless mode.

**Overruled from the minority report** (documented in commit `9d82af8` body):
- Contrarian's "revert to executing-plans" — it hid the same ambiguity with less control
- Scalability Hawk's \`Status\`/\`Evidence\` columns + mid-plan context checkpoint — secondary, needs hook enforcement to be load-bearing, out of scope for a markdown revision

## Test plan

- [x] `bash tests/template/run-all.sh` — 233/233 assertions pass across 5 suites (test-lint, test-fixtures, test-contracts, test-hooks, test-setup)
- [x] Manually verified ASCII box in `docs/explanation/workflow.md` renders correctly (61-char inner width preserved)
- [x] Cross-reference in `fix-bug.md` §4.0 now uses `.claude/commands/` directory language so it resolves in both the template repo and in installed target projects
- [ ] Field-validate on next msai-v2 feature run — confirm orchestrator now reads and follows the `## Dispatch Plan` structure instead of reinventing waves

## Remediation for existing installs

`./setup.sh -f` in any downstream project to pick up the new Phase 4 content.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)