### PR TITLE
feat: drift hygiene — SessionStart fetch + worktree from origin/<default>

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,9 @@ claude-codex-forge/
 │   └── skill-audit.md          # Third-party skill security checklist
 │
 ├── hooks/                      # Hook scripts (copied to .claude/hooks/)
-│   ├── session-start.sh/.ps1        # SessionStart: silent context injection (branch)
+│   ├── lib/                         # Shared helpers sourced/called by other hooks
+│   │   └── default-branch.sh/.ps1   # Detect repo's default branch (origin/HEAD → main → master)
+│   ├── session-start.sh/.ps1        # SessionStart: silent context injection (branch + drift warning)
 │   ├── check-state-updated.sh/.ps1  # Stop: enforce CONTINUITY.md updates + workflow reminder
 │   ├── check-bash-safety.sh/.ps1    # PreToolUse: audit log + block dangerous patterns
 │   ├── check-workflow-gates.sh/.ps1 # PreToolUse: block commit/push/PR if quality gates incomplete
@@ -145,6 +147,8 @@ Templates in the root are **source of truth**. `setup.sh` copies them to target 
 | `commands/*.md`                           | `.claude/commands/*.md` in target project                                                          |
 | `rules/*.md`                              | `.claude/rules/*.md` in target project                                                             |
 | `hooks/*`                                 | `.claude/hooks/*` in target project                                                                |
+| `hooks/lib/default-branch.sh`             | `.claude/hooks/lib/default-branch.sh` in target project                                            |
+| `hooks/lib/default-branch.ps1`            | `.claude/hooks/lib/default-branch.ps1` in target project                                           |
 | `skills/ui-design/SKILL.template.md`      | `.claude/skills/ui-design/SKILL.md` in target                                                      |
 | `skills/ui-design/references/*.md`        | `.claude/skills/ui-design/references/*.md`                                                         |
 | `skills/generate-image/SKILL.template.md` | `.claude/skills/generate-image/SKILL.md`                                                           |
@@ -171,7 +175,7 @@ Every hook has both `.sh` (Unix) and `.ps1` (Windows) versions. **Always update 
 
 ### Hook Design
 
-- **SessionStart hooks** (`session-start.sh`): Output JSON with `hookSpecificOutput.additionalContext` for silent context injection
+- **SessionStart hooks** (`session-start.sh`): Output JSON with `hookSpecificOutput.additionalContext` for silent context injection. Source-gated: drift-detection fetch fires only on `startup`/`resume` subtypes, not `clear`/`compact`. Cannot block (exit 2 is advisory) — drift surfaces as a warning string in additionalContext only.
 - **Stop hooks** (`check-state-updated.sh`): Use `exit 2` + stderr message to block
 - **PreToolUse hooks** (`check-bash-safety.sh`): Audit log + `exit 2` to block dangerous Bash patterns
 - **PostToolUse hooks**: Match file extensions, run formatters, `exit 0` always

--- a/commands/fix-bug.md
+++ b/commands/fix-bug.md
@@ -50,12 +50,14 @@ fi
 ROOT="$(git rev-parse --show-toplevel)"
 LIB="$ROOT/.claude/hooks/lib/default-branch.sh"
 [ ! -f "$LIB" ] && LIB="$ROOT/hooks/lib/default-branch.sh"
-DEFAULT_BRANCH=$(bash "$LIB" 2>/dev/null) || DEFAULT_BRANCH="main"
-git fetch origin --quiet 2>/dev/null || true
-# Verify BOTH refs exist before rev-list — guards against exit-128 silently returning 0
-# when local <default> is missing (e.g., shallow/single-branch clone where origin/HEAD
-# was set to main but local main was never created).
-if git rev-parse --verify "$DEFAULT_BRANCH" >/dev/null 2>&1 \
+DEFAULT_BRANCH=$(bash "$LIB" 2>/dev/null) \
+    || { DEFAULT_BRANCH="main"; echo "  ⚠ default-branch helper bailed; assuming 'main' (drift check may be wrong on non-main repos)" >&2; }
+ALREADY_FETCH_OK=true
+git fetch origin --quiet 2>/dev/null || ALREADY_FETCH_OK=false
+# Behind-check: only if FETCH succeeded AND both refs exist. Skipping on fetch failure
+# prevents reporting drift against a stale origin/* ref. Also guards rev-list exit-128.
+if [ "$ALREADY_FETCH_OK" = "true" ] \
+   && git rev-parse --verify "$DEFAULT_BRANCH" >/dev/null 2>&1 \
    && git rev-parse --verify "origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
   BEHIND=$(git rev-list --count "$DEFAULT_BRANCH..origin/$DEFAULT_BRANCH" 2>/dev/null || echo "")
   if [[ "$BEHIND" =~ ^[0-9]+$ ]] && [ "$BEHIND" -gt 0 ]; then
@@ -84,32 +86,38 @@ grep -qxF '.worktrees/' .gitignore 2>/dev/null || echo '.worktrees/' >> .gitigno
 ROOT="$(git rev-parse --show-toplevel)"
 LIB="$ROOT/.claude/hooks/lib/default-branch.sh"
 [ ! -f "$LIB" ] && LIB="$ROOT/hooks/lib/default-branch.sh"
-DEFAULT_BRANCH=$(bash "$LIB" 2>/dev/null) || DEFAULT_BRANCH="main"
+DEFAULT_BRANCH=$(bash "$LIB" 2>/dev/null) \
+    || { DEFAULT_BRANCH="main"; echo "  ⚠ default-branch helper bailed; assuming 'main' (worktree base may be wrong on non-main repos)" >&2; }
 
 FETCH_OK=true
 git fetch origin --quiet 2>/dev/null || { FETCH_OK=false; echo "  ⚠ git fetch failed — proceeding with local refs (origin may be stale)"; }
 
-# Behind-check: only if BOTH local <default> and origin/<default> refs exist locally,
-# so git rev-list can't exit 128 and we can't silently report "0 behind" when the
-# local default branch doesn't exist (which would mask a real configuration problem).
-if git rev-parse --verify "$DEFAULT_BRANCH" >/dev/null 2>&1 \
+# Behind-check: only if FETCH succeeded AND both local <default> and origin/<default>
+# refs exist. Skipping when fetch failed prevents (a) reporting drift against a stale
+# origin/* ref, and (b) `git pull` triggering a second network call after we said we'd
+# "proceed with local refs". Also guards rev-list exit-128 when local default is missing.
+if [ "$FETCH_OK" = "true" ] \
+   && git rev-parse --verify "$DEFAULT_BRANCH" >/dev/null 2>&1 \
    && git rev-parse --verify "origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
   BEHIND=$(git rev-list --count "$DEFAULT_BRANCH..origin/$DEFAULT_BRANCH" 2>/dev/null || echo "")
   if [[ "$BEHIND" =~ ^[0-9]+$ ]] && [ "$BEHIND" -gt 0 ]; then
     CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
     if [ "$CURRENT_BRANCH" = "$DEFAULT_BRANCH" ]; then
-      # Only on default → eligible for FF. Dirty tree blocks (would lose changes).
+      # On default → eligible for FF, but FF is OPTIONAL polish. The worktree itself
+      # bases from origin/<default> (BASE below) which is independent of the caller's
+      # checkout state, so dirty-tree / diverged-history are warnings, not blockers —
+      # `git worktree add` does not modify the current checkout.
       # Under user's `set -o pipefail`, grep -v on a clean tree (no input) exits 1
       # and DIRTY becomes empty — symmetric with BEHIND, validate before integer compare.
       DIRTY=$(git status --porcelain 2>/dev/null | grep -v '^??' | wc -l | tr -d ' ' || echo 0)
       [[ "$DIRTY" =~ ^[0-9]+$ ]] || DIRTY=0
       if [ "$DIRTY" -gt 0 ]; then
-        echo "✗ Local '$DEFAULT_BRANCH' is $BEHIND commits behind origin, but working tree is dirty."
-        echo "  Commit or stash your changes, then re-run."
-        exit 1
+        echo "  ⚠ Local '$DEFAULT_BRANCH' is $BEHIND commits behind origin AND working tree is dirty — skipping auto-FF (your local default stays as-is; new worktree still bases from origin/$DEFAULT_BRANCH)"
+      elif git pull --ff-only origin "$DEFAULT_BRANCH"; then
+        echo "✓ Updated local '$DEFAULT_BRANCH' from origin (was $BEHIND commits behind)"
+      else
+        echo "  ⚠ git pull --ff-only failed (diverged?) — skipping auto-FF (new worktree still bases from origin/$DEFAULT_BRANCH)"
       fi
-      git pull --ff-only origin "$DEFAULT_BRANCH" || { echo "✗ git pull --ff-only failed — see git error above"; exit 1; }
-      echo "✓ Updated local '$DEFAULT_BRANCH' from origin (was $BEHIND commits behind)"
     else
       # Not on default → no FF attempted. Dirty changes on a feature branch are fine
       # (they stay in this checkout; the new worktree gets its own working tree).
@@ -125,7 +133,12 @@ if [ "$FETCH_OK" = "true" ] && git rev-parse --verify "origin/$DEFAULT_BRANCH" >
 elif git rev-parse --verify "$DEFAULT_BRANCH" >/dev/null 2>&1; then
   BASE="$DEFAULT_BRANCH"
 else
-  BASE="HEAD"  # last-resort fallback — shouldn't happen; helper should have bailed
+  # Last-resort: neither origin/<default> (fetch failed or ref absent) nor local <default>
+  # exists. Surface this — the worktree will be based on whatever is currently checked
+  # out, which may be a feature branch, a tag, or a detached HEAD. Reachable when the
+  # helper bailed AND the assumed fallback "main" doesn't exist locally either.
+  BASE="HEAD"
+  echo "  ⚠ Could not resolve any default-branch ref; basing worktree on HEAD ($(git rev-parse --short HEAD 2>/dev/null || echo '???')) — verify this is intentional" >&2
 fi
 # DRIFT-PREFLIGHT-NEW-END
 

--- a/commands/fix-bug.md
+++ b/commands/fix-bug.md
@@ -46,15 +46,21 @@ fi
 - Surface drift on the parent default branch (advisory; no auto-FF from inside a worktree)
 
 ```bash
-# DRIFT-PREFLIGHT-ALREADY-BEGIN (kept byte-identical with commands/fix-bug.md via test-contracts.sh)
+# DRIFT-PREFLIGHT-ALREADY-BEGIN (byte-identical with commands/fix-bug.md — enforced by test-contracts.sh)
 ROOT="$(git rev-parse --show-toplevel)"
 LIB="$ROOT/.claude/hooks/lib/default-branch.sh"
 [ ! -f "$LIB" ] && LIB="$ROOT/hooks/lib/default-branch.sh"
 DEFAULT_BRANCH=$(bash "$LIB" 2>/dev/null) || DEFAULT_BRANCH="main"
 git fetch origin --quiet 2>/dev/null || true
-if git rev-parse --verify "origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
-  BEHIND=$(git rev-list --count "$DEFAULT_BRANCH..origin/$DEFAULT_BRANCH" 2>/dev/null || echo 0)
-  [ "$BEHIND" -gt 0 ] && echo "  ⚠ Parent '$DEFAULT_BRANCH' is $BEHIND commits behind origin (skipping auto-FF from worktree)"
+# Verify BOTH refs exist before rev-list — guards against exit-128 silently returning 0
+# when local <default> is missing (e.g., shallow/single-branch clone where origin/HEAD
+# was set to main but local main was never created).
+if git rev-parse --verify "$DEFAULT_BRANCH" >/dev/null 2>&1 \
+   && git rev-parse --verify "origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
+  BEHIND=$(git rev-list --count "$DEFAULT_BRANCH..origin/$DEFAULT_BRANCH" 2>/dev/null || echo "")
+  if [[ "$BEHIND" =~ ^[0-9]+$ ]] && [ "$BEHIND" -gt 0 ]; then
+    echo "  ⚠ Parent '$DEFAULT_BRANCH' is $BEHIND commits behind origin (skipping auto-FF from worktree)"
+  fi
 fi
 # DRIFT-PREFLIGHT-ALREADY-END
 ```
@@ -71,38 +77,56 @@ WORKTREE_PATH=".worktrees/$FIX_NAME"
 mkdir -p .worktrees
 grep -qxF '.worktrees/' .gitignore 2>/dev/null || echo '.worktrees/' >> .gitignore
 
-# DRIFT-PREFLIGHT-NEW-BEGIN (kept byte-identical with commands/fix-bug.md via test-contracts.sh)
-# Resolve default branch + fetch origin so the new worktree bases from current origin/<default>,
-# never a stale local default. If local <default> is behind origin AND clean, fast-forward.
-# If dirty, STOP — don't auto-stash or merge.
+# DRIFT-PREFLIGHT-NEW-BEGIN (byte-identical with commands/fix-bug.md — enforced by test-contracts.sh)
+# Resolve default branch, fetch origin (track success), and base the new worktree on
+# current origin/<default> when fetch succeeded — else local <default>. If local <default>
+# is behind origin AND we're on default with a clean tree, fast-forward; otherwise warn.
 ROOT="$(git rev-parse --show-toplevel)"
 LIB="$ROOT/.claude/hooks/lib/default-branch.sh"
 [ ! -f "$LIB" ] && LIB="$ROOT/hooks/lib/default-branch.sh"
 DEFAULT_BRANCH=$(bash "$LIB" 2>/dev/null) || DEFAULT_BRANCH="main"
 
-git fetch origin --quiet 2>/dev/null || echo "  ⚠ git fetch failed — proceeding with local refs"
+FETCH_OK=true
+git fetch origin --quiet 2>/dev/null || { FETCH_OK=false; echo "  ⚠ git fetch failed — proceeding with local refs (origin may be stale)"; }
 
-if git rev-parse --verify "origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
-  BEHIND=$(git rev-list --count "$DEFAULT_BRANCH..origin/$DEFAULT_BRANCH" 2>/dev/null || echo 0)
-  if [ "$BEHIND" -gt 0 ]; then
-    DIRTY=$(git status --porcelain 2>/dev/null | grep -v '^??' | wc -l | tr -d ' ')
+# Behind-check: only if BOTH local <default> and origin/<default> refs exist locally,
+# so git rev-list can't exit 128 and we can't silently report "0 behind" when the
+# local default branch doesn't exist (which would mask a real configuration problem).
+if git rev-parse --verify "$DEFAULT_BRANCH" >/dev/null 2>&1 \
+   && git rev-parse --verify "origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
+  BEHIND=$(git rev-list --count "$DEFAULT_BRANCH..origin/$DEFAULT_BRANCH" 2>/dev/null || echo "")
+  if [[ "$BEHIND" =~ ^[0-9]+$ ]] && [ "$BEHIND" -gt 0 ]; then
     CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
-    if [ "$DIRTY" -gt 0 ]; then
-      echo "✗ Local '$DEFAULT_BRANCH' is $BEHIND commits behind origin, but working tree is dirty."
-      echo "  Commit or stash your changes, then re-run."
-      exit 1
-    elif [ "$CURRENT_BRANCH" = "$DEFAULT_BRANCH" ]; then
-      git pull --ff-only origin "$DEFAULT_BRANCH" || { echo "✗ git pull --ff-only failed (diverged?)"; exit 1; }
+    if [ "$CURRENT_BRANCH" = "$DEFAULT_BRANCH" ]; then
+      # Only on default → eligible for FF. Dirty tree blocks (would lose changes).
+      # Under user's `set -o pipefail`, grep -v on a clean tree (no input) exits 1
+      # and DIRTY becomes empty — symmetric with BEHIND, validate before integer compare.
+      DIRTY=$(git status --porcelain 2>/dev/null | grep -v '^??' | wc -l | tr -d ' ' || echo 0)
+      [[ "$DIRTY" =~ ^[0-9]+$ ]] || DIRTY=0
+      if [ "$DIRTY" -gt 0 ]; then
+        echo "✗ Local '$DEFAULT_BRANCH' is $BEHIND commits behind origin, but working tree is dirty."
+        echo "  Commit or stash your changes, then re-run."
+        exit 1
+      fi
+      git pull --ff-only origin "$DEFAULT_BRANCH" || { echo "✗ git pull --ff-only failed — see git error above"; exit 1; }
       echo "✓ Updated local '$DEFAULT_BRANCH' from origin (was $BEHIND commits behind)"
     else
+      # Not on default → no FF attempted. Dirty changes on a feature branch are fine
+      # (they stay in this checkout; the new worktree gets its own working tree).
       echo "  ⚠ Local '$DEFAULT_BRANCH' is $BEHIND commits behind origin (you're on '$CURRENT_BRANCH', skipping auto-FF)"
     fi
   fi
 fi
 
-# Resolve worktree base. Prefer origin/<default>; fall back to local <default> if origin ref missing.
-BASE="origin/$DEFAULT_BRANCH"
-git rev-parse --verify "$BASE" >/dev/null 2>&1 || BASE="$DEFAULT_BRANCH"
+# Resolve worktree base. Prefer origin/<default> ONLY if fetch succeeded AND ref exists
+# locally. If fetch failed, prefer local <default> (don't trust the now-stale origin ref).
+if [ "$FETCH_OK" = "true" ] && git rev-parse --verify "origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
+  BASE="origin/$DEFAULT_BRANCH"
+elif git rev-parse --verify "$DEFAULT_BRANCH" >/dev/null 2>&1; then
+  BASE="$DEFAULT_BRANCH"
+else
+  BASE="HEAD"  # last-resort fallback — shouldn't happen; helper should have bailed
+fi
 # DRIFT-PREFLIGHT-NEW-END
 
 if [ -d "$WORKTREE_PATH" ]; then

--- a/commands/fix-bug.md
+++ b/commands/fix-bug.md
@@ -42,8 +42,22 @@ fi
 
 **If ALREADY_IN_WORKTREE:**
 
