### PR TITLE
feat(workflow): clear stale Workflow + Approach Comparison content on new feature start

### DIFF
--- a/CONTINUITY.template.md
+++ b/CONTINUITY.template.md
@@ -79,8 +79,13 @@ Ready for first task
 2. Move top of Next → Now
 3. Add to CHANGELOG.md if significant
 
-**On new feature:**
-Clear Done section, start fresh
+**On new feature start (`/new-feature` or `/fix-bug` Pre-Flight step 3):**
+
+1. **REPLACE** the `## Workflow` section entirely — do not append, do not preserve old checklist items.
+2. **Delete any stale `## Approach Comparison` blocks** in the file — these are leftover from the pre-PR-#537 workflow (which used to write design content into CONTINUITY.md). The new workflow keeps the Approach Comparison in conversation context only, then persists it into the plan file at Phase 3.2; nothing should remain in CONTINUITY.md.
+3. **Delete orphaned `[x]` / `[ ]` checkbox lines** that drifted outside any user-authored section. Includes: lines floating between sections, AND lines inside stale `## Approach Comparison` blocks you just deleted. Do NOT touch checkbox items inside user sections like `## Blockers` / `## Open Questions` — those are user content.
+
+**On new feature:** Clear Done section, start fresh.
 
 **Where detailed progress lives:**
 

--- a/commands/fix-bug.md
+++ b/commands/fix-bug.md
@@ -120,7 +120,13 @@ cat CONTINUITY.md
 
 ### 3. Initialize Workflow Tracking
 
-Write the `## Workflow` section in CONTINUITY.md (create the file if it doesn't exist):
+Write the `## Workflow` section in CONTINUITY.md (or create the file if it doesn't exist). Three cleanup steps before writing the new section:
+
+1. **REPLACE** any existing `## Workflow` section entirely — do not append, do not preserve old checklist items.
+2. **Delete any stale `## Approach Comparison` blocks** in the file. These are leftover from the pre-PR-#537 workflow (which wrote design content into CONTINUITY.md). The new workflow keeps the Approach Comparison in conversation context only, then persists it into the plan file at Phase 3.2; nothing should remain in CONTINUITY.md.
+3. **Delete orphaned `[x]` / `[ ]` checkbox lines** that drifted outside any user-authored section — lines floating between sections, AND lines inside any stale `## Approach Comparison` blocks you just deleted. Do NOT touch checkbox items inside user sections like `## Blockers` / `## Open Questions` — those are user content.
+
+Then write the new `## Workflow` section:
 
 ```markdown
 ## Workflow

--- a/commands/new-feature.md
+++ b/commands/new-feature.md
@@ -120,7 +120,13 @@ cat CONTINUITY.md
 
 ### 3. Initialize Workflow Tracking
 
-Write the `## Workflow` section in CONTINUITY.md (create the file if it doesn't exist):
+Write the `## Workflow` section in CONTINUITY.md (or create the file if it doesn't exist). Three cleanup steps before writing the new section:
+
+1. **REPLACE** any existing `## Workflow` section entirely — do not append, do not preserve old checklist items.
+2. **Delete any stale `## Approach Comparison` blocks** in the file. These are leftover from the pre-PR-#537 workflow (which wrote design content into CONTINUITY.md). The new workflow keeps the Approach Comparison in conversation context only, then persists it into the plan file at Phase 3.2; nothing should remain in CONTINUITY.md.
+3. **Delete orphaned `[x]` / `[ ]` checkbox lines** that drifted outside any user-authored section — lines floating between sections, AND lines inside any stale `## Approach Comparison` blocks you just deleted. Do NOT touch checkbox items inside user sections like `## Blockers` / `## Open Questions` — those are user content.
+
+Then write the new `## Workflow` section:
 
 ```markdown
 ## Workflow


### PR DESCRIPTION
## Summary

Closes the residual CONTINUITY.md accumulation gap left by #537. That PR stopped the new flow from **writing** design content into CONTINUITY.md, but didn't address features started under the old flow that already left stale `## Approach Comparison` blocks and orphaned checklist tails behind.

Without explicit cleanup instructions, those artifacts **stratify across multiple features** and CONTINUITY.md becomes unintelligible. msai-v2 (one downstream user) had ~250 lines of cross-feature debris (5 prior PRs' worth) accumulated between `## Workflow` and `## Done` before a manual cleanup pass surfaced the gap.

## What changed

### `commands/new-feature.md` + `commands/fix-bug.md` (Pre-Flight step 3)

Three-step cleanup before writing the new `## Workflow` section:

1. **REPLACE** any existing `## Workflow` section entirely (no append, no preserved checklist items).
2. **Delete stale `## Approach Comparison` blocks** — these are pre-#537 leftovers; the new flow keeps the comparison in conversation context only and persists it into the plan file at Phase 3.2.
3. **Delete orphaned `[x]` / `[ ]` checkbox lines** floating outside user-authored sections, including ones inside the just-deleted Approach Comparison blocks.

Explicit non-action: do NOT touch checkbox items inside user sections like `## Blockers` / `## Open Questions` — those are user content.

### `CONTINUITY.template.md` (Update Rules)

Mirrors the same three steps as a permanent rule, so users editing CONTINUITY.md by hand have the canonical guidance.

## Why these specific cleanup boundaries

The msai-v2 cleanup made the failure mode concrete:

- An old workflow's `### Checklist` items leaked OUT of the section (line breaks, formatter passes, manual edits).
- The next workflow's `## Approach Comparison` block (pre-#537) was inserted between the two.
- Now the orphaned checklist items are technically *inside* the Approach Comparison heading — a "spatial outside" rule misses them.
- This PR's step 3 explicitly handles that: "lines inside the just-deleted Approach Comparison blocks" are part of cleanup.

## What did NOT change

- No hook changes
- No test contract changes (`tests/template/test-hooks.sh:212` still asserts `Phase 3.2b` checklist string — that's the canonical Workflow checklist, unchanged)
- No template files outside `CONTINUITY.template.md`
- No retroactive cleanup of msai-v2 (that's downstream user concern; this PR is the harness fix)

## Test plan

- [x] `bash tests/template/run-all.sh` — 188/188 pass
- [x] 6 iterations of `/codex review` — each surfaced a real correctness issue (wrong boundary anchor; internal contradiction with Done retention rule; overly-aggressive cleanup that would delete user content; missed edge case for checklists trapped inside stale Approach Comparison blocks). Final iteration: clean.
- [x] /new-feature + /fix-bug get the same three-step cleanup (verified word-for-word match)
- [x] Template Update Rules consistent with command Pre-Flight steps

## Existing installs

Pull this template version + `./setup.sh -f` will refresh `commands/{new-feature,fix-bug}.md`. Next `/new-feature` invocation will perform the three-step cleanup automatically. Users with already-stratified CONTINUITY.md files (like msai-v2's pre-cleanup state) will see the cleanup happen on their next workflow start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)