### PR TITLE
feat(prd): purge solution-shaped content from /prd:create and /prd:discuss

### DIFF
--- a/commands/prd/create.md
+++ b/commands/prd/create.md
@@ -10,15 +10,7 @@ Generate a structured PRD from the refined understanding captured in `/prd:discu
 
 ## Instructions
 
-### Step 0: Research Current Best Practices
-
-Before generating the PRD:
-
-1. Use WebSearch to verify current best practices for the feature type
-2. Use WebFetch/Context7 to check current library documentation if specific tech is involved
-3. Ensure recommendations reflect up-to-date patterns, not outdated approaches
-
-> **Note:** This Step 0 is **discovery research** for the PRD. Implementation-specific research (library versions, breaking changes) happens later in Phase 2 of `/new-feature` via the `research-first` agent.
+> **Research note:** The PRD captures WHAT the user needs — goals, constraints, acceptance criteria. HOW to build it (libraries, patterns, data models, auth mechanisms) belongs in the design phase, informed by the `research-first` agent in `/new-feature` Phase 2. Do NOT run web research here; the PRD is not a technology decision document.
 
 ### Step 1: Load Context
 
@@ -27,8 +19,12 @@ Before generating the PRD:
    - Refined user stories
    - Personas identified
    - Non-goals agreed
-   - Key decisions made
-   - Technical constraints
+   - Key decisions made (scope decisions, not solution choices)
+   - Business / compliance constraints (regulatory, legal, SLA)
+   - Platform / operational constraints (browser/OS floors, accessibility targets, network conditions)
+   - Dependencies (features/systems that must exist first)
+   - Required integrations or capabilities (named external systems or named capabilities — e.g. "must sync with Salesforce", "must support SAML 2.0 SSO", "must export iCalendar")
+   - Security outcomes (who can access what, what must never leak, what must be auditable, regulatory outcomes)
    - Success metrics
 
 ### Step 2: Generate PRD
@@ -134,52 +130,45 @@ And {additional result}
 
 ---
 
-## 5. Technical Constraints
+## 5. Constraints & Policies
 
-### Known Limitations
+> Outcome-level only. Hard limits the product must respect. HOW we satisfy them is design.
 
-- {constraint 1}
-- {constraint 2}
+### Business / Compliance Constraints
 
-### Dependencies
+- {e.g. "Must comply with HIPAA — PHI cannot leave the VPC"}
+- {e.g. "Free tier limited to 100 requests/day per org"}
+
+### Platform / Operational Constraints
+
+- {e.g. "Must run on iOS 16+ — no newer API features"}
+- {e.g. "Must degrade gracefully on 3G networks"}
+
+### Dependencies & Required Integrations
+
+> Name WHAT external systems or capabilities the user requires us to work with. HOW we call them (API style, SDK, message format) is design.
 
 - **Requires:** {feature/system that must exist first}
 - **Blocked by:** {any blockers}
+- **Named integrations (scope, not mechanism):** {e.g. "Must sync with Salesforce Contacts", "Must support Okta SSO for enterprise tenants", "Must export to QuickBooks"}
 
-### Integration Points
+## 6. Security Outcomes Required
 
-- {External system 1}: {how we integrate}
-- {External system 2}: {how we integrate}
+> WHAT must be protected and against what. HOW (auth mechanisms, hashing algorithms, audit formats) is design.
 
-## 6. Data Requirements
+- **Who can access what:** {e.g. "Only org admins can delete projects"}
+- **What must never leak:** {e.g. "User passwords must never be retrievable in plaintext, by anyone, ever"}
+- **What must be auditable:** {e.g. "All mutations to billing records must be traceable to an actor"}
+- **What legal/regulatory outcomes apply:** {e.g. "GDPR right-to-erasure honored within 30 days"}
 
-### New Data Models
-
-- {Model name}: {brief description}
-
-### Data Validation Rules
-
-- {Field}: {validation rule}
-
-### Data Migration
-
-- {Any migration needed from existing data}
-
-## 7. Security Considerations
-
-- **Authentication:** {requirements}
-- **Authorization:** {who can do what}
-- **Data Protection:** {sensitive data handling}
-- **Audit:** {what needs to be logged}
-
-## 8. Open Questions
+## 7. Open Questions
 
 > Questions that need answers before or during implementation
 
 - [ ] {Question 1}
 - [ ] {Question 2}
 
-## 9. References
+## 8. References
 
 - **Discussion Log:** `docs/prds/{feature-name}-discussion.md`
 - **Related PRDs:** {links to related PRDs}
@@ -210,8 +199,11 @@ Before finalizing, verify PRD has:
 - [ ] Edge cases documented
 - [ ] Explicit non-goals
 - [ ] Success metrics with targets
-- [ ] Technical constraints listed
-- [ ] Security considerations addressed
+- [ ] Constraints & Policies stated at outcome level (no "use library X" / "implement with Y")
+- [ ] Required integrations are NAMED as scope (e.g. "must sync with Salesforce") — not HOW we call them (no SDK choice, API call shape, message broker pick)
+- [ ] Interoperability requirements ARE allowed as scope when they define the product surface (e.g. "accept SAML 2.0", "export iCalendar", "serve OpenAPI 3.1") — these are WHAT the product must interoperate with, not HOW it implements internally
+- [ ] Security outcomes stated (who accesses what, what must not leak, required auth capabilities like "SSO") — NOT internal security mechanism (hashing algorithm, token signing choice, session storage)
+- [ ] No internal implementation picks — no data model schemas, no internal algorithm choices, no internal SDK/library picks (those belong in design)
 - [ ] No TBD or placeholder text
 
 ## Output

--- a/commands/prd/discuss.md
+++ b/commands/prd/discuss.md
@@ -8,23 +8,9 @@ User stories are often incomplete. This command ensures we understand requiremen
 
 ## Instructions
 
-### Phase 0: Research
-
-**Before analyzing user stories, research the problem space:**
-
-1. Use WebSearch to find industry best practices for this type of feature
-2. Use WebFetch to read relevant documentation if specific technologies are mentioned
-3. Look for competitor implementations or established patterns
-
-This research informs better questions and identifies requirements the user may not have considered.
-
-> **Note:** This Phase 0 is **discovery research** — understanding the problem space, competitors, and industry patterns before writing requirements. It is separate from Phase 2 **implementation research** (in `/new-feature`), where the `research-first` agent checks current library versions, breaking changes, and API patterns. Both phases are necessary: discovery shapes WHAT to build; implementation research shapes HOW to build it with current tools.
-
-**Tools for discovery research:**
-
-- `WebSearch` — industry best practices, competitor analysis
-- `WebFetch` — specific product pages, documentation sites
-- `Context7` — framework/library-specific guidance (also useful during discovery)
+> **Research note:** This command is about refining WHAT the user needs — personas, goals, non-goals, acceptance. Solution research (libraries, protocols, data shapes, auth mechanisms) happens in the design phase via `/new-feature` Phase 2's `research-first` agent. Do not run solution research inside this command — staying at the requirements layer is what makes this phase valuable.
+>
+> **In-band discovery research IS allowed, when scoped to requirements.** If during the discussion you hit a question you genuinely cannot answer without competitor / industry-pattern context (e.g. "what does 'import progress' look like in products users expect?", "what accessibility floor do analogous products hit?"), you MAY pause the discussion, run targeted WebSearch / WebFetch / Context7 queries, and bring the findings back into the conversation. Keep the research focused on user expectations and product norms — NOT on implementation choices (libraries, protocols, code patterns). If the question you want to research is "which library should we use" or "which protocol is fastest," stop — that's design.
 
 ### Phase 1: Initial Analysis
 
@@ -51,7 +37,17 @@ This research informs better questions and identifies requirements the user may 
 
 ### Phase 2: Targeted Questioning
 
-Analyze the stories and ask **5-10 pointed questions** covering:
+Analyze the stories and ask **5-10 pointed questions** covering the areas below.
+
+> **Stay on the WHAT, not the HOW.** Don't ask about INTERNAL implementation choices — which library, which internal data shape, which internal auth/hashing mechanism — those are design decisions, asked during brainstorming. DO ask what the user expects to SEE and DO, and whether a specific **external protocol, standard, or format** is part of the required product surface (interoperability is scope, not implementation).
+>
+> Examples:
+>
+> - "Does the user need real-time visible progress, or is a final outcome enough?" — requirement question ✅
+> - "Must the product accept SAML 2.0 assertions from customer IdPs?" — scope question (interoperability) ✅
+> - "Must we export iCalendar format for user downloads?" — scope question (product surface) ✅
+> - "SSE vs polling for progress?" — internal mechanism, skip ❌
+> - "Which JWT algorithm for internal sessions?" — internal mechanism, skip ❌
 
 #### Personas & Access
 
@@ -161,34 +157,46 @@ Before we write a PRD, let me understand these better:
 
 **Personas:**
 1. Is "admin" the only role that can import? What about project owners
-   or super-admins?
+   or super-admins? Are there any read-only personas who need to see
+   imports happening?
 
-**Story 1 - Import from URL:**
-2. What URL formats should we support?
-   - GitHub raw URLs (raw.githubusercontent.com)
-   - npm package references (@org/package)
-   - Direct JSON/YAML config files
-   - OpenAPI/Swagger specs
+**Story 1 - Import from URL (scope & behavior):**
+2. What URL sources must we support? (public links, private repos requiring
+   auth, something else the user points us at) — scope question, not
+   protocol question.
 
-3. What happens if the URL is unreachable or returns 404?
+3. What happens if the URL is unreachable? Does the user see a
+   clear error, a retry, something else?
 
-4. What if the URL points to a valid file but invalid MCP config?
+4. What happens if the URL points to a valid file but the content is
+   not a valid MCP config? What does the user see?
 
-5. Should we support authenticated URLs (private GitHub repos)?
+5. Can the same URL be imported twice — replace, dedupe, or error?
 
-**Story 2 - Progress:**
-6. Real-time updates (SSE/WebSocket) or polling?
+**Story 2 - Import progress (user-visible behavior):**
+6. Is "progress" required to be real-time visible, or is an end-of-import
+   success/failure message sufficient? (Real-time = new requirement;
+   "end-of-import only" might be simpler and OK.)
 
-7. What stages should progress show? For example:
-   - Fetching → Parsing → Validating → Creating tools → Done
+7. If the user navigates away mid-import, what must they see when they
+   return? Is the import expected to continue running whether or not they
+   are watching? (User-visible behavior — the implementation choice of
+   foreground vs background job is design.)
 
-**Scope:**
-8. Single URL import only, or should we support bulk (multiple URLs)?
+**Scope & security outcomes:**
+8. Single URL at a time, or bulk import? (Scope decision.)
 
-9. Are we importing just the server definition, or also credentials/API keys?
+9. Does "import MCP servers" include credentials / API keys bundled
+   with the server definition, or only the definition? (This is a
+   security-outcome question — NOT "how do we encrypt them".)
 
-10. Should imported servers auto-start, or require manual activation?
+10. After import, do servers auto-start or require an explicit enable
+    action by the user?
 ```