-- You're already isolated - continue with current workspace
-- No action needed
+- You're already isolated — continue with current workspace
+- Surface drift on the parent default branch (advisory; no auto-FF from inside a worktree)
+
+```bash
+# DRIFT-PREFLIGHT-ALREADY-BEGIN (kept byte-identical with commands/fix-bug.md via test-contracts.sh)
+ROOT="$(git rev-parse --show-toplevel)"
+LIB="$ROOT/.claude/hooks/lib/default-branch.sh"
+[ ! -f "$LIB" ] && LIB="$ROOT/hooks/lib/default-branch.sh"
+DEFAULT_BRANCH=$(bash "$LIB" 2>/dev/null) || DEFAULT_BRANCH="main"
+git fetch origin --quiet 2>/dev/null || true
+if git rev-parse --verify "origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
+  BEHIND=$(git rev-list --count "$DEFAULT_BRANCH..origin/$DEFAULT_BRANCH" 2>/dev/null || echo 0)
+  [ "$BEHIND" -gt 0 ] && echo "  ⚠ Parent '$DEFAULT_BRANCH' is $BEHIND commits behind origin (skipping auto-FF from worktree)"
+fi
+# DRIFT-PREFLIGHT-ALREADY-END
+```
 
 **If NEEDS_WORKTREE → Create worktree and cd into it:**
 
@@ -57,15 +71,48 @@ WORKTREE_PATH=".worktrees/$FIX_NAME"
 mkdir -p .worktrees
 grep -qxF '.worktrees/' .gitignore 2>/dev/null || echo '.worktrees/' >> .gitignore
 
-# Create worktree (handle existing branch/worktree cases)
+# DRIFT-PREFLIGHT-NEW-BEGIN (kept byte-identical with commands/fix-bug.md via test-contracts.sh)
+# Resolve default branch + fetch origin so the new worktree bases from current origin/<default>,
+# never a stale local default. If local <default> is behind origin AND clean, fast-forward.
+# If dirty, STOP — don't auto-stash or merge.
+ROOT="$(git rev-parse --show-toplevel)"
+LIB="$ROOT/.claude/hooks/lib/default-branch.sh"
+[ ! -f "$LIB" ] && LIB="$ROOT/hooks/lib/default-branch.sh"
+DEFAULT_BRANCH=$(bash "$LIB" 2>/dev/null) || DEFAULT_BRANCH="main"
+
+git fetch origin --quiet 2>/dev/null || echo "  ⚠ git fetch failed — proceeding with local refs"
+
+if git rev-parse --verify "origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
+  BEHIND=$(git rev-list --count "$DEFAULT_BRANCH..origin/$DEFAULT_BRANCH" 2>/dev/null || echo 0)
+  if [ "$BEHIND" -gt 0 ]; then
+    DIRTY=$(git status --porcelain 2>/dev/null | grep -v '^??' | wc -l | tr -d ' ')
+    CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+    if [ "$DIRTY" -gt 0 ]; then
+      echo "✗ Local '$DEFAULT_BRANCH' is $BEHIND commits behind origin, but working tree is dirty."
+      echo "  Commit or stash your changes, then re-run."
+      exit 1
+    elif [ "$CURRENT_BRANCH" = "$DEFAULT_BRANCH" ]; then
+      git pull --ff-only origin "$DEFAULT_BRANCH" || { echo "✗ git pull --ff-only failed (diverged?)"; exit 1; }
+      echo "✓ Updated local '$DEFAULT_BRANCH' from origin (was $BEHIND commits behind)"
+    else
+      echo "  ⚠ Local '$DEFAULT_BRANCH' is $BEHIND commits behind origin (you're on '$CURRENT_BRANCH', skipping auto-FF)"
+    fi
+  fi
+fi
+
+# Resolve worktree base. Prefer origin/<default>; fall back to local <default> if origin ref missing.
+BASE="origin/$DEFAULT_BRANCH"
+git rev-parse --verify "$BASE" >/dev/null 2>&1 || BASE="$DEFAULT_BRANCH"
+# DRIFT-PREFLIGHT-NEW-END
+
 if [ -d "$WORKTREE_PATH" ]; then
   echo "✓ Worktree exists - reusing $WORKTREE_PATH"
 elif git show-ref --quiet "refs/heads/fix/$FIX_NAME" 2>/dev/null; then
   git worktree add "$WORKTREE_PATH" "fix/$FIX_NAME"
   echo "✓ Created worktree for existing branch at $WORKTREE_PATH"
 else
-  git worktree add "$WORKTREE_PATH" -b "fix/$FIX_NAME"
-  echo "✓ Created new worktree at $WORKTREE_PATH"
+  git worktree add "$WORKTREE_PATH" -b "fix/$FIX_NAME" "$BASE"
+  echo "✓ Created new worktree at $WORKTREE_PATH (based on $BASE)"
 fi
 
 # Symlink environment files (not copy) so rotated secrets propagate and .env can't be accidentally committed

--- a/commands/new-feature.md
+++ b/commands/new-feature.md
@@ -50,12 +50,14 @@ fi
 ROOT="$(git rev-parse --show-toplevel)"
 LIB="$ROOT/.claude/hooks/lib/default-branch.sh"
 [ ! -f "$LIB" ] && LIB="$ROOT/hooks/lib/default-branch.sh"
-DEFAULT_BRANCH=$(bash "$LIB" 2>/dev/null) || DEFAULT_BRANCH="main"
-git fetch origin --quiet 2>/dev/null || true
-# Verify BOTH refs exist before rev-list — guards against exit-128 silently returning 0
-# when local <default> is missing (e.g., shallow/single-branch clone where origin/HEAD
-# was set to main but local main was never created).
-if git rev-parse --verify "$DEFAULT_BRANCH" >/dev/null 2>&1 \
+DEFAULT_BRANCH=$(bash "$LIB" 2>/dev/null) \
+    || { DEFAULT_BRANCH="main"; echo "  ⚠ default-branch helper bailed; assuming 'main' (drift check may be wrong on non-main repos)" >&2; }
+ALREADY_FETCH_OK=true
+git fetch origin --quiet 2>/dev/null || ALREADY_FETCH_OK=false
+# Behind-check: only if FETCH succeeded AND both refs exist. Skipping on fetch failure
+# prevents reporting drift against a stale origin/* ref. Also guards rev-list exit-128.
+if [ "$ALREADY_FETCH_OK" = "true" ] \
+   && git rev-parse --verify "$DEFAULT_BRANCH" >/dev/null 2>&1 \
    && git rev-parse --verify "origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
   BEHIND=$(git rev-list --count "$DEFAULT_BRANCH..origin/$DEFAULT_BRANCH" 2>/dev/null || echo "")
   if [[ "$BEHIND" =~ ^[0-9]+$ ]] && [ "$BEHIND" -gt 0 ]; then
@@ -84,32 +86,38 @@ grep -qxF '.worktrees/' .gitignore 2>/dev/null || echo '.worktrees/' >> .gitigno
 ROOT="$(git rev-parse --show-toplevel)"
 LIB="$ROOT/.claude/hooks/lib/default-branch.sh"
 [ ! -f "$LIB" ] && LIB="$ROOT/hooks/lib/default-branch.sh"
-DEFAULT_BRANCH=$(bash "$LIB" 2>/dev/null) || DEFAULT_BRANCH="main"
+DEFAULT_BRANCH=$(bash "$LIB" 2>/dev/null) \
+    || { DEFAULT_BRANCH="main"; echo "  ⚠ default-branch helper bailed; assuming 'main' (worktree base may be wrong on non-main repos)" >&2; }
 
 FETCH_OK=true
 git fetch origin --quiet 2>/dev/null || { FETCH_OK=false; echo "  ⚠ git fetch failed — proceeding with local refs (origin may be stale)"; }
 
-# Behind-check: only if BOTH local <default> and origin/<default> refs exist locally,
-# so git rev-list can't exit 128 and we can't silently report "0 behind" when the
-# local default branch doesn't exist (which would mask a real configuration problem).
-if git rev-parse --verify "$DEFAULT_BRANCH" >/dev/null 2>&1 \
+# Behind-check: only if FETCH succeeded AND both local <default> and origin/<default>
+# refs exist. Skipping when fetch failed prevents (a) reporting drift against a stale
+# origin/* ref, and (b) `git pull` triggering a second network call after we said we'd
+# "proceed with local refs". Also guards rev-list exit-128 when local default is missing.
+if [ "$FETCH_OK" = "true" ] \
+   && git rev-parse --verify "$DEFAULT_BRANCH" >/dev/null 2>&1 \
    && git rev-parse --verify "origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
   BEHIND=$(git rev-list --count "$DEFAULT_BRANCH..origin/$DEFAULT_BRANCH" 2>/dev/null || echo "")
   if [[ "$BEHIND" =~ ^[0-9]+$ ]] && [ "$BEHIND" -gt 0 ]; then
     CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
     if [ "$CURRENT_BRANCH" = "$DEFAULT_BRANCH" ]; then
-      # Only on default → eligible for FF. Dirty tree blocks (would lose changes).
+      # On default → eligible for FF, but FF is OPTIONAL polish. The worktree itself
+      # bases from origin/<default> (BASE below) which is independent of the caller's
+      # checkout state, so dirty-tree / diverged-history are warnings, not blockers —
+      # `git worktree add` does not modify the current checkout.
       # Under user's `set -o pipefail`, grep -v on a clean tree (no input) exits 1
       # and DIRTY becomes empty — symmetric with BEHIND, validate before integer compare.
       DIRTY=$(git status --porcelain 2>/dev/null | grep -v '^??' | wc -l | tr -d ' ' || echo 0)
       [[ "$DIRTY" =~ ^[0-9]+$ ]] || DIRTY=0
       if [ "$DIRTY" -gt 0 ]; then
-        echo "✗ Local '$DEFAULT_BRANCH' is $BEHIND commits behind origin, but working tree is dirty."
-        echo "  Commit or stash your changes, then re-run."
-        exit 1
+        echo "  ⚠ Local '$DEFAULT_BRANCH' is $BEHIND commits behind origin AND working tree is dirty — skipping auto-FF (your local default stays as-is; new worktree still bases from origin/$DEFAULT_BRANCH)"
+      elif git pull --ff-only origin "$DEFAULT_BRANCH"; then
+        echo "✓ Updated local '$DEFAULT_BRANCH' from origin (was $BEHIND commits behind)"
+      else
+        echo "  ⚠ git pull --ff-only failed (diverged?) — skipping auto-FF (new worktree still bases from origin/$DEFAULT_BRANCH)"
       fi
-      git pull --ff-only origin "$DEFAULT_BRANCH" || { echo "✗ git pull --ff-only failed — see git error above"; exit 1; }
-      echo "✓ Updated local '$DEFAULT_BRANCH' from origin (was $BEHIND commits behind)"
     else
       # Not on default → no FF attempted. Dirty changes on a feature branch are fine
       # (they stay in this checkout; the new worktree gets its own working tree).
@@ -125,7 +133,12 @@ if [ "$FETCH_OK" = "true" ] && git rev-parse --verify "origin/$DEFAULT_BRANCH" >
 elif git rev-parse --verify "$DEFAULT_BRANCH" >/dev/null 2>&1; then
   BASE="$DEFAULT_BRANCH"
 else
-  BASE="HEAD"  # last-resort fallback — shouldn't happen; helper should have bailed
+  # Last-resort: neither origin/<default> (fetch failed or ref absent) nor local <default>
+  # exists. Surface this — the worktree will be based on whatever is currently checked
+  # out, which may be a feature branch, a tag, or a detached HEAD. Reachable when the
+  # helper bailed AND the assumed fallback "main" doesn't exist locally either.
+  BASE="HEAD"
+  echo "  ⚠ Could not resolve any default-branch ref; basing worktree on HEAD ($(git rev-parse --short HEAD 2>/dev/null || echo '???')) — verify this is intentional" >&2
 fi
 # DRIFT-PREFLIGHT-NEW-END
 

--- a/commands/new-feature.md
+++ b/commands/new-feature.md
@@ -42,8 +42,22 @@ fi
 
 **If ALREADY_IN_WORKTREE:**
 
-- You're already isolated - continue with current workspace
-- No action needed
+- You're already isolated — continue with current workspace
+- Surface drift on the parent default branch (advisory; no auto-FF from inside a worktree)
+
+```bash
+# DRIFT-PREFLIGHT-ALREADY-BEGIN (kept byte-identical with commands/fix-bug.md via test-contracts.sh)
+ROOT="$(git rev-parse --show-toplevel)"
+LIB="$ROOT/.claude/hooks/lib/default-branch.sh"
+[ ! -f "$LIB" ] && LIB="$ROOT/hooks/lib/default-branch.sh"
+DEFAULT_BRANCH=$(bash "$LIB" 2>/dev/null) || DEFAULT_BRANCH="main"
+git fetch origin --quiet 2>/dev/null || true
+if git rev-parse --verify "origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
+  BEHIND=$(git rev-list --count "$DEFAULT_BRANCH..origin/$DEFAULT_BRANCH" 2>/dev/null || echo 0)
+  [ "$BEHIND" -gt 0 ] && echo "  ⚠ Parent '$DEFAULT_BRANCH' is $BEHIND commits behind origin (skipping auto-FF from worktree)"
+fi
+# DRIFT-PREFLIGHT-ALREADY-END
+```
 
 **If NEEDS_WORKTREE → Create worktree and cd into it:**
 
@@ -57,15 +71,48 @@ WORKTREE_PATH=".worktrees/$FEATURE_NAME"
 mkdir -p .worktrees
 grep -qxF '.worktrees/' .gitignore 2>/dev/null || echo '.worktrees/' >> .gitignore
 
-# Create worktree (handle existing branch/worktree cases)
+# DRIFT-PREFLIGHT-NEW-BEGIN (kept byte-identical with commands/fix-bug.md via test-contracts.sh)
+# Resolve default branch + fetch origin so the new worktree bases from current origin/<default>,
+# never a stale local default. If local <default> is behind origin AND clean, fast-forward.
+# If dirty, STOP — don't auto-stash or merge.
+ROOT="$(git rev-parse --show-toplevel)"
+LIB="$ROOT/.claude/hooks/lib/default-branch.sh"
+[ ! -f "$LIB" ] && LIB="$ROOT/hooks/lib/default-branch.sh"
+DEFAULT_BRANCH=$(bash "$LIB" 2>/dev/null) || DEFAULT_BRANCH="main"
+
+git fetch origin --quiet 2>/dev/null || echo "  ⚠ git fetch failed — proceeding with local refs"
+
+if git rev-parse --verify "origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
+  BEHIND=$(git rev-list --count "$DEFAULT_BRANCH..origin/$DEFAULT_BRANCH" 2>/dev/null || echo 0)
+  if [ "$BEHIND" -gt 0 ]; then
+    DIRTY=$(git status --porcelain 2>/dev/null | grep -v '^??' | wc -l | tr -d ' ')
+    CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+    if [ "$DIRTY" -gt 0 ]; then
+      echo "✗ Local '$DEFAULT_BRANCH' is $BEHIND commits behind origin, but working tree is dirty."
+      echo "  Commit or stash your changes, then re-run."
+      exit 1
+    elif [ "$CURRENT_BRANCH" = "$DEFAULT_BRANCH" ]; then
+      git pull --ff-only origin "$DEFAULT_BRANCH" || { echo "✗ git pull --ff-only failed (diverged?)"; exit 1; }
+      echo "✓ Updated local '$DEFAULT_BRANCH' from origin (was $BEHIND commits behind)"
+    else
+      echo "  ⚠ Local '$DEFAULT_BRANCH' is $BEHIND commits behind origin (you're on '$CURRENT_BRANCH', skipping auto-FF)"
+    fi
+  fi
+fi
+
+# Resolve worktree base. Prefer origin/<default>; fall back to local <default> if origin ref missing.
+BASE="origin/$DEFAULT_BRANCH"
+git rev-parse --verify "$BASE" >/dev/null 2>&1 || BASE="$DEFAULT_BRANCH"
+# DRIFT-PREFLIGHT-NEW-END
+
 if [ -d "$WORKTREE_PATH" ]; then
   echo "✓ Worktree exists - reusing $WORKTREE_PATH"
 elif git show-ref --quiet "refs/heads/feat/$FEATURE_NAME" 2>/dev/null; then
   git worktree add "$WORKTREE_PATH" "feat/$FEATURE_NAME"
   echo "✓ Created worktree for existing branch at $WORKTREE_PATH"
 else
-  git worktree add "$WORKTREE_PATH" -b "feat/$FEATURE_NAME"
-  echo "✓ Created new worktree at $WORKTREE_PATH"
+  git worktree add "$WORKTREE_PATH" -b "feat/$FEATURE_NAME" "$BASE"
+  echo "✓ Created new worktree at $WORKTREE_PATH (based on $BASE)"
 fi
 
 # Symlink environment files (not copy) so rotated secrets propagate and .env can't be accidentally committed

--- a/commands/new-feature.md
+++ b/commands/new-feature.md
@@ -46,15 +46,21 @@ fi
 - Surface drift on the parent default branch (advisory; no auto-FF from inside a worktree)
 
 ```bash
-# DRIFT-PREFLIGHT-ALREADY-BEGIN (kept byte-identical with commands/fix-bug.md via test-contracts.sh)
+# DRIFT-PREFLIGHT-ALREADY-BEGIN (byte-identical with commands/fix-bug.md — enforced by test-contracts.sh)
 ROOT="$(git rev-parse --show-toplevel)"
 LIB="$ROOT/.claude/hooks/lib/default-branch.sh"
 [ ! -f "$LIB" ] && LIB="$ROOT/hooks/lib/default-branch.sh"
 DEFAULT_BRANCH=$(bash "$LIB" 2>/dev/null) || DEFAULT_BRANCH="main"
 git fetch origin --quiet 2>/dev/null || true
-if git rev-parse --verify "origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
-  BEHIND=$(git rev-list --count "$DEFAULT_BRANCH..origin/$DEFAULT_BRANCH" 2>/dev/null || echo 0)
-  [ "$BEHIND" -gt 0 ] && echo "  ⚠ Parent '$DEFAULT_BRANCH' is $BEHIND commits behind origin (skipping auto-FF from worktree)"
+# Verify BOTH refs exist before rev-list — guards against exit-128 silently returning 0
+# when local <default> is missing (e.g., shallow/single-branch clone where origin/HEAD
+# was set to main but local main was never created).
+if git rev-parse --verify "$DEFAULT_BRANCH" >/dev/null 2>&1 \
+   && git rev-parse --verify "origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
+  BEHIND=$(git rev-list --count "$DEFAULT_BRANCH..origin/$DEFAULT_BRANCH" 2>/dev/null || echo "")
+  if [[ "$BEHIND" =~ ^[0-9]+$ ]] && [ "$BEHIND" -gt 0 ]; then
+    echo "  ⚠ Parent '$DEFAULT_BRANCH' is $BEHIND commits behind origin (skipping auto-FF from worktree)"
+  fi
 fi
 # DRIFT-PREFLIGHT-ALREADY-END
 ```
