### PR TITLE
fix(setup,migrate): consolidated 'ask Claude to reconcile' message

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-green?style=flat-square"></a>
-  <a href="#version-history"><img alt="Version" src="https://img.shields.io/badge/version-5.15-blue?style=flat-square"></a>
+  <a href="#version-history"><img alt="Version" src="https://img.shields.io/badge/version-5.16-blue?style=flat-square"></a>
   <a href="docs/getting-started.md"><img alt="Platform" src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey?style=flat-square"></a>
   <a href="https://code.claude.com"><img alt="Claude Code" src="https://img.shields.io/badge/Claude_Code-enabled-purple?style=flat-square"></a>
   <a href="https://developers.openai.com/codex/"><img alt="Codex CLI" src="https://img.shields.io/badge/Codex_CLI-required-orange?style=flat-square"></a>
@@ -143,6 +143,7 @@ Recent releases:
 
 | Version | Date       | Highlights                                                                                                                     |
 | ------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| 5.16    | 2026-04-28 | Migration UX — consolidated "ask Claude" reconcile message; dropped cry-wolf drift hint                                        |
 | 5.15    | 2026-04-28 | CONTINUITY split — durable facts to CLAUDE.md, decisions to `docs/adr/`, volatile state to gitignored `.claude/local/state.md` |
 | 5.14    | 2026-04-27 | Drift hygiene — SessionStart `git fetch` warning + worktree from `origin/<default>`                                            |
 | 5.13    | 2026-04-21 | Phase 4 task-DAG dispatch with file-conflict constraints                                                                       |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to claude-codex-forge.
 