+
+> Notice: none of the questions above ask which protocol, parser, data
+> model, or storage mechanism to use. Those are design questions, asked
+> after the PRD lands.
 
 ## Output
 


### PR DESCRIPTION
## Summary

First of ~2 PRs from the 4-artifact migration (Path 1). Keeps the PRD pure WHAT — user stories, acceptance criteria, non-goals, outcome-level constraints. Everything implementation-shaped moves to the design phase.

**Council-reviewed** (5 advisors) and **Codex-reviewed** through 4 iterations (final: APPROVE, all P2s resolved).

## What changed

### `commands/prd/create.md`

- **Removed Step 0 Research** — discovery research belongs in design, not PRD creation. Replaced with a one-line note pointing to the `research-first` agent in `/new-feature` Phase 2.
- **§5 `Technical Constraints` → `Constraints & Policies`** (outcome-level only):
  - Business / Compliance Constraints (regulatory, legal, SLA)
  - Platform / Operational Constraints (browser/OS floors, a11y targets, network conditions)
  - Dependencies & Required Integrations (named external systems — "must sync with Salesforce", "must support SAML 2.0 SSO")
- **§6 `Data Requirements` deleted entirely** — data models are design.
- **§7 `Security Considerations` → `Security Outcomes Required`** — WHO accesses WHAT, WHAT must not leak, WHAT must be auditable, regulatory outcomes. Implementation (JWT alg, bcrypt rounds, audit format) is design.
- **Sections 8/9 renumbered to 7/8.**
- **Validation Checklist updated** to distinguish interoperability scope (legitimate PRD content) from internal implementation picks (design).
- **Step 1 extraction list** expanded to cover all constraint categories plus security outcomes.