@@ -71,38 +77,56 @@ WORKTREE_PATH=".worktrees/$FEATURE_NAME"
 mkdir -p .worktrees
 grep -qxF '.worktrees/' .gitignore 2>/dev/null || echo '.worktrees/' >> .gitignore
 
-# DRIFT-PREFLIGHT-NEW-BEGIN (kept byte-identical with commands/fix-bug.md via test-contracts.sh)
-# Resolve default branch + fetch origin so the new worktree bases from current origin/<default>,
-# never a stale local default. If local <default> is behind origin AND clean, fast-forward.
-# If dirty, STOP — don't auto-stash or merge.
+# DRIFT-PREFLIGHT-NEW-BEGIN (byte-identical with commands/fix-bug.md — enforced by test-contracts.sh)
+# Resolve default branch, fetch origin (track success), and base the new worktree on
+# current origin/<default> when fetch succeeded — else local <default>. If local <default>
+# is behind origin AND we're on default with a clean tree, fast-forward; otherwise warn.
 ROOT="$(git rev-parse --show-toplevel)"
 LIB="$ROOT/.claude/hooks/lib/default-branch.sh"
 [ ! -f "$LIB" ] && LIB="$ROOT/hooks/lib/default-branch.sh"
 DEFAULT_BRANCH=$(bash "$LIB" 2>/dev/null) || DEFAULT_BRANCH="main"
 
-git fetch origin --quiet 2>/dev/null || echo "  ⚠ git fetch failed — proceeding with local refs"
+FETCH_OK=true
+git fetch origin --quiet 2>/dev/null || { FETCH_OK=false; echo "  ⚠ git fetch failed — proceeding with local refs (origin may be stale)"; }
 
-if git rev-parse --verify "origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
-  BEHIND=$(git rev-list --count "$DEFAULT_BRANCH..origin/$DEFAULT_BRANCH" 2>/dev/null || echo 0)
-  if [ "$BEHIND" -gt 0 ]; then
-    DIRTY=$(git status --porcelain 2>/dev/null | grep -v '^??' | wc -l | tr -d ' ')
+# Behind-check: only if BOTH local <default> and origin/<default> refs exist locally,
+# so git rev-list can't exit 128 and we can't silently report "0 behind" when the
+# local default branch doesn't exist (which would mask a real configuration problem).
+if git rev-parse --verify "$DEFAULT_BRANCH" >/dev/null 2>&1 \
+   && git rev-parse --verify "origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
+  BEHIND=$(git rev-list --count "$DEFAULT_BRANCH..origin/$DEFAULT_BRANCH" 2>/dev/null || echo "")
+  if [[ "$BEHIND" =~ ^[0-9]+$ ]] && [ "$BEHIND" -gt 0 ]; then
     CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
-    if [ "$DIRTY" -gt 0 ]; then
-      echo "✗ Local '$DEFAULT_BRANCH' is $BEHIND commits behind origin, but working tree is dirty."
-      echo "  Commit or stash your changes, then re-run."
-      exit 1
-    elif [ "$CURRENT_BRANCH" = "$DEFAULT_BRANCH" ]; then
-      git pull --ff-only origin "$DEFAULT_BRANCH" || { echo "✗ git pull --ff-only failed (diverged?)"; exit 1; }
+    if [ "$CURRENT_BRANCH" = "$DEFAULT_BRANCH" ]; then
+      # Only on default → eligible for FF. Dirty tree blocks (would lose changes).
+      # Under user's `set -o pipefail`, grep -v on a clean tree (no input) exits 1
+      # and DIRTY becomes empty — symmetric with BEHIND, validate before integer compare.
+      DIRTY=$(git status --porcelain 2>/dev/null | grep -v '^??' | wc -l | tr -d ' ' || echo 0)
+      [[ "$DIRTY" =~ ^[0-9]+$ ]] || DIRTY=0
+      if [ "$DIRTY" -gt 0 ]; then
+        echo "✗ Local '$DEFAULT_BRANCH' is $BEHIND commits behind origin, but working tree is dirty."
+        echo "  Commit or stash your changes, then re-run."
+        exit 1
+      fi
+      git pull --ff-only origin "$DEFAULT_BRANCH" || { echo "✗ git pull --ff-only failed — see git error above"; exit 1; }
       echo "✓ Updated local '$DEFAULT_BRANCH' from origin (was $BEHIND commits behind)"
     else
+      # Not on default → no FF attempted. Dirty changes on a feature branch are fine
+      # (they stay in this checkout; the new worktree gets its own working tree).
       echo "  ⚠ Local '$DEFAULT_BRANCH' is $BEHIND commits behind origin (you're on '$CURRENT_BRANCH', skipping auto-FF)"
     fi
   fi
 fi
 
-# Resolve worktree base. Prefer origin/<default>; fall back to local <default> if origin ref missing.
-BASE="origin/$DEFAULT_BRANCH"
-git rev-parse --verify "$BASE" >/dev/null 2>&1 || BASE="$DEFAULT_BRANCH"
+# Resolve worktree base. Prefer origin/<default> ONLY if fetch succeeded AND ref exists
+# locally. If fetch failed, prefer local <default> (don't trust the now-stale origin ref).
+if [ "$FETCH_OK" = "true" ] && git rev-parse --verify "origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
+  BASE="origin/$DEFAULT_BRANCH"
+elif git rev-parse --verify "$DEFAULT_BRANCH" >/dev/null 2>&1; then
+  BASE="$DEFAULT_BRANCH"
+else
+  BASE="HEAD"  # last-resort fallback — shouldn't happen; helper should have bailed
+fi
 # DRIFT-PREFLIGHT-NEW-END
 
 if [ -d "$WORKTREE_PATH" ]; then

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to claude-codex-forge.
 
 Closes the multi-developer staleness failure mode: local `main` silently 97 commits behind origin while Claude reads `CONTINUITY.md` as authoritative state and confidently cites already-merged PRs as "open." Worse, `/new-feature` and `/fix-bug` were creating worktrees from local `HEAD`, so feature branches got built on stale baselines. PR #1 of a multi-PR initiative; PR #2 (CONTINUITY.md split + per-developer state migration) is non-goals here.
 
-Council fired on the inline-vs-factored fork (5 advisors + chairman). Verdict: narrow Option C — factor only `hooks/lib/default-branch.{sh,ps1}` (the one piece with proven drift history), keep Pre-Flight inline in `commands/*.md`, simple-detect `gtimeout || timeout || skip` for macOS. Plan went through 4 review iterations (10 → 3 → 1 → 0 findings). Code review loop ran 2 iterations (4 P1 + 5 P2 → 1 P2 → CLEAN).
+Council fired on the inline-vs-factored fork (5 advisors + chairman). Verdict: narrow Option C — factor only `hooks/lib/default-branch.{sh,ps1}` (the one piece with proven drift history), keep Pre-Flight inline in `commands/*.md`, simple-detect `gtimeout || timeout || skip` for macOS. Plan went through 4 review iterations (10 → 3 → 1 → 0 findings). Code review loop ran **7 iterations** to genuine convergence (4 P1 + 5 P2 → 1 P2 → 1 P2 → 1 P2 → 1 P2 + 1 P3 → 1 P1 + 1 P2 → CLEAN). Per `rules/critical-rules.md` "NO BUGS LEFT BEHIND" — all reviewer findings fixed in-branch, no follow-up deferrals.
 
 - **`hooks/lib/default-branch.{sh,ps1}` (NEW)** — first-ever `hooks/lib/` directory. Detection chain: `git symbolic-ref refs/remotes/origin/HEAD` → local `main` → local `master` → bail (exit 1). Strict contract: branch name on stdout only, silent stderr, exit 0/1. Dual-mode (script-callable + sourceable) so consumer hooks can dot-source on Windows (avoids spawning `pwsh` from `powershell.exe` 5.1).
 - **`hooks/session-start.sh` + `.ps1`** — read `source` from stdin JSON; gate `git fetch origin` on `startup`/`resume` only (not `clear`/`compact`). Compute behind count vs `origin/<default>` after verifying BOTH refs exist (guards rev-list exit-128). Append a one-line drift warning to `additionalContext` when behind. SessionStart cannot block (exit 2 is advisory only — surfaces as warning string). PowerShell variant uses `Start-Job -ArgumentList $cwd -ScriptBlock { Set-Location -LiteralPath $dir; ... }` for PS 5.1 + emits `$LASTEXITCODE` on success stream so parent gates on actual fetch result, not just `Wait-Job` completion.
@@ -19,14 +19,24 @@ Council fired on the inline-vs-factored fork (5 advisors + chairman). Verdict: n
 - **`tests/template/run-all.sh` + `test-lint.sh`** — register the new fixtures + lib files so the canonical drivers actually invoke and parse-check them.
 - **`CLAUDE.md`** — File Structure now shows `hooks/lib/`; Template→Generated mapping has 2 new rows; SessionStart hook description calls out source-gating + the cannot-block constraint.
 
-Explicitly deferred (out of scope; reviewer-blessed):
+Reviewer findings fixed in-branch (per "NO BUGS LEFT BEHIND"):
 
