### PR TITLE
docs(readme): refresh version metadata to 5.15 + add upgrade callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-green?style=flat-square"></a>
-  <a href="#version-history"><img alt="Version" src="https://img.shields.io/badge/version-5.5-blue?style=flat-square"></a>
+  <a href="#version-history"><img alt="Version" src="https://img.shields.io/badge/version-5.15-blue?style=flat-square"></a>
   <a href="docs/getting-started.md"><img alt="Platform" src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey?style=flat-square"></a>
   <a href="https://code.claude.com"><img alt="Claude Code" src="https://img.shields.io/badge/Claude_Code-enabled-purple?style=flat-square"></a>
   <a href="https://developers.openai.com/codex/"><img alt="Codex CLI" src="https://img.shields.io/badge/Codex_CLI-required-orange?style=flat-square"></a>
@@ -88,6 +88,15 @@ Windows users: [PowerShell instructions](docs/getting-started.md#windows).
 
 Full flag reference: **[Upgrading guide →](docs/guides/upgrading.md)**
 
+### Upgrading from a pre-5.15 install?
+
+```bash
+./setup.sh --upgrade   # picks up new files; preserves your existing CONTINUITY.md byte-for-byte
+./setup.sh --migrate   # splits CONTINUITY.md into CLAUDE.md durable + docs/adr/ decisions + .claude/local/state.md volatile
+```
+
+See [`docs/guides/upgrading.md`](docs/guides/upgrading.md) for the full walkthrough including verifying the migration and removing the legacy `@CONTINUITY.md` import.
+
 ## How it works
 
 One feature goes from idea to merged PR across 14 enforced phases — from PRD through research, dual-reviewer design loops, TDD execution, parallel code review, simplify + verify + E2E, compound learnings, and PR reviewer handling.
@@ -132,14 +141,24 @@ The pillars above cash out in specific, repo-verifiable behavior:
 
 Recent releases:
 
-| Version | Date       | Highlights                                                                                      |
-| ------- | ---------- | ----------------------------------------------------------------------------------------------- |
-| 5.5     | 2026-04-17 | `verify-e2e` agent (#449) · Playwright CI bridge (#450) · `research-first` (#472) · repo rename |
-| 5.4     | 2026-03-31 | Engineering Council — 5 advisors with Codex chairman                                            |
-| 5.3     | 2026-03-01 | Silent SessionStart context injection via JSON `hookSpecificOutput`                             |
-| 5.2     | 2026-02-20 | Frontend design plugin + `rules/frontend-design.md`                                             |
-| 5.1     | 2026-02-19 | CLAUDE.md split — slim file + auto-loaded `.claude/rules/`                                      |
-| 5.0     | 2026-02-19 | Removed Compound Engineering, replaced with built-in quality gates                              |
+| Version | Date       | Highlights                                                                                                                     |
+| ------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| 5.15    | 2026-04-28 | CONTINUITY split — durable facts to CLAUDE.md, decisions to `docs/adr/`, volatile state to gitignored `.claude/local/state.md` |
+| 5.14    | 2026-04-27 | Drift hygiene — SessionStart `git fetch` warning + worktree from `origin/<default>`                                            |
+| 5.13    | 2026-04-21 | Phase 4 task-DAG dispatch with file-conflict constraints                                                                       |
+| 5.12    | 2026-04-21 | Template-drift notice on `setup.sh -f` / `--upgrade`                                                                           |
+| 5.11    | 2026-04-20 | ARRANGE rule — close the E2E actor-boundary gap via text layer                                                                 |
+| 5.10    | 2026-04-18 | Evidence-based E2E gate — checkbox claims bound to `tests/e2e/reports/` artifact                                               |
+| 5.9     | 2026-04-18 | `E2E verified` gate — close the silent-skip loophole                                                                           |
+| 5.8     | 2026-04-18 | Multi-project interpreter preflight + isolation guide                                                                          |
+| 5.7     | 2026-04-18 | Template self-test suite (4 bash suites, ~5s)                                                                                  |
+| 5.6     | 2026-04-17 | Template monorepo support + Playwright security fixes                                                                          |
+| 5.5     | 2026-04-17 | `verify-e2e` agent (#449) · Playwright CI bridge (#450) · `research-first` (#472) · repo rename                                |
+| 5.4     | 2026-03-31 | Engineering Council — 5 advisors with Codex chairman                                                                           |
+| 5.3     | 2026-03-01 | Silent SessionStart context injection via JSON `hookSpecificOutput`                                                            |
+| 5.2     | 2026-02-20 | Frontend design plugin + `rules/frontend-design.md`                                                                            |
+| 5.1     | 2026-02-19 | CLAUDE.md split — slim file + auto-loaded `.claude/rules/`                                                                     |
+| 5.0     | 2026-02-19 | Removed Compound Engineering, replaced with built-in quality gates                                                             |
 
 Full history: **[docs/CHANGELOG.md](docs/CHANGELOG.md)**
 


### PR DESCRIPTION
## Summary

Pre-existing housekeeping debt — README badge had been stale through 10 releases (5.5 → 5.15). Three changes:

1. **Version badge**: `5.5` → `5.15` to match latest CHANGELOG entry
2. **Version history table**: appended 5.6 through 5.15 rows (10 missing releases) with taglines pulled from `docs/CHANGELOG.md`
3. **Upgrading callout** in Quick Start: 2-line incantation pointing existing-install users at `setup.sh --upgrade` + `setup.sh --migrate` for the PR #564 (5.15) migration. Links to full guide.

Discovered after PR #564 (continuity-split) merge — the migration was less discoverable than it should have been because README didn't advertise it.

Standing rule going forward: every PR that bumps the CHANGELOG to a new `## X.YY` entry must also update README's badge + version history table.

## Test plan

- [x] No code changes — README only
- [x] Template self-test suite green (`bash tests/template/run-all.sh` — All suites passed)
- [x] Markdown still parseable (badge URL, table, links)