### `commands/prd/discuss.md`

- **Removed Phase 0 Research** — replaced with a note allowing in-band *requirements-focused* research when needed (NOT solution research like "which library").
- **Phase 2 gets a `WHAT not HOW` side note** with worked examples distinguishing internal mechanism questions (skip) from interoperability scope questions (legitimate).
- **Example Interaction rewritten** — every solution-shaped question replaced with its requirements-shaped equivalent. Closing notice reinforces the rule.

## What did NOT change

- `CONTINUITY.md` / `CONTINUITY.template.md`
- `/new-feature` / `/fix-bug` workflows
- `research-first` agent (broadening is Stage B, separate PR)
- Design / plan artifact split (deferred — council found the full V1 migration underbaked)
- E2E use case location (deferred)

## Test plan

- [x] `bash tests/template/run-all.sh` — 188/188 passed (61 contract + 27 lint + 100 setup)
- [x] `rg 'Data Requirements|Step 0: Research|Phase 0: Research|Technical Constraints' tests/ docs/` — no matches
- [x] Codex review iterations 1–4 — final APPROVE, zero P0/P1/P2
- [x] Council review (5 advisors) on the broader migration design that informed this PR

## Follow-up

- **PR 2** (queued): CONTINUITY.md becomes status-only. Moves approach comparison from CONTINUITY.md into the plan-file header via in-context passing (Codex-verified handoff); applies Codex's tightened Phase 3.1c verbatim-paste language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)