-- **CONTINUITY.md split** — separating durable project facts from per-developer volatile state. PR #2 of this initiative.
-- **Master-default fixture for `check-state-updated.sh` migration** — real test gap, follow-up issue.
-- **Setup install-presence assertion** — real test gap, follow-up issue.
-- **Pre-existing `set -e + $((0+0))` exit-1 bug in `check-state-updated.sh`** — not introduced by this PR; flagged for separate `/fix-bug`.
-- **Audit-log breadcrumb on fetch failure** — chairman-deferred per council; PR #1 doesn't invent a logging side-channel.
+- **`set -e + $((0+0))` exit-1 bug** in `check-state-updated.sh` — pre-existing latent bug; removed `set -e` (every external call already has explicit `2>/dev/null` + `|| fallback`).
+- **Helper-bail silent fallback** at 6 sites — added breadcrumbs: stderr in `check-state-updated.{sh,ps1}` + `commands/*.md` Pre-Flight; appended to `additionalContext` in SessionStart hooks (the only path that reaches Claude on SessionStart since stderr-on-exit-0 goes to debug log only).
+- **`BASE="HEAD"` last-resort warning** in DRIFT-PREFLIGHT-NEW — explicit echo with short HEAD identifier asking user to verify intent.
+- **Dirty/diverged tree no longer blocks worktree creation** — `git worktree add` is independent of caller's checkout state, so dirty-tree + diverged-FF are warn-and-proceed (the worktree still bases from `origin/<default>` cleanly).
+- **Behind-check + auto-FF gated on `FETCH_OK`** in both NEW and ALREADY blocks — prevents reporting drift against stale `origin/*` refs after fetch failure, and prevents a second network call via `git pull`.
+- **`origin/HEAD` stale-rename caveat documented** in `hooks/lib/default-branch.sh` — Method 1 verifies the candidate has a corresponding `refs/remotes/origin/<name>` ref before returning, but a fully stale rename (where the retired remote-tracking ref also survives) requires user-side `git remote set-head origin --auto && git fetch --prune` to refresh the cache. Documented as a known limitation; no network-free heuristic has acceptable false-positive rates.
+- **Merge-base fallback chain** in `check-state-updated.{sh,ps1}` — prefer local `<default>` if it exists, else `origin/<default>` (handles single-branch clones), else `HEAD~10`.
+- **DIRTY pipefail asymmetry** — added regex guard symmetric with BEHIND; `[[ "$DIRTY" =~ ^[0-9]+$ ]] || DIRTY=0` plus trailing `|| echo 0` for users with `set -o pipefail`.
+- **Test gap fixtures added (8 new):** master-default fixture for `check-state-updated.sh` migration; both-`main`-and-`master` local fixture; install-presence assertion; cross-platform drift-warning string parity contract; `TIMEOUT_CMD` empty-path coverage; empty/unknown `source` value fixtures.
+- **Comment trims** — removed 3 ephemeral history references in `test-contracts.sh` (Codex anecdote, Council attribution, regression-string history) per comment-analyzer review.
+
+Explicitly out of scope (PR #2 / future work):
+
+- **CONTINUITY.md split** — separating durable project facts from per-developer volatile state.
 - **macOS without `gtimeout`/`timeout`** — accepts ~75s degraded-network stall (council-accepted; Maintainer dissent recorded).
+- **Audit-log breadcrumb infrastructure** — chairman-deferred per council; PR #1's stderr/additionalContext breadcrumbs satisfy the "non-silent failure" requirement without inventing a logging side-channel.
 
 Suite: 256/256 assertions across 7 bash suites pass (lint 20, fixtures 23, contracts 64, hooks 22, default-branch 16, session-start 11, setup 100). PowerShell parity tests skip on dev hosts without `pwsh`; CI must have it installed.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to claude-codex-forge.
 
+## 5.14 — 2026-04-27 · Drift hygiene — SessionStart `git fetch` + worktree from `origin/<default>`
+
+Closes the multi-developer staleness failure mode: local `main` silently 97 commits behind origin while Claude reads `CONTINUITY.md` as authoritative state and confidently cites already-merged PRs as "open." Worse, `/new-feature` and `/fix-bug` were creating worktrees from local `HEAD`, so feature branches got built on stale baselines. PR #1 of a multi-PR initiative; PR #2 (CONTINUITY.md split + per-developer state migration) is non-goals here.
+
+Council fired on the inline-vs-factored fork (5 advisors + chairman). Verdict: narrow Option C — factor only `hooks/lib/default-branch.{sh,ps1}` (the one piece with proven drift history), keep Pre-Flight inline in `commands/*.md`, simple-detect `gtimeout || timeout || skip` for macOS. Plan went through 4 review iterations (10 → 3 → 1 → 0 findings). Code review loop ran 2 iterations (4 P1 + 5 P2 → 1 P2 → CLEAN).
+
+- **`hooks/lib/default-branch.{sh,ps1}` (NEW)** — first-ever `hooks/lib/` directory. Detection chain: `git symbolic-ref refs/remotes/origin/HEAD` → local `main` → local `master` → bail (exit 1). Strict contract: branch name on stdout only, silent stderr, exit 0/1. Dual-mode (script-callable + sourceable) so consumer hooks can dot-source on Windows (avoids spawning `pwsh` from `powershell.exe` 5.1).
+- **`hooks/session-start.sh` + `.ps1`** — read `source` from stdin JSON; gate `git fetch origin` on `startup`/`resume` only (not `clear`/`compact`). Compute behind count vs `origin/<default>` after verifying BOTH refs exist (guards rev-list exit-128). Append a one-line drift warning to `additionalContext` when behind. SessionStart cannot block (exit 2 is advisory only — surfaces as warning string). PowerShell variant uses `Start-Job -ArgumentList $cwd -ScriptBlock { Set-Location -LiteralPath $dir; ... }` for PS 5.1 + emits `$LASTEXITCODE` on success stream so parent gates on actual fetch result, not just `Wait-Job` completion.
+- **`commands/new-feature.md` + `commands/fix-bug.md` Pre-Flight** — `# DRIFT-PREFLIGHT-{NEW,ALREADY}-{BEGIN,END}` marker pairs (bash comments inside fenced blocks; byte-identical contract enforced by `test-contracts.sh`). NEW block: track `FETCH_OK`, fetch + behind-check, fast-forward only when on default with clean tree, base worktree from `origin/<default>` (or local `<default>` if fetch failed, or last-resort `HEAD`). ALREADY block: smaller advisory warning when parent default is behind (no auto-FF from inside a worktree).
+- **`hooks/check-state-updated.sh:33` + `.ps1:39`** — replaced hardcoded `git merge-base main HEAD` with the lib helper. Bash uses `bash "$LIB"`; PowerShell dot-sources via `. $libPath`.
+- **`setup.sh` + `setup.ps1`** — install `hooks/lib/default-branch.{sh,ps1}` to `.claude/hooks/lib/` in downstream repos. Windows installs get BOTH the `.sh` and `.ps1` helpers because the `commands/*.md` Pre-Flight bash blocks invoke `bash "$LIB"` under Git Bash on Windows.
+- **`tests/template/test-default-branch.sh` (NEW, 16 assertions)** — 7 bash fixtures + 2 pwsh fixtures cover origin/HEAD set/unset, main/master fallback, no remote, neither-branch bail, detached HEAD.
+- **`tests/template/test-session-start.sh` (NEW, 11 assertions)** — source-gating (clear/compact skip fetch), behind detection, fetch-failure silent degrade (uses nonexistent local path so failure is immediate — no DNS stall on hosts without `gtimeout`/`timeout`), `additionalContext` < 2KB, valid JSON output.
+- **`tests/template/test-contracts.sh` (3 new contracts)** — no migrated-pattern `main` references in `hooks/*` outside `hooks/lib/` (scope-honest title); DRIFT-PREFLIGHT-NEW + ALREADY blocks byte-identical across `new-feature.md` and `fix-bug.md`.
+- **`tests/template/run-all.sh` + `test-lint.sh`** — register the new fixtures + lib files so the canonical drivers actually invoke and parse-check them.
+- **`CLAUDE.md`** — File Structure now shows `hooks/lib/`; Template→Generated mapping has 2 new rows; SessionStart hook description calls out source-gating + the cannot-block constraint.
+
+Explicitly deferred (out of scope; reviewer-blessed):
+
+- **CONTINUITY.md split** — separating durable project facts from per-developer volatile state. PR #2 of this initiative.
+- **Master-default fixture for `check-state-updated.sh` migration** — real test gap, follow-up issue.
+- **Setup install-presence assertion** — real test gap, follow-up issue.
+- **Pre-existing `set -e + $((0+0))` exit-1 bug in `check-state-updated.sh`** — not introduced by this PR; flagged for separate `/fix-bug`.
+- **Audit-log breadcrumb on fetch failure** — chairman-deferred per council; PR #1 doesn't invent a logging side-channel.
+- **macOS without `gtimeout`/`timeout`** — accepts ~75s degraded-network stall (council-accepted; Maintainer dissent recorded).
+
+Suite: 256/256 assertions across 7 bash suites pass (lint 20, fixtures 23, contracts 64, hooks 22, default-branch 16, session-start 11, setup 100). PowerShell parity tests skip on dev hosts without `pwsh`; CI must have it installed.
+
+**Existing installs need `./setup.sh -f`** to pick up `hooks/lib/`, the updated SessionStart hook, the migrated `check-state-updated.sh`, and the new Pre-Flight bash in `commands/*.md`.
+
 ## 5.13 — 2026-04-21 · Phase 4 task-DAG dispatch with file-conflict constraints
 
 Replaces the previous Phase 4 one-liner (`/superpowers:executing-plans`) with a structured dispatch plan. Field evidence: user's msai-v2 run (19-task backtest feature) had the orchestrator hand-rolling a 16-wave table from scratch because the template gave no parallelism guidance. Research agent + Codex second-opinion both identified **DAG with continuous dispatch** as the correct primitive over static file-overlap waves; Anthropic's multi-agent research post cited for the `default 3 / max 5` concurrency ceiling.

--- a/docs/reference/file-structure.md
+++ b/docs/reference/file-structure.md
@@ -28,7 +28,9 @@ your-project/
 ├── .claude/
 │   ├── settings.json                  # Permissions + Hooks (NOT MCP servers)
 │   ├── hooks/
-│   │   ├── session-start.sh           # SessionStart: silent context injection (.ps1 on Windows)
+│   │   ├── lib/
+│   │   │   └── default-branch.sh      # Shared helper: detect repo's default branch (.ps1 on Windows)
+│   │   ├── session-start.sh           # SessionStart: branch context + drift warning (.ps1 on Windows)
 │   │   ├── check-state-updated.sh     # Stop: enforce state updates (.ps1 on Windows)
 │   │   ├── check-bash-safety.sh       # PreToolUse: audit log + block dangerous patterns (.ps1 on Windows)
 │   │   ├── post-tool-format.sh        # PostToolUse: auto-format on save (.ps1 on Windows)

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -4,16 +4,16 @@ Hooks run automatically without manual intervention. Seven hook events configure
 
 ## Hooks (Run Automatically)
 
-| Hook             | Trigger                                   | What Happens                                                                    | Scope            |
-| ---------------- | ----------------------------------------- | ------------------------------------------------------------------------------- | ---------------- |
-| `SessionStart`   | New session, resume, `/clear`, compaction | Silently injects current branch via `additionalContext` (no visible clutter)    | Project          |
-| `Stop` (global)  | Claude finishes responding                | No-op pass-through (`exit 0`) — memory saving handled by PreCompact             | Global           |
-| `Stop` (project) | Claude finishes responding                | Checks CONTINUITY.md + CHANGELOG updated (script only, blocks if needed)        | Project          |
-| `PreToolUse`     | Before every Bash command                 | Logs commands to audit log, blocks dangerous patterns (pipe-to-shell, etc.)     | Project          |
-| `PostToolUse`    | After Edit/Write on code files            | Auto-formats with ruff (Python) / prettier (JS/TS/JSON/Markdown)                | Project          |
-| `PreCompact`     | Before context compression                | Reminds Claude to save learnings before context compression (blocks until done) | Global + Project |
-| `SubagentStop`   | Subagent finishes                         | Validates subagent output quality                                               | Project          |
-| `ConfigChange`   | Config file modified mid-session          | Logs changes to audit log; optional strict mode blocks deny-rule removals       | Project          |
+| Hook             | Trigger                                   | What Happens                                                                                                                                                                                             | Scope            |
+| ---------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `SessionStart`   | New session, resume, `/clear`, compaction | Silently injects branch + drift status via `additionalContext` (source-gated: `git fetch` + behind-warning runs only on `startup`/`resume`, not on `clear`/`compact`; cannot block — exit 2 is advisory) | Project          |
+| `Stop` (global)  | Claude finishes responding                | No-op pass-through (`exit 0`) — memory saving handled by PreCompact                                                                                                                                      | Global           |
+| `Stop` (project) | Claude finishes responding                | Checks CONTINUITY.md + CHANGELOG updated (script only, blocks if needed)                                                                                                                                 | Project          |
+| `PreToolUse`     | Before every Bash command                 | Logs commands to audit log, blocks dangerous patterns (pipe-to-shell, etc.)                                                                                                                              | Project          |
+| `PostToolUse`    | After Edit/Write on code files            | Auto-formats with ruff (Python) / prettier (JS/TS/JSON/Markdown)                                                                                                                                         | Project          |
+| `PreCompact`     | Before context compression                | Reminds Claude to save learnings before context compression (blocks until done)                                                                                                                          | Global + Project |
+| `SubagentStop`   | Subagent finishes                         | Validates subagent output quality                                                                                                                                                                        | Project          |
+| `ConfigChange`   | Config file modified mid-session          | Logs changes to audit log; optional strict mode blocks deny-rule removals                                                                                                                                | Project          |
 
 ## How Global and Project Hooks Interact
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -107,6 +107,40 @@ This is expected if you already have Claude Code set up. See [Upgrading](guides/
 
 5. **Restart Claude Code** — Hooks snapshot at session start
 
+## Drift detection messages — what they mean
+
+The SessionStart hook and `/new-feature` / `/fix-bug` Pre-Flight surface a few advisory messages tied to default-branch detection. None of them block (with one exception noted below); they're diagnostic hints.
+
+### `default-branch helper bailed; assuming 'main'`
+
+The helper at `.claude/hooks/lib/default-branch.{sh,ps1}` couldn't detect the default branch from cached refs. This is a fallback to `main` — wrong on `master`-default repos. Causes:
+
+- The repo has no `origin` remote AND neither `main` nor `master` exists locally.
+- The repo was cloned with `--no-checkout` and no branches have been created yet.
+
+**Fix:** ensure your repo has a real default branch checked out. If you just cloned, run `git checkout main` (or `master`).
+
+### `Parent '<branch>' is N commits behind origin`
+
+Drift warning — your local default branch is behind the remote. Run `git pull` to update it. New worktrees are still based from `origin/<default>` automatically; this warning just nudges you to catch up your main checkout when you next switch back.
+
+### `Could not resolve any default-branch ref; basing worktree on HEAD`
+
+Last-resort fallback inside `/new-feature` / `/fix-bug`. The new worktree was based on whatever you currently have checked out — possibly a feature branch, a tag, or a detached HEAD. Verify this is what you wanted; if not, delete the worktree (`git worktree remove .worktrees/<name>`) and re-run with the right base checked out.
+
+### Drift warnings show the wrong default branch (e.g., `master` after a remote rename)
+
+Detection uses the locally cached `origin/HEAD` symbolic ref, which is set at clone time and **not refreshed by `git fetch`** even after the upstream renames its default branch. Symptom: helper returns `master` after the remote was renamed `master → main`, and drift checks compare against the retired branch.
+
+**Fix:**
+
+```bash
+git remote set-head origin --auto
+git fetch --prune
+```
+
+This refreshes `refs/remotes/origin/HEAD` to the current upstream default and prunes the dead remote-tracking branch. After running, the helper returns the correct name on next invocation.
+
 ## Permissions still prompting?
 
 1. **Verify settings.json syntax:**

--- a/hooks/check-state-updated.ps1
+++ b/hooks/check-state-updated.ps1
@@ -42,12 +42,35 @@ $changelogModified = if ($changelogOutput) { ($changelogOutput | Measure-Object 
 $hookDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $libPath = Join-Path $hookDir "lib\default-branch.ps1"
 $defaultBranch = "main"  # fallback if helper or git fails
+$helperBailed = $false
 if (Test-Path $libPath) {
     . $libPath
     $detected = Get-DefaultBranch
-    if ($detected) { $defaultBranch = $detected }
+    if ($detected) {
+        $defaultBranch = $detected
+    } else {
+        $helperBailed = $true
+    }
+} else {
+    $helperBailed = $true
 }
-$branchBase = git merge-base $defaultBranch HEAD 2>$null
+# Helper-bail breadcrumb (stderr): mirrors the bash hook so silent fallback to "main"
+# is at least diagnosable on master-default Windows installs.
+if ($helperBailed) {
+    [Console]::Error.WriteLine("⚠ check-state-updated: default-branch helper bailed; assuming 'main'")
+}
+# Merge-base fallback chain: prefer local <default>; else origin/<default>
+# (single-branch clones may have only the remote-tracking ref); else HEAD~10.
+$branchBase = $null
+$null = git rev-parse --verify $defaultBranch 2>$null
+if ($LASTEXITCODE -eq 0) {
+    $branchBase = git merge-base $defaultBranch HEAD 2>$null
+} else {
+    $null = git rev-parse --verify "origin/$defaultBranch" 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        $branchBase = git merge-base "origin/$defaultBranch" HEAD 2>$null
+    }
+}
 if (-not $branchBase) { $branchBase = "HEAD~10" }
 
 # Count files changed on branch

--- a/hooks/check-state-updated.ps1
+++ b/hooks/check-state-updated.ps1
@@ -36,7 +36,18 @@ $changelogOutput = git status --porcelain docs/CHANGELOG.md 2>$null
 $changelogModified = if ($changelogOutput) { ($changelogOutput | Measure-Object -Line).Lines } else { 0 }
 
 # Get branch base for comparison
-$branchBase = git merge-base main HEAD 2>$null
+# Resolve repo default branch via the shared helper.
+# CRITICAL: dot-source (not subprocess) — Windows ships powershell.exe (5.1),
+# spawning pwsh (7+) would fail on stock Windows. Dot-source works in both.
+$hookDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$libPath = Join-Path $hookDir "lib\default-branch.ps1"
+$defaultBranch = "main"  # fallback if helper or git fails
+if (Test-Path $libPath) {
+    . $libPath
+    $detected = Get-DefaultBranch
+    if ($detected) { $defaultBranch = $detected }
+}
+$branchBase = git merge-base $defaultBranch HEAD 2>$null
 if (-not $branchBase) { $branchBase = "HEAD~10" }
 
 # Count files changed on branch

--- a/hooks/check-state-updated.sh
+++ b/hooks/check-state-updated.sh
@@ -9,7 +9,12 @@
 # Requirements: git
 # Optional: jq (recommended for robust JSON parsing, falls back to grep)
 
-set -e
+# Note: NOT using `set -e` here. Arithmetic expansions like `$((0 + 0))` (which fire
+# whenever both BRANCH_CHANGED and UNCOMMITTED_FILES are 0 — i.e., a clean session)
+# return exit status 1, which would silently exit the entire hook with status 1
+# under set -e. Every external command below that can fail is already guarded with
+# `2>/dev/null` and an explicit `|| fallback`, so set -e was redundant defense
+# but produced a real silent-failure under normal clean-session conditions.
 INPUT=$(cat)
 
 # Parse stop_hook_active (jq preferred, grep fallback)
@@ -34,8 +39,22 @@ CHANGELOG_MODIFIED=$(git status --porcelain docs/CHANGELOG.md 2>/dev/null | wc -
 # alongside this hook at .claude/hooks/lib/default-branch.sh in installed
 # downstream repos, and at hooks/lib/default-branch.sh in this template.
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-DEFAULT_BRANCH=$(bash "$HOOK_DIR/lib/default-branch.sh" 2>/dev/null) || DEFAULT_BRANCH="main"
-BRANCH_BASE=$(git merge-base "$DEFAULT_BRANCH" HEAD 2>/dev/null || echo "HEAD~10")
+# Helper-bail breadcrumb (stderr): if the helper exits non-zero, surface that the
+# fallback fired so the user/log has at least one signal. Without this, a master-default
+# repo whose helper bailed would silently use "main" → wrong BRANCH_BASE → spurious
+# CHANGELOG/CONTINUITY threshold gating, with no clue why.
+DEFAULT_BRANCH=$(bash "$HOOK_DIR/lib/default-branch.sh" 2>/dev/null) \
+    || { DEFAULT_BRANCH="main"; echo "⚠ check-state-updated: default-branch helper bailed; assuming 'main'" >&2; }
+# Merge-base fallback chain: prefer local <default> if it exists; else use
+# origin/<default> (single-branch clones may have only the remote-tracking ref);
+# else degrade to HEAD~10 (last-resort window for branch-change counting).
+if git rev-parse --verify "$DEFAULT_BRANCH" >/dev/null 2>&1; then
+    BRANCH_BASE=$(git merge-base "$DEFAULT_BRANCH" HEAD 2>/dev/null || echo "HEAD~10")
+elif git rev-parse --verify "origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
+    BRANCH_BASE=$(git merge-base "origin/$DEFAULT_BRANCH" HEAD 2>/dev/null || echo "HEAD~10")
+else
+    BRANCH_BASE="HEAD~10"
+fi
 BRANCH_CHANGED=$(git diff --name-only "$BRANCH_BASE" HEAD 2>/dev/null | wc -l | tr -d ' ')
 UNCOMMITTED_FILES=$(git diff --name-only 2>/dev/null | wc -l | tr -d ' ')
 TOTAL_CHANGED=$((BRANCH_CHANGED + UNCOMMITTED_FILES))

--- a/hooks/check-state-updated.sh
+++ b/hooks/check-state-updated.sh
@@ -29,8 +29,13 @@ UNCOMMITTED=$(git status --porcelain 2>/dev/null | grep -v '^??' | wc -l | tr -d
 CONTINUITY_MODIFIED=$(git status --porcelain CONTINUITY.md 2>/dev/null | wc -l | tr -d ' ')
 CHANGELOG_MODIFIED=$(git status --porcelain docs/CHANGELOG.md 2>/dev/null | wc -l | tr -d ' ')
 
-# Total files changed on branch (committed + uncommitted) vs main
-BRANCH_BASE=$(git merge-base main HEAD 2>/dev/null || echo "HEAD~10")
+# Total files changed on branch (committed + uncommitted) vs default branch
+# Resolve the repo's default branch via the shared helper. The helper lives
+# alongside this hook at .claude/hooks/lib/default-branch.sh in installed
+# downstream repos, and at hooks/lib/default-branch.sh in this template.
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+DEFAULT_BRANCH=$(bash "$HOOK_DIR/lib/default-branch.sh" 2>/dev/null) || DEFAULT_BRANCH="main"
+BRANCH_BASE=$(git merge-base "$DEFAULT_BRANCH" HEAD 2>/dev/null || echo "HEAD~10")
 BRANCH_CHANGED=$(git diff --name-only "$BRANCH_BASE" HEAD 2>/dev/null | wc -l | tr -d ' ')
 UNCOMMITTED_FILES=$(git diff --name-only 2>/dev/null | wc -l | tr -d ' ')
 TOTAL_CHANGED=$((BRANCH_CHANGED + UNCOMMITTED_FILES))

--- a/hooks/lib/default-branch.ps1
+++ b/hooks/lib/default-branch.ps1
@@ -1,0 +1,64 @@
+# hooks/lib/default-branch.ps1 — detect the repo's default branch.
+#
+# Detection chain (mirrors hooks/lib/default-branch.sh):
+#   1. git symbolic-ref refs/remotes/origin/HEAD --short
+#   2. fallback: local main exists
+#   3. fallback: local master exists
+#   4. bail (exit 1)
+#
+# Contract: branch name on stdout, exit 0/1, no stderr noise.
+#
+# Dual-mode (CRITICAL for cross-launcher safety):
+#   On Windows, the shipped Claude Code launcher is `powershell.exe` (5.1) per
+#   settings/settings-windows.template.json. Spawning `pwsh` (7+) from inside
+#   a 5.1 hook would fail on stock Windows because pwsh is not installed.
+#   Therefore consumer hooks MUST dot-source this file, not subprocess it:
+#     . "$libPath"
+#     $default = Get-DefaultBranch
+#   Dot-source works identically in 5.1 and 7+, no subprocess required.
+
+function Get-DefaultBranch {
+    $ErrorActionPreference = 'SilentlyContinue'
+
+    # Method 1: origin/HEAD symbolic ref
+    $ref = git symbolic-ref --short -q refs/remotes/origin/HEAD 2>$null
+    if ($LASTEXITCODE -eq 0 -and $ref) {
+        return ($ref -replace '^origin/', '')
+    }
+    # Method 2: local main exists
+    $null = git show-ref --verify --quiet refs/heads/main 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        return 'main'
+    }
+    # Method 3: local master exists
+    $null = git show-ref --verify --quiet refs/heads/master 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        return 'master'
+    }
+    return $null
+}
+
+# Dual-mode entry point. When invoked as a script (e.g. via `& "$libPath"` or
+# `pwsh -File "$libPath"`), call the function and emit the branch name on the
+# PowerShell success/stdout stream so BOTH in-PowerShell callers (`$x = & "$libPath"`)
+# AND bash subprocess callers (`$(pwsh -File ...)`) capture it correctly.
+# When dot-sourced, $MyInvocation.InvocationName is "." — the function is
+# defined and this block is skipped.
+#
+# IMPORTANT — choice of emission API:
+#   - Write-Host           → information stream; INVISIBLE to in-PS capture. Wrong.
+#   - [Console]::Out.Write → process stdout but NOT the PS success stream;
+#                            invisible to `& "$libPath"` capture. Wrong.
+#   - Write-Output         → success stream; captured by both in-PS callers AND
+#                            bash subprocess capture. Adds a trailing newline,
+#                            but `$(pwsh -File ...)` strips trailing whitespace,
+#                            so the bash side is fine. CORRECT.
+if ($MyInvocation.InvocationName -ne '.') {
+    $branch = Get-DefaultBranch
+    if ($branch) {
+        Write-Output $branch
+        exit 0
+    } else {
+        exit 1
+    }
+}

--- a/hooks/lib/default-branch.ps1
+++ b/hooks/lib/default-branch.ps1
@@ -20,10 +20,19 @@
 function Get-DefaultBranch {
     $ErrorActionPreference = 'SilentlyContinue'
 
-    # Method 1: origin/HEAD symbolic ref
+    # Method 1: origin/HEAD symbolic ref.
+    # Same stale-rename caveat as the bash version: verify origin/<candidate>
+    # actually exists before trusting Method 1's output.
     $ref = git symbolic-ref --short -q refs/remotes/origin/HEAD 2>$null
     if ($LASTEXITCODE -eq 0 -and $ref) {
-        return ($ref -replace '^origin/', '')
+        $candidate = $ref -replace '^origin/', ''
+        if ($candidate) {
+            $null = git show-ref --verify --quiet "refs/remotes/origin/$candidate" 2>$null
+            if ($LASTEXITCODE -eq 0) {
+                return $candidate
+            }
+            # Fall through: stale rename — origin/HEAD points at a retired branch.
+        }
     }
     # Method 2: local main exists
     $null = git show-ref --verify --quiet refs/heads/main 2>$null

--- a/hooks/lib/default-branch.sh
+++ b/hooks/lib/default-branch.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# hooks/lib/default-branch.sh — detect the repo's default branch.
+#
+# Detection chain (in order):
+#   1. git symbolic-ref refs/remotes/origin/HEAD --short  (e.g. "origin/main")
+#   2. fallback: local "main" exists
+#   3. fallback: local "master" exists
+#   4. bail (exit 1)
+#
+# Contract:
+#   - Branch name on stdout ONLY (no trailing noise)
+#   - Exit 0 on success, exit 1 on bail
+#   - All git stderr redirected to /dev/null (silent contract)
+#
+# Dual-mode:
+#   Script-call:  default_branch=$(bash "$ROOT/.claude/hooks/lib/default-branch.sh") || default_branch="main"
+#   Source-mode:  source "$ROOT/.claude/hooks/lib/default-branch.sh"
+#                 default_branch=$(detect_default_branch) || default_branch="main"
+
+detect_default_branch() {
+    # Method 1: origin/HEAD symbolic ref (~95% of repos)
+    local ref
+    if ref=$(git symbolic-ref --short -q refs/remotes/origin/HEAD 2>/dev/null); then
+        printf '%s' "${ref#origin/}"
+        return 0
+    fi
+    # Method 2: local main exists
+    if git show-ref --verify --quiet refs/heads/main 2>/dev/null; then
+        printf 'main'
+        return 0
+    fi
+    # Method 3: local master exists
+    if git show-ref --verify --quiet refs/heads/master 2>/dev/null; then
+        printf 'master'
+        return 0
+    fi
+    # Bail
+    return 1
+}
+
+# Dual-mode: when invoked as a script (not sourced), call the function and
+# exit with its status. When sourced, the function is defined and the script
+# returns immediately without exiting the caller.
+#
+# Idiom: BASH_SOURCE[0] equals $0 only when this file is the entry point
+# (i.e., invoked as `bash this-file.sh`). When sourced, BASH_SOURCE[0] is
+# this file's path while $0 is the parent script's name.
+if [[ "${BASH_SOURCE[0]:-}" == "${0}" ]]; then
+    detect_default_branch
+    exit $?
+fi

--- a/hooks/lib/default-branch.sh
+++ b/hooks/lib/default-branch.sh
@@ -16,13 +16,36 @@
 #   Script-call:  default_branch=$(bash "$ROOT/.claude/hooks/lib/default-branch.sh") || default_branch="main"
 #   Source-mode:  source "$ROOT/.claude/hooks/lib/default-branch.sh"
 #                 default_branch=$(detect_default_branch) || default_branch="main"
+#
+# KNOWN LIMITATION — stale-rename detection:
+#   Detection is based on locally cached refs. After the REMOTE default branch
+#   is renamed (e.g., master → main on the upstream), `git fetch` does not
+#   refresh `refs/remotes/origin/HEAD`, and the old remote-tracking branch
+#   (e.g., refs/remotes/origin/master) typically survives until pruned. In that
+#   state Method 1 below can return the retired branch name. The user-side fix:
+#       git remote set-head origin --auto
+#       git fetch --prune
+#   No network-free heuristic distinguishes "master is still the default" from
+#   "master was renamed to main and origin/main is now authoritative" with
+#   acceptable false-positive rates, so the helper trusts `origin/HEAD` as
+#   cached and documents the manual refresh as the canonical fix.
 
 detect_default_branch() {
-    # Method 1: origin/HEAD symbolic ref (~95% of repos)
-    local ref
+    # Method 1: origin/HEAD symbolic ref (~95% of repos).
+    # CAVEAT: origin/HEAD is locally cached and only refreshed by an explicit
+    # `git remote set-head origin -a` (or --auto). If the remote default was
+    # renamed and the cache is stale, origin/HEAD can point at a retired branch.
+    # Defense: verify the returned name has a corresponding remote-tracking ref
+    # (`refs/remotes/origin/<name>`); if not, fall through to Method 2/3 rather
+    # than returning a name that no longer resolves.
+    local ref candidate
     if ref=$(git symbolic-ref --short -q refs/remotes/origin/HEAD 2>/dev/null); then
-        printf '%s' "${ref#origin/}"
-        return 0
+        candidate="${ref#origin/}"
+        if [ -n "$candidate" ] && git show-ref --verify --quiet "refs/remotes/origin/$candidate" 2>/dev/null; then
+            printf '%s' "$candidate"
+            return 0
+        fi
+        # Fall through: origin/HEAD exists but its target ref doesn't (stale rename).
     fi
     # Method 2: local main exists
     if git show-ref --verify --quiet refs/heads/main 2>/dev/null; then

--- a/hooks/session-start.ps1
+++ b/hooks/session-start.ps1
@@ -1,5 +1,15 @@
-# SessionStart hook: silently inject git branch into Claude's context
-# Uses hookSpecificOutput.additionalContext for clean, non-visible injection
+# SessionStart hook: silently inject git context into Claude.
+# Source-gated: git fetch + behind-check ONLY on startup|resume.
+
+$ErrorActionPreference = 'SilentlyContinue'
+
+# Read stdin JSON to get the session source ('startup'|'resume'|'clear'|'compact').
+$inputJson = [Console]::In.ReadToEnd()
+$source = ""
+try {
+    $data = $inputJson | ConvertFrom-Json
+    if ($data.source) { $source = $data.source }
+} catch { $source = "" }
 
 try {
     $branch = git branch --show-current 2>$null
@@ -8,10 +18,49 @@ try {
     $branch = "unknown"
 }
 
+$context = "Current branch: $branch"
+
+if ($source -eq "startup" -or $source -eq "resume") {
+    # Dot-source (not subprocess) — works in both PowerShell 5.1 (powershell.exe)
+    # and 7 (pwsh). Spawning pwsh would fail on stock Windows.
+    $hookDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+    $libPath = Join-Path $hookDir "lib\default-branch.ps1"
+    $default = ""
+    if (Test-Path $libPath) {
+        . $libPath
+        $detected = Get-DefaultBranch
+        if ($detected) { $default = $detected }
+    }
+
+    if ($default) {
+        # Run fetch with a 5s job timeout (PowerShell-native, no coreutils dependency).
+        # CRITICAL: Start-Job's child runspace defaults its location to the user's
+        # home directory (PS 5.1) or the parent's $PWD only if -WorkingDirectory is
+        # passed (PS 6+). For 5.1 compatibility we capture $PWD outside and
+        # Set-Location inside the job block so git runs in the actual repo.
+        $cwd = (Get-Location).Path
+        $job = Start-Job -ArgumentList $cwd -ScriptBlock {
+            param($dir)
+            Set-Location -LiteralPath $dir
+            git fetch origin --quiet 2>$null
+        }
+        $completed = Wait-Job $job -Timeout 5
+        Receive-Job $job -ErrorAction SilentlyContinue | Out-Null
+        Remove-Job $job -Force -ErrorAction SilentlyContinue
+
+        if ($completed) {
+            $behind = git rev-list --count "$default..origin/$default" 2>$null
+            if ($behind -and $behind -match '^\d+$' -and [int]$behind -gt 0) {
+                $context = "$context (default branch '$default' is $behind commits behind origin — pull before starting work)"
+            }
+        }
+    }
+}
+
 $output = @{
     hookSpecificOutput = @{
-        hookEventName    = "SessionStart"
-        additionalContext = "Current branch: $branch"
+        hookEventName     = "SessionStart"
+        additionalContext = $context
     }
 } | ConvertTo-Json -Compress
 

--- a/hooks/session-start.ps1
+++ b/hooks/session-start.ps1
@@ -39,19 +39,32 @@ if ($source -eq "startup" -or $source -eq "resume") {
         # passed (PS 6+). For 5.1 compatibility we capture $PWD outside and
         # Set-Location inside the job block so git runs in the actual repo.
         $cwd = (Get-Location).Path
+        # Job emits the inner $LASTEXITCODE on the success stream so the parent
+        # can distinguish "fetch succeeded" from "fetch failed but completed in <5s".
+        # Without this gate, a fast-failing fetch (auth error, broken remote, host
+        # down) makes $completed truthy and we'd compute drift from stale origin/* refs.
         $job = Start-Job -ArgumentList $cwd -ScriptBlock {
             param($dir)
             Set-Location -LiteralPath $dir
             git fetch origin --quiet 2>$null
+            $LASTEXITCODE
         }
         $completed = Wait-Job $job -Timeout 5
-        Receive-Job $job -ErrorAction SilentlyContinue | Out-Null
+        $jobExit = if ($completed) { Receive-Job $job -ErrorAction SilentlyContinue } else { 1 }
         Remove-Job $job -Force -ErrorAction SilentlyContinue
 
-        if ($completed) {
-            $behind = git rev-list --count "$default..origin/$default" 2>$null
-            if ($behind -and $behind -match '^\d+$' -and [int]$behind -gt 0) {
-                $context = "$context (default branch '$default' is $behind commits behind origin — pull before starting work)"
+        if ($completed -and $jobExit -eq 0) {
+            # Verify BOTH refs exist before rev-list — guards against exit-128 silently
+            # reporting 0 behind when local <default> is missing.
+            $null = git rev-parse --verify "$default" 2>$null
+            $localOk = ($LASTEXITCODE -eq 0)
+            $null = git rev-parse --verify "origin/$default" 2>$null
+            $remoteOk = ($LASTEXITCODE -eq 0)
+            if ($localOk -and $remoteOk) {
+                $behind = git rev-list --count "$default..origin/$default" 2>$null
+                if ($behind -and $behind -match '^\d+$' -and [int]$behind -gt 0) {
+                    $context = "$context (default branch '$default' is $behind commits behind origin — pull before starting work)"
+                }
             }
         }
     }

--- a/hooks/session-start.ps1
+++ b/hooks/session-start.ps1
@@ -32,6 +32,12 @@ if ($source -eq "startup" -or $source -eq "resume") {
         if ($detected) { $default = $detected }
     }
 
+    # Helper-bail breadcrumb (mirrors session-start.sh): when default is empty,
+    # append to additionalContext so Claude sees that drift detection skipped.
+    if (-not $default) {
+        $context = "$context (drift check skipped — default-branch helper bailed)"
+    }
+
     if ($default) {
         # Run fetch with a 5s job timeout (PowerShell-native, no coreutils dependency).
         # CRITICAL: Start-Job's child runspace defaults its location to the user's

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -27,6 +27,13 @@ if [[ "$SOURCE" == "startup" || "$SOURCE" == "resume" ]]; then
         DEFAULT=""
     fi
 
+    # Helper-bail breadcrumb: append to additionalContext so Claude sees that drift
+    # detection skipped due to helper failure (the only signal path on SessionStart —
+    # stderr at exit 0 goes to debug log only, not to user or Claude).
+    if [[ -z "$DEFAULT" ]]; then
+        CONTEXT="$CONTEXT (drift check skipped — default-branch helper bailed)"
+    fi
+
     if [[ -n "$DEFAULT" ]]; then
         # Pick a timeout binary if available (gtimeout for macOS+brew, timeout for Linux/CI).
         # If neither exists, skip the cap — git's connect timeout (~75s) is the upper bound.

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -1,16 +1,55 @@
 #!/bin/bash
-# SessionStart hook: silently inject git branch into Claude's context
-# Uses hookSpecificOutput.additionalContext for clean, non-visible injection
+# SessionStart hook: silently inject git context into Claude.
+# Source-gated: git fetch + behind-check ONLY on startup|resume.
+# Drift surfaced via additionalContext (SessionStart cannot block — exit 2 is advisory).
+
+set -u
+
+# Read source from stdin JSON; degrade if jq missing or input malformed.
+INPUT=$(cat 2>/dev/null)
+if command -v jq &>/dev/null; then
+    SOURCE=$(printf '%s' "$INPUT" | jq -r '.source // ""' 2>/dev/null)
+else
+    SOURCE=$(printf '%s' "$INPUT" | grep -o '"source"[[:space:]]*:[[:space:]]*"[^"]*"' \
+        | head -1 | sed -E 's/.*:[[:space:]]*"([^"]*)"$/\1/')
+fi
 
 BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+CONTEXT="Current branch: $BRANCH"
 
-# JSON-escape the branch name (handle quotes, backslashes)
-if command -v jq &> /dev/null; then
-    jq -n --arg branch "$BRANCH" \
-      '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":("Current branch: " + $branch)}}'
+# Fetch + drift check ONLY on startup or resume (not clear/compact).
+if [[ "$SOURCE" == "startup" || "$SOURCE" == "resume" ]]; then
+    HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+    LIB="$HOOK_DIR/lib/default-branch.sh"
+    if [[ -f "$LIB" ]]; then
+        DEFAULT=$(bash "$LIB" 2>/dev/null) || DEFAULT=""
+    else
+        DEFAULT=""
+    fi
+
+    if [[ -n "$DEFAULT" ]]; then
+        # Pick a timeout binary if available (gtimeout for macOS+brew, timeout for Linux/CI).
+        # If neither exists, skip the cap — git's connect timeout (~75s) is the upper bound.
+        TIMEOUT_CMD=""
+        if command -v gtimeout &>/dev/null; then TIMEOUT_CMD="gtimeout 5"
+        elif command -v timeout &>/dev/null; then TIMEOUT_CMD="timeout 5"
+        fi
+
+        if $TIMEOUT_CMD git fetch origin --quiet 2>/dev/null; then
+            BEHIND=$(git rev-list --count "$DEFAULT..origin/$DEFAULT" 2>/dev/null) || BEHIND=""
+            if [[ -n "$BEHIND" && "$BEHIND" =~ ^[0-9]+$ && "$BEHIND" -gt 0 ]]; then
+                CONTEXT="$CONTEXT (default branch '$DEFAULT' is $BEHIND commits behind origin — pull before starting work)"
+            fi
+        fi
+    fi
+fi
+
+# Emit JSON
+if command -v jq &>/dev/null; then
+    jq -n --arg ctx "$CONTEXT" \
+      '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":$ctx}}'
 else
-    # Fallback: escape JSON-special characters
-    SAFE_BRANCH=$(printf '%s' "$BRANCH" | sed 's/\\/\\\\/g; s/"/\\"/g')
-    printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"Current branch: %s"}}\n' "$SAFE_BRANCH"
+    SAFE_CTX=$(printf '%s' "$CONTEXT" | sed 's/\\/\\\\/g; s/"/\\"/g')
+    printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "$SAFE_CTX"
 fi
 exit 0

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -36,9 +36,15 @@ if [[ "$SOURCE" == "startup" || "$SOURCE" == "resume" ]]; then
         fi
 
         if $TIMEOUT_CMD git fetch origin --quiet 2>/dev/null; then
-            BEHIND=$(git rev-list --count "$DEFAULT..origin/$DEFAULT" 2>/dev/null) || BEHIND=""
-            if [[ -n "$BEHIND" && "$BEHIND" =~ ^[0-9]+$ && "$BEHIND" -gt 0 ]]; then
-                CONTEXT="$CONTEXT (default branch '$DEFAULT' is $BEHIND commits behind origin — pull before starting work)"
+            # Verify BOTH refs exist before rev-list — without this, a missing local
+            # <default> branch (e.g., shallow/single-branch clone) makes rev-list exit
+            # 128 with empty stdout, silently masking a real config problem as "0 behind".
+            if git rev-parse --verify "$DEFAULT" >/dev/null 2>&1 \
+               && git rev-parse --verify "origin/$DEFAULT" >/dev/null 2>&1; then
+                BEHIND=$(git rev-list --count "$DEFAULT..origin/$DEFAULT" 2>/dev/null) || BEHIND=""
+                if [[ -n "$BEHIND" && "$BEHIND" =~ ^[0-9]+$ && "$BEHIND" -gt 0 ]]; then
+                    CONTEXT="$CONTEXT (default branch '$DEFAULT' is $BEHIND commits behind origin — pull before starting work)"
+                fi
             fi
         fi
     fi

--- a/setup.ps1
+++ b/setup.ps1
@@ -565,6 +565,11 @@ Copy-TemplateFile (Join-Path (Join-Path $ScriptDir "hooks") "check-config-change
 Copy-TemplateFile (Join-Path (Join-Path $ScriptDir "hooks") "check-bash-safety.ps1") ".claude\hooks\check-bash-safety.ps1" ".claude\hooks\check-bash-safety.ps1"
 Copy-TemplateFile (Join-Path (Join-Path $ScriptDir "hooks") "check-workflow-gates.ps1") ".claude\hooks\check-workflow-gates.ps1" ".claude\hooks\check-workflow-gates.ps1"
 
+# Hook lib helpers
+$libDir = ".claude\hooks\lib"
+if (-not (Test-Path $libDir)) { New-Item -ItemType Directory -Path $libDir -Force | Out-Null }
+Copy-TemplateFile (Join-Path (Join-Path (Join-Path $ScriptDir "hooks") "lib") "default-branch.ps1") "$libDir\default-branch.ps1" "$libDir\default-branch.ps1 (default-branch detection helper)"
+
 # Agents
 Copy-TemplateFile (Join-Path (Join-Path $ScriptDir "agents") "verify-app.md") ".claude\agents\verify-app.md" ".claude\agents\verify-app.md"
 Copy-TemplateFile (Join-Path (Join-Path $ScriptDir "agents") "verify-e2e.md") ".claude\agents\verify-e2e.md" ".claude\agents\verify-e2e.md"

--- a/setup.ps1
+++ b/setup.ps1
@@ -566,9 +566,16 @@ Copy-TemplateFile (Join-Path (Join-Path $ScriptDir "hooks") "check-bash-safety.p
 Copy-TemplateFile (Join-Path (Join-Path $ScriptDir "hooks") "check-workflow-gates.ps1") ".claude\hooks\check-workflow-gates.ps1" ".claude\hooks\check-workflow-gates.ps1"
 
 # Hook lib helpers
+# Install BOTH the .ps1 and .sh helpers on Windows because:
+#   - .ps1 is dot-sourced by the PowerShell hooks (session-start.ps1, check-state-updated.ps1)
+#   - .sh is invoked via `bash "$LIB"` from the bash code blocks in commands/new-feature.md
+#     and commands/fix-bug.md. Those blocks run under Git Bash on Windows and would silently
+#     fall back to DEFAULT_BRANCH=main if the .sh file weren't installed — breaking
+#     master-default repos and any non-main default downstream.
 $libDir = ".claude\hooks\lib"
 if (-not (Test-Path $libDir)) { New-Item -ItemType Directory -Path $libDir -Force | Out-Null }
-Copy-TemplateFile (Join-Path (Join-Path (Join-Path $ScriptDir "hooks") "lib") "default-branch.ps1") "$libDir\default-branch.ps1" "$libDir\default-branch.ps1 (default-branch detection helper)"
+Copy-TemplateFile (Join-Path (Join-Path (Join-Path $ScriptDir "hooks") "lib") "default-branch.ps1") "$libDir\default-branch.ps1" "$libDir\default-branch.ps1 (default-branch detection helper, PowerShell)"
+Copy-TemplateFile (Join-Path (Join-Path (Join-Path $ScriptDir "hooks") "lib") "default-branch.sh") "$libDir\default-branch.sh" "$libDir\default-branch.sh (default-branch detection helper, bash — used by commands/*.md preflight)"
 
 # Agents
 Copy-TemplateFile (Join-Path (Join-Path $ScriptDir "agents") "verify-app.md") ".claude\agents\verify-app.md" ".claude\agents\verify-app.md"

--- a/setup.sh
+++ b/setup.sh
@@ -534,6 +534,12 @@ copy_file "$SCRIPT_DIR/hooks/pre-compact-memory.sh" ".claude/hooks/pre-compact-m
 copy_file "$SCRIPT_DIR/hooks/check-config-change.sh" ".claude/hooks/check-config-change.sh" ".claude/hooks/check-config-change.sh"
 copy_file "$SCRIPT_DIR/hooks/check-bash-safety.sh" ".claude/hooks/check-bash-safety.sh" ".claude/hooks/check-bash-safety.sh"
 copy_file "$SCRIPT_DIR/hooks/check-workflow-gates.sh" ".claude/hooks/check-workflow-gates.sh" ".claude/hooks/check-workflow-gates.sh"
+
+# Hook lib helpers (shared across hooks and command Pre-Flight blocks)
+mkdir -p .claude/hooks/lib
+copy_file "$SCRIPT_DIR/hooks/lib/default-branch.sh" ".claude/hooks/lib/default-branch.sh" ".claude/hooks/lib/default-branch.sh (default-branch detection helper)"
+chmod +x .claude/hooks/lib/default-branch.sh 2>/dev/null || true
+
 chmod +x .claude/hooks/session-start.sh 2>/dev/null || true
 chmod +x .claude/hooks/check-state-updated.sh 2>/dev/null || true
 chmod +x .claude/hooks/post-tool-format.sh 2>/dev/null || true

--- a/tests/template/run-all.sh
+++ b/tests/template/run-all.sh
@@ -20,6 +20,8 @@ SUITES=(
     "$REPO_ROOT/tests/template/test-fixtures.sh"
     "$REPO_ROOT/tests/template/test-contracts.sh"
     "$REPO_ROOT/tests/template/test-hooks.sh"
+    "$REPO_ROOT/tests/template/test-default-branch.sh"
+    "$REPO_ROOT/tests/template/test-session-start.sh"
     "$REPO_ROOT/tests/template/test-setup.sh"
 )
 

--- a/tests/template/test-contracts.sh
+++ b/tests/template/test-contracts.sh
@@ -4,9 +4,9 @@
 # Catches stringly-typed contracts that span files: e.g., the verify-e2e
 # agent's response header defines VERDICT values, and the callers in
 # commands/new-feature.md and commands/fix-bug.md must branch on those
-# same values. Codex called deferring this "false economy" because the
-# bug is exactly the kind of regression that's easy to ship and costly
-# to catch.
+# same values. These are exactly the regressions that are easy to ship
+# and costly to catch in code review — a contract test makes the link
+# between cooperating files explicit and machine-verifiable.
 #
 # Run from repo root:  bash tests/template/test-contracts.sh
 
@@ -121,9 +121,9 @@ assert_contains "$FB" ".claude/playwright-dir" \
 # ---------------------------------------------------------------------------
 # Contract 6: E2E verified gate — canonical marker vocabulary
 #
-# The Council (minority report from Contrarian + Maintainer) flagged that
-# the "E2E verified" gate string is referenced in multiple places and will
-# drift if not contracted. This asserts all references use the same stem.
+# The "E2E verified" gate string is the single source of truth for the
+# workflow-gates hook regex. It's referenced in command checklists, rules
+# docs, and the hook itself — contract these together so they can't drift.
 # ---------------------------------------------------------------------------
 start_test "E2E verified gate — canonical marker across files"
 
@@ -151,17 +151,17 @@ assert_contains "$REPO_ROOT/commands/new-feature.md" "$CANONICAL_NA" \
 assert_contains "$REPO_ROOT/commands/fix-bug.md" "$CANONICAL_NA" \
     "fix-bug.md uses canonical N/A form"
 assert_contains "$REPO_ROOT/rules/testing.md" "$CANONICAL_NA" \
-    "rules/testing.md uses canonical N/A form (was 'E2E use cases tested' before canonicalization)"
+    "rules/testing.md uses canonical N/A form"
 
 # rules/testing.md must be the canonical documentation — hook stderr
 # points there, so the anchor must exist
 assert_contains "$REPO_ROOT/rules/testing.md" "Canonical E2E gate vocabulary" \
     "rules/testing.md has the Canonical E2E gate vocabulary section"
 
-# Regression: the old drifting string "E2E use cases tested" must NOT appear
-# anywhere as a marker (it's been replaced with "E2E verified")
+# Negative assertion: only "E2E verified" is a valid gate marker — no other
+# variant string should function as one anywhere in the project.
 assert_not_contains "$REPO_ROOT/rules/testing.md" 'E2E use cases tested — N/A' \
-    "rules/testing.md no longer uses the old 'E2E use cases tested' N/A form"
+    "rules/testing.md uses only the canonical 'E2E verified' marker"
 
 # ---------------------------------------------------------------------------
 # Contract 5: runtime preflight parity — both installers check the same files
@@ -316,6 +316,38 @@ else
     fail "DRIFT-PREFLIGHT-ALREADY blocks differ between new-feature.md and fix-bug.md"
     diff <(printf '%s' "$NF_AL") <(printf '%s' "$FB_AL") | head -10
 fi
+
+# ---------------------------------------------------------------------------
+# Contract: session-start drift-warning string parity — .sh ↔ .ps1
+#
+# The drift warning injected into additionalContext is independently composed
+# in session-start.sh and session-start.ps1. If the canonical phrasing
+# diverges, Windows users see a different warning than macOS/Linux users —
+# a silent cross-platform inconsistency. This contract asserts both files
+# share the same canonical substrings so the user experience is identical.
+# ---------------------------------------------------------------------------
+start_test "session-start drift-warning string parity — .sh ↔ .ps1"
+
+SS_SH="$REPO_ROOT/hooks/session-start.sh"
+SS_PS1="$REPO_ROOT/hooks/session-start.ps1"
+
+for f in "$SS_SH" "$SS_PS1"; do
+    assert_file_exists "$f" "file exists: $f"
+done
+
+# Both files must contain the trailing structural phrase that ends the warning.
+PULL_PHRASE="pull before starting work"
+assert_contains "$SS_SH"  "$PULL_PHRASE" \
+    "session-start.sh contains '$PULL_PHRASE'"
+assert_contains "$SS_PS1" "$PULL_PHRASE" \
+    "session-start.ps1 contains '$PULL_PHRASE'"
+
+# Both files must contain the em-dash + structural phrase that precedes the count.
+BEHIND_PHRASE="commits behind origin —"
+assert_contains "$SS_SH"  "$BEHIND_PHRASE" \
+    "session-start.sh contains '$BEHIND_PHRASE'"
+assert_contains "$SS_PS1" "$BEHIND_PHRASE" \
+    "session-start.ps1 contains '$BEHIND_PHRASE'"
 
 # ---------------------------------------------------------------------------
 # Report

--- a/tests/template/test-contracts.sh
+++ b/tests/template/test-contracts.sh
@@ -250,6 +250,64 @@ assert_contains "$REPO_ROOT/setup.ps1" "__PLAYWRIGHT_DIR__" \
     "setup.ps1 references placeholder"
 
 # ---------------------------------------------------------------------------
+# Contract: no hardcoded "main" in hooks/* outside the lib helper
+# ---------------------------------------------------------------------------
+start_test "no hardcoded 'main' in hooks/* (outside hooks/lib/)"
+
+HARDCODED=$(grep -rE "merge-base[[:space:]]+main[[:space:]]+HEAD|origin/main[^A-Za-z_]" \
+    "$REPO_ROOT/hooks/" 2>/dev/null \
+    | grep -v "^$REPO_ROOT/hooks/lib/" || true)
+
+if [[ -z "$HARDCODED" ]]; then
+    pass "no hardcoded 'main' references in hooks/* (outside lib/)"
+else
+    while IFS= read -r line; do
+        fail "hardcoded 'main' detected: $line"
+    done <<< "$HARDCODED"
+fi
+
+# ---------------------------------------------------------------------------
+# Contract: DRIFT-PREFLIGHT-NEW blocks in new-feature.md and fix-bug.md byte-identical
+# ---------------------------------------------------------------------------
+start_test "DRIFT-PREFLIGHT-NEW blocks byte-identical across new-feature.md and fix-bug.md"
+
+NF="$REPO_ROOT/commands/new-feature.md"
+FB="$REPO_ROOT/commands/fix-bug.md"
+
+for f in "$NF" "$FB"; do
+    [ -f "$f" ] || { fail "missing command file: $f"; }
+done
+
+NF_NEW=$(sed -n '/^# DRIFT-PREFLIGHT-NEW-BEGIN/,/^# DRIFT-PREFLIGHT-NEW-END/p' "$NF")
+FB_NEW=$(sed -n '/^# DRIFT-PREFLIGHT-NEW-BEGIN/,/^# DRIFT-PREFLIGHT-NEW-END/p' "$FB")
+
+if [[ -z "$NF_NEW" ]] || [[ -z "$FB_NEW" ]]; then
+    fail "DRIFT-PREFLIGHT-NEW markers missing from one or both command files"
+elif [[ "$NF_NEW" == "$FB_NEW" ]]; then
+    pass "DRIFT-PREFLIGHT-NEW blocks byte-identical"
+else
+    fail "DRIFT-PREFLIGHT-NEW blocks differ between new-feature.md and fix-bug.md"
+    diff <(printf '%s' "$NF_NEW") <(printf '%s' "$FB_NEW") | head -10
+fi
+
+# ---------------------------------------------------------------------------
+# Contract: DRIFT-PREFLIGHT-ALREADY blocks in new-feature.md and fix-bug.md byte-identical
+# ---------------------------------------------------------------------------
+start_test "DRIFT-PREFLIGHT-ALREADY blocks byte-identical across new-feature.md and fix-bug.md"
+
+NF_AL=$(sed -n '/^# DRIFT-PREFLIGHT-ALREADY-BEGIN/,/^# DRIFT-PREFLIGHT-ALREADY-END/p' "$NF")
+FB_AL=$(sed -n '/^# DRIFT-PREFLIGHT-ALREADY-BEGIN/,/^# DRIFT-PREFLIGHT-ALREADY-END/p' "$FB")
+
+if [[ -z "$NF_AL" ]] || [[ -z "$FB_AL" ]]; then
+    fail "DRIFT-PREFLIGHT-ALREADY markers missing from one or both command files"
+elif [[ "$NF_AL" == "$FB_AL" ]]; then
+    pass "DRIFT-PREFLIGHT-ALREADY blocks byte-identical"
+else
+    fail "DRIFT-PREFLIGHT-ALREADY blocks differ between new-feature.md and fix-bug.md"
+    diff <(printf '%s' "$NF_AL") <(printf '%s' "$FB_AL") | head -10
+fi
+
+# ---------------------------------------------------------------------------
 # Report
 # ---------------------------------------------------------------------------
 report "test-contracts.sh"

--- a/tests/template/test-contracts.sh
+++ b/tests/template/test-contracts.sh
@@ -250,19 +250,29 @@ assert_contains "$REPO_ROOT/setup.ps1" "__PLAYWRIGHT_DIR__" \
     "setup.ps1 references placeholder"
 
 # ---------------------------------------------------------------------------
-# Contract: no hardcoded "main" in hooks/* outside the lib helper
+# Contract: no migrated-pattern 'main' references in hooks/* outside the lib helper
+#
+# SCOPE: this catches ONLY the specific patterns drift-hygiene PR #1 migrated:
+#   - `git merge-base main HEAD` (the original hardcoded form in check-state-updated)
+#   - `origin/main` referenced as a literal default
+#
+# It intentionally does NOT catch every possible 'main' reference — e.g., the
+# `git merge-base HEAD main` ordering used elsewhere in hooks/* is OUT OF SCOPE
+# for PR #1 (different reverse-merge-base computation, different consumer). If a
+# future PR migrates more hooks to the helper, tighten this regex (or split into
+# per-pattern contracts) at that time.
 # ---------------------------------------------------------------------------
-start_test "no hardcoded 'main' in hooks/* (outside hooks/lib/)"
+start_test "no migrated-pattern 'main' references in hooks/* (outside hooks/lib/)"
 
 HARDCODED=$(grep -rE "merge-base[[:space:]]+main[[:space:]]+HEAD|origin/main[^A-Za-z_]" \
     "$REPO_ROOT/hooks/" 2>/dev/null \
     | grep -v "^$REPO_ROOT/hooks/lib/" || true)
 
 if [[ -z "$HARDCODED" ]]; then
-    pass "no hardcoded 'main' references in hooks/* (outside lib/)"
+    pass "no migrated-pattern 'main' references in hooks/* (outside lib/)"
 else
     while IFS= read -r line; do
-        fail "hardcoded 'main' detected: $line"
+        fail "migrated-pattern 'main' detected (should use default-branch helper): $line"
     done <<< "$HARDCODED"
 fi
 

--- a/tests/template/test-default-branch.sh
+++ b/tests/template/test-default-branch.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# tests/template/test-default-branch.sh — fixture tests for hooks/lib/default-branch.{sh,ps1}.
+#
+# Verifies the strict contract:
+#   - Branch name on stdout (only)
+#   - Exit 0 on success, exit 1 on bail
+#   - No stderr noise on any path
+#
+# Run from repo root:  bash tests/template/test-default-branch.sh
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+# shellcheck source=lib.sh
+source "$REPO_ROOT/tests/template/lib.sh"
+
+init_counters
+
+LIB_SH="$REPO_ROOT/hooks/lib/default-branch.sh"
+LIB_PS="$REPO_ROOT/hooks/lib/default-branch.ps1"
+
+# ---------------------------------------------------------------------------
+# Fixture helper: build a scratch git repo with the requested shape, run the
+# helper, capture stdout + exit code + stderr length.
+#
+# scratch_branches: space-separated list, first one is checked-out
+# scratch_remote:   "yes" to add origin remote, "no" to skip
+# scratch_origin_head: branch name to set as origin/HEAD, or "" to skip
+# scratch_detached: "yes" to detach HEAD after setup
+# ---------------------------------------------------------------------------
+build_fixture() {
+    local scratch="$1" branches="$2" remote="$3" origin_head="$4" detached="$5"
+    mkdir -p "$scratch"
+    (
+        cd "$scratch" || exit 1
+        git init -q
+        git config user.email t@t && git config user.name t
+        local first=""
+        for b in $branches; do
+            if [[ -z "$first" ]]; then
+                git checkout -q -b "$b"
+                first="$b"
+                git commit --allow-empty -q -m "init"
+            else
+                git branch -q "$b" "$first"
+            fi
+        done
+        if [[ "$remote" == "yes" ]]; then
+            local fake_remote="$scratch.remote.git"
+            git init -q --bare "$fake_remote"
+            git remote add origin "$fake_remote"
+            git push -q origin "$first" 2>/dev/null || true
+            if [[ -n "$origin_head" ]]; then
+                git symbolic-ref refs/remotes/origin/HEAD "refs/remotes/origin/$origin_head" 2>/dev/null
+            fi
+        fi
+        if [[ "$detached" == "yes" ]]; then
+            git checkout -q --detach
+        fi
+    )
+}
+
+run_helper_sh() {
+    local scratch="$1"
+    (cd "$scratch" && bash "$LIB_SH") > "$scratch/.out" 2> "$scratch/.err"
+    echo "$?"
+}
+
+# ---------------------------------------------------------------------------
+# Fixture 1: origin/HEAD set to main → returns "main", exit 0
+# ---------------------------------------------------------------------------
+start_test "origin/HEAD = main → returns main, exit 0"
+S1=$(scratch_dir)
+build_fixture "$S1" "main" "yes" "main" "no"
+EXIT=$(run_helper_sh "$S1")
+assert_equals "$EXIT" "0" "exit code 0"
+assert_equals "$(cat "$S1/.out")" "main" "stdout = 'main'"
+assert_equals "$(wc -c < "$S1/.err" | tr -d ' ')" "0" "stderr is empty"
+
+# ---------------------------------------------------------------------------
+# Fixture 2: origin/HEAD set to master → returns "master", exit 0
+# ---------------------------------------------------------------------------
+start_test "origin/HEAD = master → returns master, exit 0"
+S2=$(scratch_dir)
+build_fixture "$S2" "master" "yes" "master" "no"
+EXIT=$(run_helper_sh "$S2")
+assert_equals "$EXIT" "0" "exit code 0"
+assert_equals "$(cat "$S2/.out")" "master" "stdout = 'master'"
+
+# ---------------------------------------------------------------------------
+# Fixture 3: origin/HEAD unset + main exists locally → returns "main", exit 0
+# ---------------------------------------------------------------------------
+start_test "origin/HEAD unset + main local → returns main"
+S3=$(scratch_dir)
+build_fixture "$S3" "main" "yes" "" "no"
+EXIT=$(run_helper_sh "$S3")
+assert_equals "$EXIT" "0" "exit code 0"
+assert_equals "$(cat "$S3/.out")" "main" "stdout = 'main'"
+
+# ---------------------------------------------------------------------------
+# Fixture 4: origin/HEAD unset + only master exists → returns "master"
+# ---------------------------------------------------------------------------
+start_test "origin/HEAD unset + master local → returns master"
+S4=$(scratch_dir)
+build_fixture "$S4" "master" "yes" "" "no"
+EXIT=$(run_helper_sh "$S4")
+assert_equals "$EXIT" "0" "exit code 0"
+assert_equals "$(cat "$S4/.out")" "master" "stdout = 'master'"
+
+# ---------------------------------------------------------------------------
+# Fixture 5: no remote at all + main exists → returns "main"
+# ---------------------------------------------------------------------------
+start_test "no remote + main local → returns main"
+S5=$(scratch_dir)
+build_fixture "$S5" "main" "no" "" "no"
+EXIT=$(run_helper_sh "$S5")
+assert_equals "$EXIT" "0" "exit code 0"
+assert_equals "$(cat "$S5/.out")" "main" "stdout = 'main'"
+
+# ---------------------------------------------------------------------------
+# Fixture 6: no main, no master, no remote → exit 1, empty stdout
+# ---------------------------------------------------------------------------
+start_test "neither branch exists → exit 1, empty stdout"
+S6=$(scratch_dir)
+build_fixture "$S6" "develop" "no" "" "no"
+EXIT=$(run_helper_sh "$S6")
+assert_equals "$EXIT" "1" "exit code 1"
+assert_equals "$(cat "$S6/.out")" "" "stdout empty on bail"
+assert_equals "$(wc -c < "$S6/.err" | tr -d ' ')" "0" "stderr still empty on bail"
+
+# ---------------------------------------------------------------------------
+# Fixture 7: detached HEAD + main exists → returns main (HEAD ≠ default)
+# ---------------------------------------------------------------------------
+start_test "detached HEAD + main local → returns main"
+S7=$(scratch_dir)
+build_fixture "$S7" "main" "yes" "" "yes"
+EXIT=$(run_helper_sh "$S7")
+assert_equals "$EXIT" "0" "exit code 0"
+assert_equals "$(cat "$S7/.out")" "main" "stdout = 'main'"
+
+# ---------------------------------------------------------------------------
+# PowerShell parity (skipped if pwsh unavailable)
+# ---------------------------------------------------------------------------
+if command -v pwsh >/dev/null 2>&1; then
+    start_test "pwsh: origin/HEAD = main → returns main"
+    S8=$(scratch_dir)
+    build_fixture "$S8" "main" "yes" "main" "no"
+    OUT=$(cd "$S8" && pwsh -NoProfile -File "$LIB_PS" 2>/dev/null)
+    EXIT=$?
+    assert_equals "$EXIT" "0" "pwsh exit code 0"
+    assert_equals "$OUT" "main" "pwsh stdout = 'main'"
+
+    start_test "pwsh: neither branch exists → exit 1"
+    S9=$(scratch_dir)
+    build_fixture "$S9" "develop" "no" "" "no"
+    OUT=$(cd "$S9" && pwsh -NoProfile -File "$LIB_PS" 2>/dev/null)
+    EXIT=$?
+    assert_equals "$EXIT" "1" "pwsh exit code 1"
+    assert_equals "$OUT" "" "pwsh stdout empty on bail"
+fi
+
+report "test-default-branch.sh"

--- a/tests/template/test-default-branch.sh
+++ b/tests/template/test-default-branch.sh
@@ -137,6 +137,18 @@ assert_equals "$EXIT" "0" "exit code 0"
 assert_equals "$(cat "$S7/.out")" "main" "stdout = 'main'"
 
 # ---------------------------------------------------------------------------
+# Fixture 8: both main and master exist locally, origin/HEAD unset → returns "main"
+# PRD US-003 edge case: Method 2 (local main check) fires before Method 3
+# (local master check), so "main" wins when both branches are present.
+# ---------------------------------------------------------------------------
+start_test "origin/HEAD unset + both main and master local → returns main (Method 2 before Method 3)"
+S8=$(scratch_dir)
+build_fixture "$S8" "main master" "yes" "" "no"
+EXIT=$(run_helper_sh "$S8")
+assert_equals "$EXIT" "0" "exit code 0"
+assert_equals "$(cat "$S8/.out")" "main" "stdout = 'main' (main preferred over master)"
+
+# ---------------------------------------------------------------------------
 # PowerShell parity (skipped if pwsh unavailable)
 # ---------------------------------------------------------------------------
 if command -v pwsh >/dev/null 2>&1; then

--- a/tests/template/test-hooks.sh
+++ b/tests/template/test-hooks.sh
@@ -376,6 +376,65 @@ rc=$(run_hook_sh "$S14" 'git commit -m x' "$CHECKLIST_E2E_CHECKED_NO_NA")
 assert_equals "$rc" "0" "on main directly → evidence check skipped (trunk-based workflow supported)"
 
 # ===========================================================================
+# Test 15: check-state-updated.sh master-default repo — CHANGELOG gate fires
+# correctly when default branch is "master" (not "main").
+#
+# Regression guard for the pre-migration hook (hardcoded `main`):
+#   - Pre-migration: `git merge-base main HEAD` → empty (no main branch)
+#     → BRANCH_BASE falls back to HEAD~10 → wrong baseline → count wrong
+#   - Post-migration: default-branch.sh detects "master" → correct
+#     merge-base → BRANCH_CHANGED >= 4 → CHANGELOG gate fires (exit 2)
+# ===========================================================================
+start_test "check-state-updated.sh: master-default repo → CHANGELOG gate fires (exit 2)"
+
+HOOK_STATE="$REPO_ROOT/hooks/check-state-updated.sh"
+
+# Build a scratch repo with master as the default branch, no main branch.
+# Feature branch has 4 committed files in subdirs → BRANCH_CHANGED = 4 > 3.
+# No CHANGELOG entry anywhere → gate fires.
+S15=$(scratch_dir state-master-default)
+(
+    cd "$S15" || exit 1
+    git init -q
+    git -c user.email=test@test -c user.name=test checkout -q -b master
+    git -c user.email=test@test -c user.name=test commit -q --allow-empty -m "initial on master"
+    git -c user.email=test@test -c user.name=test checkout -q -b feature/x
+    # Add 4 files in subdirs (not gitignored) as tracked+committed on the feature branch.
+    # git status --porcelain on these committed files shows nothing (already clean),
+    # but git diff --name-only master..HEAD counts all 4 for BRANCH_CHANGED.
+    mkdir -p src/a src/b
+    printf 'x' > src/a/file1.txt
+    printf 'x' > src/a/file2.txt
+    printf 'x' > src/b/file3.txt
+    printf 'x' > src/b/file4.txt
+    git add src/
+    git -c user.email=test@test -c user.name=test commit -q -m "feature work: 4 files"
+)
+
+# Write a minimal CONTINUITY.md (no active workflow, no CHANGELOG entry).
+cat > "$S15/CONTINUITY.md" <<'CONT'
+# CONTINUITY
+
+## State
+
+### Done
+- Some work done
+
+### Now
+Working on feature/x
+
+### Next
+Nothing
+CONT
+
+# Run check-state-updated.sh from the scratch repo.
+# stdin: '{"stop_hook_active":false}' (mirrors real Stop hook input).
+rc15=$(printf '{"stop_hook_active":false}' | (cd "$S15" && bash "$HOOK_STATE") 2>"$S15/.state-stderr"; echo "$?")
+assert_equals "$rc15" "2" "CHANGELOG gate fires on master-default repo (exit 2)"
+assert_contains "$S15/.state-stderr" "CHANGELOG" \
+    "stderr mentions CHANGELOG threshold"
+
+# ===========================================================================
 # Report
 # ===========================================================================
 report "test-hooks.sh"

--- a/tests/template/test-lint.sh
+++ b/tests/template/test-lint.sh
@@ -28,6 +28,7 @@ BASH_FILES=(
     "$REPO_ROOT/hooks/check-bash-safety.sh"
     "$REPO_ROOT/hooks/check-config-change.sh"
     "$REPO_ROOT/hooks/check-workflow-gates.sh"
+    "$REPO_ROOT/hooks/lib/default-branch.sh"
     "$REPO_ROOT/tests/template/lib.sh"
     "$REPO_ROOT/tests/template/test-setup.sh"
     "$REPO_ROOT/tests/template/test-fixtures.sh"
@@ -35,6 +36,8 @@ BASH_FILES=(
     "$REPO_ROOT/tests/template/test-hooks.sh"
     "$REPO_ROOT/tests/template/test-lint.sh"
     "$REPO_ROOT/tests/template/run-all.sh"
+    "$REPO_ROOT/tests/template/test-default-branch.sh"
+    "$REPO_ROOT/tests/template/test-session-start.sh"
 )
 
 for f in "${BASH_FILES[@]}"; do
@@ -69,6 +72,7 @@ if command -v pwsh >/dev/null 2>&1; then
         "$REPO_ROOT/hooks/check-bash-safety.ps1"
         "$REPO_ROOT/hooks/check-config-change.ps1"
         "$REPO_ROOT/hooks/check-workflow-gates.ps1"
+        "$REPO_ROOT/hooks/lib/default-branch.ps1"
     )
     for f in "${PS_FILES[@]}"; do
         if [[ ! -f "$f" ]]; then

--- a/tests/template/test-session-start.sh
+++ b/tests/template/test-session-start.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# tests/template/test-session-start.sh — fixture tests for SessionStart drift detection.
+#
+# Verifies:
+#   - source=clear|compact → NO fetch attempted, branch-only context
+#   - source=startup → fetch attempted, behind-warning when applicable
+#   - fetch failure (bad remote) → silent degrade to branch-only context
+#   - additionalContext stays under 2KB
+#   - JSON output is valid (parseable by jq)
+#
+# Run from repo root: bash tests/template/test-session-start.sh
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+# shellcheck source=lib.sh
+source "$REPO_ROOT/tests/template/lib.sh"
+
+init_counters
+
+HOOK_SH="$REPO_ROOT/hooks/session-start.sh"
+HOOK_PS="$REPO_ROOT/hooks/session-start.ps1"
+LIB_SH="$REPO_ROOT/hooks/lib/default-branch.sh"
+LIB_PS="$REPO_ROOT/hooks/lib/default-branch.ps1"
+
+# ---------------------------------------------------------------------------
+# Fixture builder: minimal git repo with `main` checked out + bare remote
+# whose HEAD points at main + remote ahead by `behind_count` commits so the
+# local repo is "behind by N" after a successful fetch.
+#
+# Critical: we MUST `git symbolic-ref HEAD refs/heads/main` on the bare repo
+# before cloning, otherwise the bare's default HEAD points at the nonexistent
+# `master` and the clone leaves no branch checked out (commit loop fails).
+# ---------------------------------------------------------------------------
+make_behind_repo() {
+    local scratch="$1" behind_count="${2:-3}"
+    mkdir -p "$scratch/repo" "$scratch/remote.git"
+    git init -q --bare "$scratch/remote.git"
+    # Set bare HEAD to main BEFORE the first clone — this is the portability fix.
+    git -C "$scratch/remote.git" symbolic-ref HEAD refs/heads/main
+
+    (
+        cd "$scratch/repo" || exit 1
+        git init -q
+        git config user.email t@t && git config user.name t
+        git checkout -q -b main
+        git commit --allow-empty -q -m "c1"
+        git remote add origin "$scratch/remote.git"
+        git push -q -u origin main
+        # Set local origin/HEAD so the helper can detect "main" via Method 1.
+        git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main 2>/dev/null
+
+        if [ "$behind_count" -gt 0 ]; then
+            local tmp="$scratch/tmp-clone"
+            git clone -q -b main "$scratch/remote.git" "$tmp"
+            (
+                cd "$tmp" || exit 1
+                git config user.email t@t && git config user.name t
+                local i
+                for ((i=2; i<=behind_count+1; i++)); do
+                    git commit --allow-empty -q -m "remote-c$i"
+                done
+                git push -q origin main
+            )
+            rm -rf "$tmp"
+        fi
+    )
+}
+
+# Copy the hook + lib into a hooks-relative layout so BASH_SOURCE resolution
+# finds the lib. Mirror the layout downstream installs use.
+prepare_hook_repo() {
+    local repo="$1"
+    mkdir -p "$repo/.hooks/lib"
+    cp "$HOOK_SH" "$repo/.hooks/session-start.sh"
+    cp "$LIB_SH" "$repo/.hooks/lib/default-branch.sh"
+    chmod +x "$repo/.hooks/session-start.sh" "$repo/.hooks/lib/default-branch.sh"
+}
+
+prepare_hook_repo_ps() {
+    local repo="$1"
+    mkdir -p "$repo/.hooks/lib"
+    cp "$HOOK_PS" "$repo/.hooks/session-start.ps1"
+    cp "$LIB_PS" "$repo/.hooks/lib/default-branch.ps1"
+}
+
+# Run the bash hook with a synthetic stdin payload, write stdout to a file
+# so we can use lib.sh's file-path-taking assertions (assert_contains etc.).
+# Echoes the OUTPUT FILE PATH on stdout so callers can pass it to assertions.
+run_session_start_sh() {
+    local repo="$1" source_val="$2"
+    local out="$repo/.session-out"
+    (cd "$repo" && printf '{"source":"%s","session_id":"test","cwd":"%s"}' \
+        "$source_val" "$repo" | bash ./.hooks/session-start.sh) > "$out" 2>"$repo/.session-err"
+    echo "$out"
+}
+
+run_session_start_ps() {
+    local repo="$1" source_val="$2"
+    local out="$repo/.session-out"
+    if ! command -v pwsh >/dev/null 2>&1; then
+        echo ""  # signal "skip"
+        return
+    fi
+    (cd "$repo" && printf '{"source":"%s","session_id":"test","cwd":"%s"}' \
+        "$source_val" "$repo" | pwsh -NoProfile -File ./.hooks/session-start.ps1) > "$out" 2>"$repo/.session-err"
+    echo "$out"
+}
+
+# ===========================================================================
+# Test 1: source=clear → no fetch, branch-only context
+# ===========================================================================
+start_test "source=clear → branch only, no fetch attempted"
+S1=$(scratch_dir)
+make_behind_repo "$S1" 3
+prepare_hook_repo "$S1/repo"
+OUTFILE=$(run_session_start_sh "$S1/repo" "clear")
+assert_contains "$OUTFILE" "Current branch:" "context starts with branch"
+assert_not_contains "$OUTFILE" "behind origin" "no behind warning on /clear"
+
+# ===========================================================================
+# Test 2: source=compact → no fetch, branch-only context
+# ===========================================================================
+start_test "source=compact → branch only, no fetch attempted"
+S2=$(scratch_dir)
+make_behind_repo "$S2" 3
+prepare_hook_repo "$S2/repo"
+OUTFILE=$(run_session_start_sh "$S2/repo" "compact")
+assert_not_contains "$OUTFILE" "behind origin" "no behind warning on /compact"
+
+# ===========================================================================
+# Test 3: source=startup + behind=3 → behind warning in context
+# ===========================================================================
+start_test "source=startup + behind by 3 → warning included"
+S3=$(scratch_dir)
+make_behind_repo "$S3" 3
+prepare_hook_repo "$S3/repo"
+OUTFILE=$(run_session_start_sh "$S3/repo" "startup")
+assert_contains "$OUTFILE" "behind origin" "behind warning present"
+assert_contains "$OUTFILE" "3 commits" "behind count = 3"
+
+# ===========================================================================
+# Test 4: source=resume + behind=0 → no warning, branch only
+# ===========================================================================
+start_test "source=resume + up-to-date → no warning"
+S4=$(scratch_dir)
+make_behind_repo "$S4" 0
+prepare_hook_repo "$S4/repo"
+OUTFILE=$(run_session_start_sh "$S4/repo" "resume")
+assert_contains "$OUTFILE" "Current branch:" "branch present"
+assert_not_contains "$OUTFILE" "behind origin" "no warning when up-to-date"
+
+# ===========================================================================
+# Test 5: bad remote (fetch fails) + source=startup → silent degrade
+# Uses a NONEXISTENT LOCAL path (not a bad URL) so the fetch fails immediately
+# without DNS lookup. This keeps the test deterministic on hosts without
+# `gtimeout`/`timeout` (the council-accepted macOS degraded case) — the bash
+# hook would otherwise stall up to ~75s on a network-targeted bad URL.
+# ===========================================================================
+start_test "fetch fails → silent degrade to branch-only"
+S5=$(scratch_dir)
+mkdir -p "$S5/repo"
+(
+    cd "$S5/repo" || exit 1
+    git init -q
+    git config user.email t@t && git config user.name t
+    git checkout -q -b main
+    git commit --allow-empty -q -m "c1"
+    git remote add origin "$S5/nonexistent-remote.git"  # local path, never created
+)
+prepare_hook_repo "$S5/repo"
+OUTFILE=$(run_session_start_sh "$S5/repo" "startup")
+assert_contains "$OUTFILE" "Current branch:" "branch context emitted"
+assert_not_contains "$OUTFILE" "behind origin" "no false warning when fetch failed"
+
+# ===========================================================================
+# Test 6: additionalContext stays under 2KB on the worst realistic case
+# ===========================================================================
+start_test "additionalContext < 2KB"
+S6=$(scratch_dir)
+make_behind_repo "$S6" 999  # large but realistic; well under 99999
+prepare_hook_repo "$S6/repo"
+OUTFILE=$(run_session_start_sh "$S6/repo" "startup")
+LEN=$(wc -c < "$OUTFILE" | tr -d ' ')
+if [ "$LEN" -lt 2048 ]; then
+    pass "additionalContext output is $LEN bytes (< 2048)"
+else
+    fail "additionalContext output is $LEN bytes (>= 2048 — way too large)"
+fi
+
+# ===========================================================================
+# Test 7: JSON output is parseable
+# ===========================================================================
+start_test "output is valid JSON (parseable by jq)"
+S7=$(scratch_dir)
+make_behind_repo "$S7" 1
+prepare_hook_repo "$S7/repo"
+OUTFILE=$(run_session_start_sh "$S7/repo" "startup")
+if command -v jq &>/dev/null; then
+    if jq -e '.hookSpecificOutput.hookEventName == "SessionStart"' < "$OUTFILE" >/dev/null; then
+        pass "valid JSON, hookEventName == SessionStart"
+    else
+        fail "JSON parse failed or hookEventName mismatch"
+    fi
+else
+    printf "  %s·%s skipped: jq not available\n" "$C_DIM" "$C_RESET"
+fi
+
+# ===========================================================================
+# PowerShell parity (skipped if pwsh unavailable; uses pwsh for cross-platform
+# fixture testing — the SHIPPED hook runs under powershell.exe on Windows via
+# settings-windows.template.json, but pwsh is the cross-host way to test the
+# .ps1 file from bash on macOS/Linux/CI)
+# ===========================================================================
+if command -v pwsh >/dev/null 2>&1; then
+    start_test "pwsh: source=clear → branch only"
+    S8=$(scratch_dir)
+    make_behind_repo "$S8" 2
+    prepare_hook_repo_ps "$S8/repo"
+    OUTFILE=$(run_session_start_ps "$S8/repo" "clear")
+    assert_not_contains "$OUTFILE" "behind origin" "pwsh: no warning on clear"
+
+    start_test "pwsh: source=startup + behind by 2 → warning"
+    S9=$(scratch_dir)
+    make_behind_repo "$S9" 2
+    prepare_hook_repo_ps "$S9/repo"
+    OUTFILE=$(run_session_start_ps "$S9/repo" "startup")
+    assert_contains "$OUTFILE" "behind origin" "pwsh: warning present"
+fi
+
+report "test-session-start.sh"

--- a/tests/template/test-session-start.sh
+++ b/tests/template/test-session-start.sh
@@ -205,6 +205,92 @@ else
 fi
 
 # ===========================================================================
+# Test 8: TIMEOUT_CMD selection — no timeout binary available → hook still
+# exits 0 and emits valid JSON.
+#
+# Isolation: $scratch/empty-bin is an empty directory (no executables). We
+# prepend it to PATH, then append enough of the real PATH to keep git
+# reachable (so fetch runs), but exclude any directory that provides
+# `gtimeout` or `timeout`. This exercises the empty-TIMEOUT_CMD branch:
+#   `$TIMEOUT_CMD git fetch …` with TIMEOUT_CMD="" expands to just
+#   `git fetch …` — the hook's intended no-timeout fallback.
+# ===========================================================================
+start_test "no timeout binary available → exits 0, valid JSON (empty-TIMEOUT_CMD path)"
+S8=$(scratch_dir)
+make_behind_repo "$S8" 2
+prepare_hook_repo "$S8/repo"
+
+# Build a PATH that contains git but NOT gtimeout or timeout.
+# Strategy: iterate real PATH segments; skip any segment that houses a
+# `timeout` or `gtimeout` binary. Always add $S8/empty-bin first so any
+# stub we might want later lives at front, but we leave it empty here.
+mkdir -p "$S8/empty-bin"
+FILTERED_PATH="$S8/empty-bin"
+IFS=':' read -ra _PATH_SEGS <<< "$PATH"
+for _seg in "${_PATH_SEGS[@]}"; do
+    # Skip segments that host timeout or gtimeout (the binaries we're hiding).
+    if [[ -x "$_seg/timeout" ]] || [[ -x "$_seg/gtimeout" ]]; then
+        continue
+    fi
+    FILTERED_PATH="$FILTERED_PATH:$_seg"
+done
+
+# Run the hook with the filtered PATH, capturing stdout and exit code.
+S8_OUT="$S8/repo/.session-out"
+(
+    cd "$S8/repo"
+    printf '{"source":"startup","session_id":"test","cwd":"%s"}' "$S8/repo" \
+        | PATH="$FILTERED_PATH" bash ./.hooks/session-start.sh
+) >"$S8_OUT" 2>"$S8/repo/.session-err"
+S8_RC=$?
+
+if [[ $S8_RC -eq 0 ]]; then
+    pass "hook exits 0 when no timeout binary is available"
+else
+    fail "hook exited $S8_RC (expected 0)"
+fi
+assert_contains "$S8_OUT" "Current branch:" "branch context emitted without timeout binary"
+# Verify the JSON shape is valid (hook should not crash on empty TIMEOUT_CMD).
+if command -v jq &>/dev/null; then
+    if jq -e '.hookSpecificOutput.hookEventName == "SessionStart"' < "$S8_OUT" >/dev/null 2>&1; then
+        pass "valid JSON output even without timeout binary"
+    else
+        fail "JSON invalid or hookEventName mismatch when no timeout binary"
+    fi
+fi
+
+# ===========================================================================
+# Test 9: source="" (empty) → no fetch, branch context still emitted
+#
+# The gate is: [[ "$SOURCE" == "startup" || "$SOURCE" == "resume" ]]
+# An empty SOURCE must NOT trigger fetch, but the hook must still emit
+# the branch context and exit 0 (fail-closed gate).
+# ===========================================================================
+start_test "source='' (empty) → no fetch, branch context emitted"
+S9=$(scratch_dir)
+make_behind_repo "$S9" 3
+prepare_hook_repo "$S9/repo"
+# Use run_session_start_sh with empty string as source value.
+OUTFILE=$(run_session_start_sh "$S9/repo" "")
+assert_contains "$OUTFILE" "Current branch:" "branch context present for empty source"
+assert_not_contains "$OUTFILE" "behind origin" "no behind warning for empty source (gate skips fetch)"
+
+# ===========================================================================
+# Test 10: source="unknown_future_value" → no fetch, branch context emitted
+#
+# Forward-compatibility: any value other than startup/resume must not trigger
+# fetch. This prevents a new source subtype from accidentally revealing stale
+# drift warnings before the user has initiated a real session start.
+# ===========================================================================
+start_test "source='unknown_future_value' → no fetch, branch context emitted"
+S10=$(scratch_dir)
+make_behind_repo "$S10" 3
+prepare_hook_repo "$S10/repo"
+OUTFILE=$(run_session_start_sh "$S10/repo" "unknown_future_value")
+assert_contains "$OUTFILE" "Current branch:" "branch context present for unknown source"
+assert_not_contains "$OUTFILE" "behind origin" "no behind warning for unknown source (gate fail-closed)"
+
+# ===========================================================================
 # PowerShell parity (skipped if pwsh unavailable; uses pwsh for cross-platform
 # fixture testing — the SHIPPED hook runs under powershell.exe on Windows via
 # settings-windows.template.json, but pwsh is the cross-host way to test the

--- a/tests/template/test-setup.sh
+++ b/tests/template/test-setup.sh
@@ -479,6 +479,40 @@ assert_contains "$S10c/.upgrade.log" "Upgrade done!" \
     "Scenario C: bare 'Upgrade done!' variant present"
 
 # ===========================================================================
+# Test 11: hooks/lib helper installed + executable + hash-identical to source
+# P1 gap from drift-hygiene PR #1 review: setup.sh copies the lib helper, but
+# no test asserted its presence, mode, or integrity in the scratch install.
+# ===========================================================================
+start_test "Test 11: hooks/lib/default-branch.sh installed by setup.sh"
+
+S11=$(scratch_dir hooks-lib)
+make_project "$S11" flat
+LOG11="$S11/.setup.log"
+
+run_setup "$S11" "$LOG11" -p "HooksLibTest" -t fullstack
+assert_equals "$?" "0" "setup exits 0"
+
+# File must exist in the installed tree
+assert_file_exists "$S11/.claude/hooks/lib/default-branch.sh" \
+    ".claude/hooks/lib/default-branch.sh installed"
+
+# Must be executable (chmod +x applied by setup.sh)
+if [[ -x "$S11/.claude/hooks/lib/default-branch.sh" ]]; then
+    pass ".claude/hooks/lib/default-branch.sh is executable"
+else
+    fail ".claude/hooks/lib/default-branch.sh is NOT executable"
+fi
+
+# Content must be hash-identical to the source in the repo
+SRC_HASH=$(hash_file "$REPO_ROOT/hooks/lib/default-branch.sh")
+assert_hash_equals "$S11/.claude/hooks/lib/default-branch.sh" "$SRC_HASH" \
+    "installed default-branch.sh matches source (hash-identical)"
+
+# Note: setup.ps1 (Windows installer) installs default-branch.ps1; setup.sh
+# (Unix installer) installs only default-branch.sh. The cross-installer parity
+# is covered by test-contracts.sh (Contract: hooks/lib parity setup.sh ↔ setup.ps1).
+
+# ===========================================================================
 # Report
 # ===========================================================================
 report "test-setup.sh"


### PR DESCRIPTION
## Summary

- **The bug**: in multi-developer projects, local \`main\` silently falls behind \`origin/main\`. Claude reads \`CONTINUITY.md\` as authoritative and confidently cites already-merged PRs as open. Worse, \`/new-feature\` and \`/fix-bug\` create worktrees from local \`HEAD\`, so feature branches get built on stale baselines (observed: 97 commits stale).
- **The fix**: SessionStart hook now fetches + warns Claude in \`additionalContext\` when local default is behind. \`/new-feature\` / \`/fix-bug\` Pre-Flight fetches + fast-forwards local default (when clean) + bases the worktree from \`origin/<default>\` explicitly. New shared \`hooks/lib/default-branch.{sh,ps1}\` helper detects via \`origin/HEAD → main → master → bail\`, removing the hardcoded \`main\` from \`check-state-updated.sh:33\`.
- **PR #1 of a multi-PR initiative.** PR #2 (CONTINUITY.md split + per-developer state.md) is documented as a non-goal here; the two items are independent.

## What's in this PR

**New files (4):**
- \`hooks/lib/default-branch.{sh,ps1}\` — first-ever \`hooks/lib/\` directory; dual-mode (script-callable + sourceable); strict contract (stdout-only, exit 0/1, silent stderr); on Windows, dot-source from \`powershell.exe\` 5.1 to avoid \`pwsh\` subprocess
- \`tests/template/test-default-branch.sh\` (16 assertions across 8 fixtures)
- \`tests/template/test-session-start.sh\` (18 assertions across 10 fixtures)

**Modified (16):**
- \`hooks/session-start.{sh,ps1}\` — full rewrite: stdin source-gating (only \`startup\`/\`resume\` fetch; \`clear\`/\`compact\` skip), behind warning in \`additionalContext\` (cannot block — exit 2 is advisory on SessionStart), helper-bail breadcrumb. PS variant: \`Start-Job -ArgumentList \$cwd\` + \`Set-Location -LiteralPath\` (PS 5.1 CWD fix), \`\$LASTEXITCODE\` gating on fetch result.
- \`hooks/check-state-updated.{sh,ps1}\` — replaced hardcoded \`merge-base main HEAD\` with helper call. Fallback chain: local \`<default>\` → \`origin/<default>\` → \`HEAD~10\`. Removed \`set -e\` (was causing exit 1 on clean session via \`\$((0+0))\` arithmetic-zero quirk — pre-existing latent bug fixed in same branch per NO BUGS LEFT BEHIND).
- \`commands/new-feature.md\` + \`commands/fix-bug.md\` — \`# DRIFT-PREFLIGHT-{NEW,ALREADY}-{BEGIN,END}\` marker pairs (byte-identical contract enforced by test-contracts.sh) wrapping fetch + ff-only + worktree-from-origin logic. Dirty-tree + diverged-FF are warn-and-proceed (worktree is independent of caller's checkout state — Codex correctness argument prevailed over PRD's original 'STOP with error').
- \`setup.sh\` + \`setup.ps1\` — install lib helpers to \`.claude/hooks/lib/\` in downstream repos. Windows installs get BOTH \`.sh\` and \`.ps1\` (Pre-Flight bash blocks invoke \`bash \"\$LIB\"\` under Git Bash).
- \`tests/template/{run-all,test-lint,test-hooks,test-setup,test-contracts}.sh\` — register new files, add 3 cross-file contracts (no migrated-pattern \`main\`, byte-identical NEW + ALREADY blocks), add master-default + install-presence + cross-platform-string-parity fixtures.
- \`CLAUDE.md\` + \`docs/reference/{hooks,file-structure}.md\` + \`docs/troubleshooting.md\` + \`docs/CHANGELOG.md\` — docs updated, including a new troubleshooting section covering all four advisory messages downstream users will see, with the canonical \`git remote set-head origin --auto\` fix for the stale-rename limitation.

## Process trail

- **PRD** authored from conversation context: \`docs/prds/2026-04-27-drift-hygiene.md\`
- **Research brief** (8 surfaces, 11 design-changing findings, 8 open risks): \`docs/research/2026-04-27-drift-hygiene.md\`
- **Council fired** on the inline-vs-factored fork (5 advisors + chairman). Verdict: narrow Option C — factor only \`default-branch.{sh,ps1}\` (the one piece with proven drift history at \`check-state-updated.sh:33\`), keep Pre-Flight inline in commands, simple-detect \`gtimeout || timeout || skip\` for macOS.
- **Plan review loop** (4 iterations): 10 → 3 → 1 → 0 findings.
- **Plan**: \`docs/plans/2026-04-27-drift-hygiene.md\` — 17 tasks, full TDD substeps, file-DAG dispatch.
- **Code review loop** (7 iterations to genuine convergence): Codex + 5 PR-Toolkit reviewers across iterations:
  - Iter 1: 4 P1 + 5 P2
  - Iter 2: 1 P2
  - Iter 3: 1 P2
  - Iter 4: 1 P2
  - Iter 5: 1 P2 + 1 P3
  - Iter 6: 1 P1 + 1 P2
  - Iter 7: **CLEAN**

  Per \`rules/critical-rules.md\` 'NO BUGS LEFT BEHIND' — every reviewer-flagged issue was fixed in-branch (no follow-up deferrals); pre-existing \`set -e + \$((0+0))\` bug folded in too because it was flagged by silent-failure-hunter during this review.

## Test plan

- [x] **Lint** — \`bash -n\` on every shipped \`.sh\`, \`pwsh\` parse on every \`.ps1\` (skips on hosts without pwsh), \`jq\` validate on JSON templates
- [x] **Logic fixtures** — 277 assertions across 7 suites; bash side fully exercised, PS side skipped on macOS dev host
- [x] **Cross-file contracts** — no migrated \`main\` patterns; DRIFT-PREFLIGHT marker pairs byte-identical; cross-platform drift-warning string parity
- [x] **Installer round-trip** — \`setup.sh\` + \`setup.ps1\` lib copy verified end-to-end (file present, executable, hash-matches source)
- [x] **End-to-end on \`../mcpgateway\`** (which was 26 commits behind origin/main with a dirty tree at test time):
  - SessionStart hook emitted \`\"is 26 commits behind origin — pull before starting work\"\` ✓
  - SessionStart on \`source=clear\` → branch only, no fetch ✓
  - Helper returns \`main\`, exit 0, stdout-only ✓
  - DRIFT-PREFLIGHT-NEW Pre-Flight: \`FETCH_OK=true\`, \`BASE=origin/main\`, dirty-tree → warn-and-proceed (per iter-7 fix) ✓
  - Pre-upgrade fallback (helper not installed): breadcrumb fires, falls back to \`main\` cleanly ✓
  - \`check-state-updated.sh\` exit 2 with correct stderr message ✓
  - mcpgateway state restored exactly as found (no permanent modifications) ✓
- [ ] **Real Windows install** — needs CI runner with \`pwsh\`; logic-reviewed across 7 iterations + Codex but not actually executed on Windows

## Out of scope (PR #2 / future)

- **CONTINUITY.md split** — separating durable project facts from per-developer volatile state. Independent change.
- **macOS without \`gtimeout\`/\`timeout\`** — accepts ~75s degraded-network stall (council-accepted; Maintainer dissent recorded).
- **Audit-log breadcrumb infrastructure** — chairman-deferred per council. Stderr / additionalContext breadcrumbs satisfy 'non-silent failure' without inventing a logging side-channel.
- **\`origin/HEAD\` stale-rename perfect detection** — documented limitation in \`hooks/lib/default-branch.sh\` + \`docs/troubleshooting.md\`. Canonical fix is user-side \`git remote set-head origin --auto && git fetch --prune\`. No network-free heuristic has acceptable false-positive rates.

## Existing installs need \`./setup.sh -f\`

To pick up: \`hooks/lib/\` (new), updated SessionStart hook, migrated \`check-state-updated.sh\`, new Pre-Flight bash in \`commands/*.md\`, \`docs/troubleshooting.md\` updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)