+## 5.16 — 2026-04-28 · Migration UX — consolidated "ask Claude" reconcile message; dropped cry-wolf drift hint
+
+Replaces two separate warnings with one consolidated instruction:
+
+- `setup.sh -f` / `--upgrade` previously printed "⚠ Template may have drifted since your last upgrade" with a `git diff --no-index` command on every run, regardless of actual drift — cry wolf.
+- `setup.sh --migrate` previously printed a separate "@CONTINUITY.md dangling import — remove manually" warning.
+
+Both are now replaced by a single Variant B message at the end of `--migrate` output telling the user to paste this prompt into Claude Code:
+
+> Reconcile my CLAUDE.md against `$SCRIPT_DIR/CLAUDE.template.md`. Port any new template sections I'm missing, preserving my project-specific content. If you see an `@CONTINUITY.md` line on top, remove it -- it's a dangling import from before the 5.15 migration.
+
+Codex reviewed Variant A (minimal — bet that "reconcile" naturally removes the @-import) vs Variant B (explicit @-import callout); picked B because "reconcile + preserve project-specific" gives Claude room to keep unmatched top-of-file lines, and the @-import line is exactly the kind of stale-but-user-owned content that can survive without explicit naming.
+
+A "Manual fallback" subsection in `docs/guides/upgrading.md` covers SSH / scripted-install users (per Codex's caveat).
+
+- `scripts/migrate-continuity.{sh,ps1}` — replace @-import warning with Variant B message; both compute their own SCRIPT_DIR (bash/PS dispatch is direct, no env-var pass-through).
+- `setup.sh` + `setup.ps1` — drop the `git diff --no-index ... CLAUDE.template.md ...` cry-wolf hint from the upgrade summary. Legacy CONTINUITY.md detection block stays (actionable, not cry-wolf). Four-variant Upgrade-done message stays.
+- `docs/guides/upgrading.md` — add "Manual fallback" subsection; rewrite the dangling-import paragraph to point at the migration's Variant B prompt.
+- `README.md` — version badge bump 5.15 → 5.16, prepend version-history row.
+
+**Existing installs:** the new wording lands on next `setup.sh --upgrade`. No content migration needed.
+
 ## 5.15 — 2026-04-28 · CONTINUITY split — durable facts to CLAUDE.md, decisions to docs/adr/, volatile state to .claude/local/state.md (gitignored)
 
 Closes the multi-developer state-file conflict failure mode at the source: CONTINUITY.md mixed two genres (durable team-shared facts + volatile per-developer state) in one tracked file, producing merge conflicts on every multi-dev pull and silently injecting stale per-developer state into Claude's auto-loaded context. PR #2 of the multi-PR drift-hygiene initiative; PR #1 (drift-hygiene, 5.14) addressed the symptom via SessionStart fetch + warning. PR #2 fixes the source by splitting the artifact.

--- a/docs/guides/upgrading.md
+++ b/docs/guides/upgrading.md
@@ -85,13 +85,7 @@ The migration assistant is **deterministic, idempotent, and non-destructive**:
 - The original `CONTINUITY.md` is **preserved byte-for-byte**. The script never modifies or deletes it. Once you've reviewed the migrated outputs, you can delete the legacy file yourself.
 - A sentinel marker is written into each migrated destination so re-running `--migrate` is safe — the assistant detects already-migrated content and skips it.
 
-If your `CLAUDE.md` still contains a `@CONTINUITY.md` import line (the pre-5.15 default), the migration assistant **flags it but does not auto-edit**. Claude Code's `@`-imports fail silently when the target is missing, so the dangling import won't crash anything — but it's clutter. Remove the line manually:
-
-```diff
--@CONTINUITY.md
--
- # CLAUDE.md - my-project
-```
+If your `CLAUDE.md` still contains a `@CONTINUITY.md` import line (the pre-5.15 default), the migration assistant **flags it and prints a prompt you can paste into Claude Code**. The prompt asks Claude to reconcile your `CLAUDE.md` against the latest `CLAUDE.template.md` (porting any new template sections you're missing while preserving project-specific content) AND to remove the dangling `@CONTINUITY.md` line in the same operation. Claude Code's `@`-imports fail silently when the target is missing, so the dangling import won't crash anything — but it's clutter that's worth a one-shot reconcile pass.
 
 ### Verifying the migration
 
@@ -110,3 +104,21 @@ ls -la CONTINUITY.md
 ```
 
 If any of those four checks fails, see the [troubleshooting guide](../troubleshooting.md#migration-and-the-volatile-state-file) for recovery steps.
+
+### Manual fallback (no Claude Code at hand)
+
+If you're upgrading over SSH, in a CI pipeline, or in any context where you can't paste prompts into Claude Code, the migration's "ask Claude to reconcile" recommendation can be done manually:
+
+```bash
+# Remove the dangling @CONTINUITY.md import
+sed -i.bak '/^@CONTINUITY\.md$/d' CLAUDE.md && rm CLAUDE.md.bak
+
+# Diff your CLAUDE.md against the latest template
+git diff --no-index -- ~/Code/claude-codex-forge/CLAUDE.template.md CLAUDE.md
+
+# Manually merge any template sections you want, preserving project-specific content
+```
+
+(Substitute your actual Forge clone path if different.)
+
+The Claude-mediated path is recommended because Claude can judge what counts as "project-specific" vs "stale template scaffolding"; the manual diff requires you to make those calls yourself.

--- a/scripts/migrate-continuity.ps1
+++ b/scripts/migrate-continuity.ps1
@@ -7,6 +7,12 @@
 # matching the bash 'set -u' (no -e) discipline.
 Set-StrictMode -Version Latest
 
+# Resolve this script's Forge-clone root so the dangling-import reconcile
+# message can name the canonical CLAUDE.template.md path. Forward slash kept
+# in the emitted text for cross-platform display + bash/PS parity (we
+# normalize $PSScriptRoot's backslashes to forward slashes when emitting).
+$ScriptDir = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path -replace '\\', '/'
+
 $LegacyFile = "CONTINUITY.md"
 $SentinelPrefix = "<!-- forge:migrated"
 $SentinelToday = "<!-- forge:migrated $(Get-Date -Format 'yyyy-MM-dd') -->"
@@ -288,8 +294,22 @@ foreach ($section in @("Now", "Next")) {
 }
 
 # --- (d) Flag dangling @CONTINUITY.md import in CLAUDE.md ---
+# Variant B reconcile-prompt: byte-equivalent to bash mirror's warning text
+# (AC-4 parity). LF separators via "`n" (PS literal LF, NOT CRLF). The literal
+# "@CONTINUITY.md" and "dangling" tokens are preserved for the existing
+# fixture asserts in tests/template/test-migrate.sh.
 if ((Test-Path "CLAUDE.md") -and (Select-String -Path "CLAUDE.md" -Pattern '^@CONTINUITY\.md\b' -Quiet -ErrorAction SilentlyContinue)) {
-    [void]$warnings.Add("CLAUDE.md still contains a '@CONTINUITY.md' dangling import - Claude Code silently ignores missing imports, but you may want to remove the line manually for cleanliness.")
+    $reconcilePrompt = "CLAUDE.md still contains an '@CONTINUITY.md' dangling import.`n" +
+        "    Open Claude Code in this project and paste this prompt:`n" +
+        "`n" +
+        "      Reconcile my CLAUDE.md against $ScriptDir/CLAUDE.template.md.`n" +
+        "      Port any new template sections I'm missing, preserving my`n" +
+        "      project-specific content. If you see an @CONTINUITY.md line`n" +
+        "      on top, remove it -- it's a dangling import from before the`n" +
+        "      5.15 migration.`n" +
+        "`n" +
+        "    (Not in Claude Code? See docs/guides/upgrading.md `"Manual fallback`".)"
+    [void]$warnings.Add($reconcilePrompt)
 }
 
 # --- (e) Print summary (byte-equivalent strings to bash) ---

--- a/scripts/migrate-continuity.sh
+++ b/scripts/migrate-continuity.sh
@@ -12,6 +12,11 @@ set -u  # fail on unset vars; do NOT set -e (we handle errors explicitly)
 # matches scripts/migrate-continuity.ps1 byte-for-byte under the test contract.
 # If interactive callers want color, setup.sh / setup.ps1 can wrap the dispatch.
 
+# Resolve this script's Forge-clone root so the dangling-import reconcile
+# message can name the canonical CLAUDE.template.md path. Forward slash kept
+# in the emitted text for cross-platform display + bash/PS parity.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
 # Sentinel marker for idempotency -- embedded in migrated content.
 SENTINEL_PREFIX="<!-- forge:migrated"
 SENTINEL_TODAY="<!-- forge:migrated $(date +%Y-%m-%d) -->"
@@ -276,8 +281,22 @@ for section in Now Next; do
 done
 
 # --- (d) Flag dangling @CONTINUITY.md import in CLAUDE.md ---
+# Variant B reconcile-prompt: one consolidated "ask Claude" instruction that
+# (a) reconciles CLAUDE.md against the latest template AND (b) removes the
+# dangling @-import in a single operation. The literal "@CONTINUITY.md" and
+# "dangling" tokens are preserved for the existing fixture asserts in
+# tests/template/test-migrate.sh and for keyword-grep discoverability.
 if [ -f "CLAUDE.md" ] && grep -qE '^@CONTINUITY\.md\b' CLAUDE.md; then
-    warnings+=("CLAUDE.md still contains a '@CONTINUITY.md' dangling import - Claude Code silently ignores missing imports, but you may want to remove the line manually for cleanliness.")
+    warnings+=("CLAUDE.md still contains an '@CONTINUITY.md' dangling import.
+    Open Claude Code in this project and paste this prompt:
+
+      Reconcile my CLAUDE.md against $SCRIPT_DIR/CLAUDE.template.md.
+      Port any new template sections I'm missing, preserving my
+      project-specific content. If you see an @CONTINUITY.md line
+      on top, remove it -- it's a dangling import from before the
+      5.15 migration.
+
+    (Not in Claude Code? See docs/guides/upgrading.md \"Manual fallback\".)")
 fi
 
 # --- (e) Print summary (ASCII-safe characters for AC-4 byte-equivalence with PS) ---

--- a/setup.ps1
+++ b/setup.ps1
@@ -990,25 +990,10 @@ if ($Upgrade) {
     Write-Host "   git commit -m `"chore: upgrade Claude Code automation templates`""
     Write-Host "   git push"
     Write-Host ""
-    # Consolidated drift reminder — surface once at the end. Only mention files
-    # that were actually preserved (boolean-gated, no false claims).
-    if ($hadClaude -or $hadContinuity) {
-        Write-Color "! Template may have drifted since your last upgrade." "Yellow"
-        Write-Host "  Review and merge any new sections manually:"
-        # Single-quoted paths + Get-Location-absolutized local side so the
-        # command survives copy-paste regardless of shell metachars or cwd.
-        $cwd = (Get-Location).Path
-        if ($hadClaude) {
-            $templatePath = Join-Path $ScriptDir "CLAUDE.template.md"
-            $localAbs = Join-Path $cwd "CLAUDE.md"
-            Write-Host "    git diff --no-index -- '$templatePath' '$localAbs'"
-        }
-        if ($hadContinuity) {
-            Write-Host "    (Legacy CONTINUITY.md detected -- see migration prompt below.)"
-        }
-        Write-Host "  (Or ask Claude to reconcile - point it at the diff output.)"
-        Write-Host ""
-    }
+    # 5.16: dropped the "Template may have drifted" cry-wolf preamble that
+    # fired on every --upgrade regardless of actual drift. The migration
+    # script's Variant B "ask Claude to reconcile" message handles drift
+    # reconciliation when it actually matters (during --migrate).
     # PR #2 (continuity-split): legacy CONTINUITY.md migration prompt.
     if ($hadContinuity) {
         Write-Color "! Legacy CONTINUITY.md detected." "Yellow"

--- a/setup.sh
+++ b/setup.sh
@@ -908,26 +908,10 @@ if [[ "$UPGRADE" == true ]]; then
     echo "   git commit -m \"chore: upgrade Claude Code automation templates\""
     echo "   git push"
     echo ""
-    # Consolidated drift reminder — surface once at the end so users who scrolled
-    # past the per-file hints still see a reconciliation prompt. Only mention
-    # files that were actually preserved (boolean-gated, no false claims).
-    if [[ "$had_claude_md" == true ]] || [[ "$had_continuity_md" == true ]]; then
-        echo -e "${YELLOW}⚠ Template may have drifted since your last upgrade.${NC}"
-        echo "  Review and merge any new sections manually:"
-        # Single-quoted paths + absolute local path so the command survives
-        # copy-paste regardless of shell metachars or working dir. cwd is
-        # captured once — avoids re-forking $(pwd) per emitted line and
-        # mirrors setup.ps1's $cwd = (Get-Location).Path pattern for parity.
-        local_cwd="$(pwd)"
-        if [[ "$had_claude_md" == true ]]; then
-            echo "    git diff --no-index -- '$SCRIPT_DIR/CLAUDE.template.md' '$local_cwd/CLAUDE.md'"
-        fi
-        if [[ "$had_continuity_md" == true ]]; then
-            echo "    (Legacy CONTINUITY.md detected — see migration prompt below.)"
-        fi
-        echo "  (Or ask Claude to reconcile — point it at the diff output.)"
-        echo ""
-    fi
+    # 5.16: dropped the "Template may have drifted" cry-wolf preamble that
+    # fired on every --upgrade regardless of actual drift. The migration
+    # script's Variant B "ask Claude to reconcile" message handles drift
+    # reconciliation when it actually matters (during --migrate).
     # PR #2 (continuity-split): legacy CONTINUITY.md migration prompt.
     if [[ "$had_continuity_md" == true ]]; then
         echo -e "${YELLOW}⚠ Legacy CONTINUITY.md detected.${NC}"


### PR DESCRIPTION
## Summary

Replaces two separate warnings with one consolidated "ask Claude" instruction:

1. `setup.sh -f` / `--upgrade` previously printed "Template may have drifted since your last upgrade" with a git diff command on every run regardless of actual drift -- cry wolf.
2. `setup.sh --migrate` previously printed a separate "@CONTINUITY.md dangling import -- remove manually" warning.

Both -> one Variant B message at the end of `--migrate` telling the user to paste a prompt into Claude Code that reconciles CLAUDE.md against the latest template AND removes the dangling @-import in one operation.

Codex reviewed Variant A (minimal) vs Variant B (explicit @-import callout) and picked B because "reconcile + preserve project-specific" gives Claude room to keep unmatched top-of-file lines.

Manual fallback for SSH/script users added to `docs/guides/upgrading.md` per Codex's caveat.

## Files changed

- `scripts/migrate-continuity.{sh,ps1}` -- Variant B message; both compute their own SCRIPT_DIR
- `setup.sh` + `setup.ps1` -- drop the cry-wolf consolidated drift preamble (per-file inline hint stays)
- `docs/guides/upgrading.md` -- add "Manual fallback"; rewrite dangling-import paragraph
- `docs/CHANGELOG.md` -- 5.16 entry
- `README.md` -- badge bump + version-history row

## Test plan

- [x] `bash tests/template/run-all.sh`: all 5 suites green (test-lint 31, test-fixtures 23, test-contracts 81, test-hooks 36, test-default-branch 18, test-session-start 18, test-migrate 28, test-setup 119)
- [x] `migration-parity-bash-vs-ps` contract still passes (no pwsh locally -> graceful skip; bash + PS warning text constructed for byte-equivalence)
- [x] Bash migrate output manually inspected on `@CONTINUITY.md` fixture -- Variant B prompt formatted correctly
- [x] CHANGELOG entry 5.16 added
- [x] README badge + version-history bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)