### PR TITLE
fix(setup): drop per-file drift hint; soft 'ask Claude to reconcile' tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-green?style=flat-square"></a>
-  <a href="#version-history"><img alt="Version" src="https://img.shields.io/badge/version-5.16-blue?style=flat-square"></a>
+  <a href="#version-history"><img alt="Version" src="https://img.shields.io/badge/version-5.17-blue?style=flat-square"></a>
   <a href="docs/getting-started.md"><img alt="Platform" src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey?style=flat-square"></a>
   <a href="https://code.claude.com"><img alt="Claude Code" src="https://img.shields.io/badge/Claude_Code-enabled-purple?style=flat-square"></a>
   <a href="https://developers.openai.com/codex/"><img alt="Codex CLI" src="https://img.shields.io/badge/Codex_CLI-required-orange?style=flat-square"></a>
@@ -143,6 +143,7 @@ Recent releases:
 
 | Version | Date       | Highlights                                                                                                                     |
 | ------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| 5.17    | 2026-04-28 | Drop per-file template-drift cry-wolf hint; soft "ask Claude to reconcile" tip                                                 |
 | 5.16    | 2026-04-28 | Migration UX — consolidated "ask Claude" reconcile message; dropped cry-wolf drift hint                                        |
 | 5.15    | 2026-04-28 | CONTINUITY split — durable facts to CLAUDE.md, decisions to `docs/adr/`, volatile state to gitignored `.claude/local/state.md` |
 | 5.14    | 2026-04-27 | Drift hygiene — SessionStart `git fetch` warning + worktree from `origin/<default>`                                            |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to claude-codex-forge.
 
+## 5.17 — 2026-04-28 · Drop per-file template-drift cry-wolf hint; soft "ask Claude to reconcile" tip
+
+Removes the per-file inline `Template may have drifted. To review: git diff --no-index ...` hint that fired every time CLAUDE.md was preserved during `--upgrade`. Same cry-wolf problem as the consolidated preamble dropped in 5.16, just at a different layer.
+
+Replaced with a single soft tip at end of upgrade summary recommending the full Variant B "ask Claude to reconcile" prompt (matches the migration script's wording from 5.16, including the `@CONTINUITY.md` dangling-import cleanup clause for consistency). Fires once per upgrade (when CLAUDE.md was preserved), not per-file. Soft `Tip:` prefix in blue, no warning glyph.
+
+The "Full guide" reference uses the absolute path to the Forge clone (`$SCRIPT_DIR/docs/guides/upgrading.md` on bash, `$ScriptDir/docs/guides/upgrading.md` on PowerShell) so it resolves correctly when users run `setup.sh --upgrade` from inside their project (the harness guides aren't shipped to downstream installs).
+
+This is a fix-up of an earlier attempt that Codex flagged with two P2 issues: the soft tip dropped the `@CONTINUITY.md` cleanup clause (inconsistent with Variant B), and the "Full guide" reference used a relative path that resolved under the user's project. Both addressed here.
+
+- `setup.sh` + `setup.ps1` — removed inline `print_template_drift_hint` / `Write-TemplateDriftHint` helpers + invocations; added soft tip at end of upgrade summary with full Variant B prompt and absolute-path guide reference
+- `tests/template/test-setup.sh` + `test-contracts.sh` — updated assertions: legacy "Template may have drifted" string banned in installers, soft tip + `@CONTINUITY.md` clause present, absolute path used for "Full guide"
+
 ## 5.16 — 2026-04-28 · Migration UX — consolidated "ask Claude" reconcile message; dropped cry-wolf drift hint
 
 Replaces two separate warnings with one consolidated instruction:

--- a/setup.ps1
+++ b/setup.ps1
@@ -126,28 +126,6 @@ function Copy-TemplateFile {
     Write-Host " Created $Description"
 }
 
-# Template-drift hint: fired when a user-owned file is preserved and the
-# harness template may have evolved since the user's last upgrade. Points
-# the user at the canonical diff command (git diff --no-index works in
-# Git Bash on Windows, no bash prerequisite beyond git).
-#
-# Paths are wrapped in single-quotes in the emitted command so they survive
-# copy-paste regardless of shell metachars in the path. The local file is
-# absolutized against Get-Location so the suggestion still works if the user
-# cd's elsewhere before pasting.
-function Write-TemplateDriftHint {
-    param(
-        [string]$TemplateName,  # e.g., CLAUDE.template.md
-        [string]$LocalName      # e.g., CLAUDE.md
-    )
-    Write-Host "    " -NoNewline
-    Write-Color "!" "Yellow"
-    Write-Host "  Template may have drifted. To review:"
-    $templatePath = Join-Path $ScriptDir $TemplateName
-    $localAbs = Join-Path (Get-Location).Path $LocalName
-    Write-Host "         git diff --no-index -- '$templatePath' '$localAbs'"
-}
-
 # ============================================================================
 # GLOBAL SETUP (-Global flag)
 # ============================================================================
@@ -534,7 +512,6 @@ $hadContinuity = Test-Path "CONTINUITY.md"
 
 if ($hadClaude) {
     Write-Host "  " -NoNewline; Write-Color "o" "Blue"; Write-Host " CLAUDE.md already exists (never overwritten - user content)"
-    Write-TemplateDriftHint "CLAUDE.template.md" "CLAUDE.md"
 } else {
     Copy-TemplateFile (Join-Path $ScriptDir "CLAUDE.template.md") "CLAUDE.md" "CLAUDE.md"
 }
@@ -990,10 +967,12 @@ if ($Upgrade) {
     Write-Host "   git commit -m `"chore: upgrade Claude Code automation templates`""
     Write-Host "   git push"
     Write-Host ""
-    # 5.16: dropped the "Template may have drifted" cry-wolf preamble that
-    # fired on every --upgrade regardless of actual drift. The migration
-    # script's Variant B "ask Claude to reconcile" message handles drift
-    # reconciliation when it actually matters (during --migrate).
+    # 5.16: dropped the consolidated cry-wolf drift preamble that fired on
+    # every --upgrade regardless of actual drift. The migration script's
+    # Variant B "ask Claude to reconcile" message handles drift reconciliation
+    # when it actually matters (during --migrate). 5.17: also dropped the
+    # per-file inline drift hint at the same layer; replaced by the soft tip
+    # at end of upgrade summary below.
     # PR #2 (continuity-split): legacy CONTINUITY.md migration prompt.
     if ($hadContinuity) {
         Write-Color "! Legacy CONTINUITY.md detected." "Yellow"
@@ -1018,6 +997,27 @@ if ($Upgrade) {
         Write-Color "Upgrade done! Your CONTINUITY.md was preserved (run -Migrate to move content to the new structure)." "Green"
     } else {
         Write-Color "Upgrade done!" "Green"
+    }
+
+    # 5.17: soft tip recommending Claude-driven CLAUDE.md reconciliation when
+    # the user's CLAUDE.md was preserved. Replaces the per-file inline drift
+    # hint (cry-wolf -- fired every upgrade regardless of actual drift). Uses
+    # the full Variant B prompt from the migration script for consistency,
+    # including the @CONTINUITY.md dangling-import cleanup clause. The "Full
+    # guide" reference uses an absolute path to the Forge clone so it resolves
+    # correctly when users run setup.ps1 -Upgrade from inside their project.
+    if ($hadClaude) {
+        Write-Host ""
+        Write-Host "Tip:" -ForegroundColor Blue -NoNewline
+        Write-Host " ask Claude to reconcile your CLAUDE.md against the latest template:"
+        Write-Host ""
+        Write-Host "  `"Reconcile my CLAUDE.md against $ScriptDir/CLAUDE.template.md."
+        Write-Host "   Port any new template sections, preserving my project-specific content."
+        Write-Host "   If you see an @CONTINUITY.md line on top, remove it -- it's a dangling"
+        Write-Host "   import from before the 5.15 migration.`""
+        Write-Host ""
+        Write-Host "  (Full guide: $ScriptDir/docs/guides/upgrading.md)"
+        Write-Host ""
     }
 } else {
     Write-Color "============================================" "Green"

--- a/setup.sh
+++ b/setup.sh
@@ -135,22 +135,6 @@ copy_file() {
     echo -e "  ${GREEN}✓${NC} Created $desc"
 }
 
-# Template-drift hint: fired when a user-owned file is preserved and the
-# harness template may have evolved since the user's last upgrade. The user
-# has to reconcile manually — we point them at the canonical diff command.
-#
-# Paths are wrapped in single-quotes in the emitted command so they survive
-# copy-paste regardless of shell metachars in the path (a path containing
-# '$USER' would otherwise re-expand on paste). The local file is absolutized
-# against $(pwd) so the suggestion still works if the user cd's elsewhere
-# before pasting.
-print_template_drift_hint() {
-    local template_name="$1"  # e.g., CLAUDE.template.md
-    local local_name="$2"     # e.g., CLAUDE.md
-    echo -e "    ${YELLOW}⚠${NC}  Template may have drifted. To review:"
-    echo -e "         git diff --no-index -- '$SCRIPT_DIR/$template_name' '$(pwd)/$local_name'"
-}
-
 # ============================================================================
 # GLOBAL SETUP (--global flag)
 # ============================================================================
@@ -519,7 +503,6 @@ if [[ -f "CONTINUITY.md" ]]; then had_continuity_md=true; else had_continuity_md
 
 if [[ "$had_claude_md" == true ]]; then
     echo -e "  ${BLUE}○${NC} CLAUDE.md already exists (never overwritten — user content)"
-    print_template_drift_hint "CLAUDE.template.md" "CLAUDE.md"
 else
     copy_file "$SCRIPT_DIR/CLAUDE.template.md" "CLAUDE.md" "CLAUDE.md"
 fi
@@ -908,10 +891,12 @@ if [[ "$UPGRADE" == true ]]; then
     echo "   git commit -m \"chore: upgrade Claude Code automation templates\""
     echo "   git push"
     echo ""
-    # 5.16: dropped the "Template may have drifted" cry-wolf preamble that
-    # fired on every --upgrade regardless of actual drift. The migration
-    # script's Variant B "ask Claude to reconcile" message handles drift
-    # reconciliation when it actually matters (during --migrate).
+    # 5.16: dropped the consolidated cry-wolf drift preamble that fired on
+    # every --upgrade regardless of actual drift. The migration script's
+    # Variant B "ask Claude to reconcile" message handles drift reconciliation
+    # when it actually matters (during --migrate). 5.17: also dropped the
+    # per-file inline drift hint at the same layer; replaced by the soft tip
+    # at end of upgrade summary below.
     # PR #2 (continuity-split): legacy CONTINUITY.md migration prompt.
     if [[ "$had_continuity_md" == true ]]; then
         echo -e "${YELLOW}⚠ Legacy CONTINUITY.md detected.${NC}"
@@ -936,6 +921,26 @@ if [[ "$UPGRADE" == true ]]; then
         echo -e "${GREEN}Upgrade done! Your CONTINUITY.md was preserved (run --migrate to move content to the new structure).${NC}"
     else
         echo -e "${GREEN}Upgrade done!${NC}"
+    fi
+
+    # 5.17: soft tip recommending Claude-driven CLAUDE.md reconciliation when
+    # the user's CLAUDE.md was preserved. Replaces the per-file inline drift
+    # hint (cry-wolf — fired every upgrade regardless of actual drift). Uses
+    # the full Variant B prompt from the migration script for consistency,
+    # including the @CONTINUITY.md dangling-import cleanup clause. The "Full
+    # guide" reference uses an absolute path to the Forge clone so it resolves
+    # correctly when users run setup.sh --upgrade from inside their project.
+    if [[ "$had_claude_md" == true ]]; then
+        echo ""
+        echo -e "${BLUE}Tip:${NC} ask Claude to reconcile your CLAUDE.md against the latest template:"
+        echo ""
+        echo "  \"Reconcile my CLAUDE.md against $SCRIPT_DIR/CLAUDE.template.md."
+        echo "   Port any new template sections, preserving my project-specific content."
+        echo "   If you see an @CONTINUITY.md line on top, remove it -- it's a dangling"
+        echo "   import from before the 5.15 migration.\""
+        echo ""
+        echo "  (Full guide: $SCRIPT_DIR/docs/guides/upgrading.md)"
+        echo ""
     fi
 else
     echo -e "${GREEN}============================================${NC}"

--- a/tests/template/test-contracts.sh
+++ b/tests/template/test-contracts.sh
@@ -182,42 +182,78 @@ assert_file_exists "$REPO_ROOT/docs/guides/multi-project-isolation.md" \
     "canonical isolation guide exists"
 
 # ---------------------------------------------------------------------------
-# Contract 7: Template-drift hint + upgrade-summary parity
+# Contract 7: Soft "ask Claude to reconcile" tip + upgrade-summary parity
 #
-# Both installers must ship the same drift hint helper AND the same four
+# Both installers must ship the same end-of-summary soft tip AND the same four
 # boolean-gated final-summary variants. Without this contract, setup.ps1 can
 # silently diverge from setup.sh (bash tests don't execute PowerShell).
+#
+# 5.17: replaced the per-file inline "Template may have drifted ... git diff
+# --no-index" hint (cry-wolf — fired every upgrade regardless of actual drift)
+# with a single end-of-summary soft tip that recommends the full Variant B
+# "ask Claude to reconcile" prompt (matches the migration script's wording,
+# including the @CONTINUITY.md dangling-import cleanup clause).
 # ---------------------------------------------------------------------------
-start_test "Template-drift hint + upgrade-summary parity"
+start_test "Soft reconcile tip + upgrade-summary parity"
 
 SETUP_SH="$REPO_ROOT/setup.sh"
 SETUP_PS1="$REPO_ROOT/setup.ps1"
 
-# (i) User-facing drift-hint string
-DRIFT_MSG="Template may have drifted"
-assert_contains "$SETUP_SH"  "$DRIFT_MSG" "setup.sh contains drift-hint message"
-assert_contains "$SETUP_PS1" "$DRIFT_MSG" "setup.ps1 contains drift-hint message"
+# (i) Legacy cry-wolf drift-hint string MUST be absent from both installers
+# (5.17 regression guard). The literal "Template may have drifted" must not
+# appear anywhere in setup.{sh,ps1} — including comments — to make the regression
+# guard unambiguous. Comments referencing the legacy hint use a paraphrased form.
+assert_not_contains "$SETUP_SH"  "Template may have drifted" \
+    "setup.sh does NOT contain legacy 'Template may have drifted' cry-wolf hint (5.17)"
+assert_not_contains "$SETUP_PS1" "Template may have drifted" \
+    "setup.ps1 does NOT contain legacy 'Template may have drifted' cry-wolf hint (5.17)"
+
+# (i-bis) Drift-hint helpers must be removed (no orphaned definitions or callsites)
+assert_not_contains "$SETUP_SH"  "print_template_drift_hint" \
+    "setup.sh does NOT contain print_template_drift_hint helper or callsites (5.17)"
+assert_not_contains "$SETUP_PS1" "Write-TemplateDriftHint" \
+    "setup.ps1 does NOT contain Write-TemplateDriftHint helper or callsites (5.17)"
 
 # (ii) Template filenames referenced
 # Post PR #2: CONTINUITY.template.md no longer ships, so it must NOT be
 # referenced from setup.{sh,ps1}. CLAUDE.template.md remains the source for
-# the preserved-CLAUDE drift hint.
+# the preserved-CLAUDE soft reconcile tip.
 assert_contains     "$SETUP_SH"  "CLAUDE.template.md"      "setup.sh references CLAUDE.template.md"
 assert_not_contains "$SETUP_SH"  "CONTINUITY.template.md"  "setup.sh does NOT reference CONTINUITY.template.md (deleted in PR #2)"
 assert_contains     "$SETUP_PS1" "CLAUDE.template.md"      "setup.ps1 references CLAUDE.template.md"
 assert_not_contains "$SETUP_PS1" "CONTINUITY.template.md"  "setup.ps1 does NOT reference CONTINUITY.template.md (deleted in PR #2)"
 
-# (iii) git diff --no-index suggested (cross-platform, works in Git Bash)
-assert_contains "$SETUP_SH"  "git diff --no-index" "setup.sh suggests git diff --no-index"
-assert_contains "$SETUP_PS1" "git diff --no-index" "setup.ps1 suggests git diff --no-index"
+# (iii) Soft tip is present in both installers (5.17). The "Tip:" prefix +
+# "ask Claude to reconcile" anchor are the user-visible identity of the new tip.
+assert_contains "$SETUP_SH"  "ask Claude to reconcile your CLAUDE.md against the latest template" \
+    "setup.sh contains soft 'ask Claude to reconcile' tip (5.17)"
+assert_contains "$SETUP_PS1" "ask Claude to reconcile your CLAUDE.md against the latest template" \
+    "setup.ps1 contains soft 'ask Claude to reconcile' tip (5.17)"
 
-# (iv) Exact call-site fingerprints — prove the CLAUDE.md drift-hint helper
-# is invoked, not dead. The CONTINUITY drift-hint call site is removed in
-# PR #2 (the file is gone); migration prompt replaces it.
-assert_contains "$SETUP_SH" 'print_template_drift_hint "CLAUDE.template.md" "CLAUDE.md"' \
-    "setup.sh calls drift-hint helper for CLAUDE.md"
-assert_contains "$SETUP_PS1" 'Write-TemplateDriftHint "CLAUDE.template.md" "CLAUDE.md"' \
-    "setup.ps1 calls drift-hint helper for CLAUDE.md"
+# (iv) Soft tip MUST include the full Variant B prompt with the @CONTINUITY.md
+# dangling-import cleanup clause (matches migration script wording from 5.16).
+# Codex-flagged P2 #1 from the v1 attempt: dropping this clause leaves users on
+# a non-migrate path without instructions to remove the dangling import.
+assert_contains "$SETUP_SH"  "Reconcile my CLAUDE.md against" \
+    "setup.sh soft tip includes Variant B 'Reconcile my CLAUDE.md against' prompt"
+assert_contains "$SETUP_SH"  "@CONTINUITY.md line on top" \
+    "setup.sh soft tip includes @CONTINUITY.md dangling-import cleanup clause"
+assert_contains "$SETUP_SH"  "dangling" \
+    "setup.sh soft tip explains the @CONTINUITY.md line is a dangling import"
+assert_contains "$SETUP_PS1" "Reconcile my CLAUDE.md against" \
+    "setup.ps1 soft tip includes Variant B 'Reconcile my CLAUDE.md against' prompt"
+assert_contains "$SETUP_PS1" "@CONTINUITY.md line on top" \
+    "setup.ps1 soft tip includes @CONTINUITY.md dangling-import cleanup clause"
+assert_contains "$SETUP_PS1" "dangling" \
+    "setup.ps1 soft tip explains the @CONTINUITY.md line is a dangling import"
+
+# (v) "Full guide" reference uses absolute path semantics ($SCRIPT_DIR / $ScriptDir)
+# so the link resolves to the Forge clone's docs/guides/upgrading.md, not the
+# user's project (where the guide doesn't exist). Codex-flagged P2 #2 from v1.
+assert_contains "$SETUP_SH"  '(Full guide: $SCRIPT_DIR/docs/guides/upgrading.md)' \
+    "setup.sh 'Full guide' reference uses \$SCRIPT_DIR absolute path (5.17)"
+assert_contains "$SETUP_PS1" '(Full guide: $ScriptDir/docs/guides/upgrading.md)' \
+    "setup.ps1 'Full guide' reference uses \$ScriptDir absolute path (5.17)"
 
 # (iv-bis) Migration prompt — both installers must surface --migrate (sh) /
 # -Migrate (ps1) when a legacy CONTINUITY.md is detected.

--- a/tests/template/test-setup.sh
+++ b/tests/template/test-setup.sh
@@ -233,11 +233,13 @@ assert_file_exists "$S8/.claude/commands/new-feature.md" \
 assert_file_exists "$S8/docs/CHANGELOG.md" \
     "initial install created docs/CHANGELOG.md"
 
-# First-install drift-notice regression guard: LOG8a is the initial-install
+# First-install soft-tip regression guard: LOG8a is the initial-install
 # log from above. CLAUDE.md/CONTINUITY.md did not exist before that run, so
-# no drift hint should have fired.
+# no soft tip (or legacy drift notice) should have fired.
 assert_not_contains "$LOG8a" "Template may have drifted" \
-    "first install does NOT show drift notice (UC3 regression guard)"
+    "first install does NOT show legacy drift notice (UC3 regression guard)"
+assert_not_contains "$LOG8a" "ask Claude to reconcile" \
+    "first install does NOT show soft reconcile tip (5.17 regression guard)"
 
 # Simulate the user actually using CHANGELOG and CLAUDE.md — they add their
 # own release entries and project notes. This is the content that MUST NOT
@@ -272,15 +274,25 @@ assert_hash_equals "$S8/CLAUDE.md" "$HASH_CLAUDE" \
 assert_hash_equals "$S8/CONTINUITY.md" "$HASH_CONTINUITY" \
     "--upgrade does not touch CONTINUITY.md at all"
 
-# UC1 drift notice: --upgrade with BOTH user files present → per-file hints,
-# consolidated reminder, both-preserved final summary.
-# Post PR #2: CONTINUITY.template.md no longer exists, so the per-file diff
-# hint only applies to CLAUDE.md. Legacy CONTINUITY.md gets a migration prompt
-# instead, and the both-preserved final summary now points at --migrate.
-assert_contains "$LOG8b" "Template may have drifted" \
-    "UC1: --upgrade shows drift notice"
-assert_contains "$LOG8b" "git diff --no-index" \
-    "UC1: --upgrade suggests git diff --no-index"
+# UC1 soft tip: --upgrade with CLAUDE.md preserved → end-of-summary soft tip
+# with full Variant B prompt, both-preserved final summary, migration prompt
+# for legacy CONTINUITY.md.
+# Post PR #2: CONTINUITY.template.md no longer exists. Legacy CONTINUITY.md gets
+# a migration prompt, and the both-preserved final summary points at --migrate.
+# 5.17: per-file inline drift hint dropped; soft tip fires once at end of summary
+# when CLAUDE.md was preserved.
+assert_not_contains "$LOG8b" "Template may have drifted" \
+    "UC1: --upgrade does NOT contain legacy 'Template may have drifted' hint (5.17)"
+assert_contains "$LOG8b" "ask Claude to reconcile your CLAUDE.md" \
+    "UC1: --upgrade shows soft reconcile tip (5.17)"
+assert_contains "$LOG8b" "Reconcile my CLAUDE.md against" \
+    "UC1: --upgrade soft tip includes full Variant B prompt"
+assert_contains "$LOG8b" "@CONTINUITY.md line on top" \
+    "UC1: --upgrade soft tip includes @CONTINUITY.md cleanup clause"
+assert_contains "$LOG8b" "Full guide:" \
+    "UC1: --upgrade soft tip includes 'Full guide:' reference"
+assert_contains "$LOG8b" "/docs/guides/upgrading.md" \
+    "UC1: --upgrade soft tip 'Full guide:' uses absolute path to Forge clone"
 assert_contains "$LOG8b" "CLAUDE.template.md" \
     "UC1: --upgrade references CLAUDE.template.md"
 assert_not_contains "$LOG8b" "CONTINUITY.template.md" \
@@ -304,11 +316,11 @@ assert_hash_equals "$S8/CLAUDE.md" "$HASH_CLAUDE" \
 assert_hash_equals "$S8/CONTINUITY.md" "$HASH_CONTINUITY" \
     "-f does not touch CONTINUITY.md"
 
-# UC2 drift notice: -f also fires the per-file hint.
-assert_contains "$LOG8c" "Template may have drifted" \
-    "UC2: -f shows drift notice"
-assert_contains "$LOG8c" "git diff --no-index" \
-    "UC2: -f suggests git diff --no-index"
+# UC2 soft tip: -f path runs the install branch (not the --upgrade branch),
+# which does NOT emit the soft tip. Confirm legacy drift hint is absent and
+# that the -f path is silent on the reconcile tip (which is upgrade-mode-only).
+assert_not_contains "$LOG8c" "Template may have drifted" \
+    "UC2: -f does NOT contain legacy 'Template may have drifted' hint (5.17)"
 
 # ===========================================================================
 # Test 9: runtime preflight — warns but never blocks
@@ -447,6 +459,10 @@ assert_not_contains "$S10a/.upgrade.log" "Your CLAUDE.md and CONTINUITY.md were 
     "Scenario A: final summary is NOT the both-preserved variant"
 assert_not_contains "$S10a/.upgrade.log" "were not modified" \
     "Scenario A: final summary does NOT contain legacy string"
+# 5.17: soft tip is gated on had_claude_md=true. Scenario A removed CLAUDE.md
+# before --upgrade, so the soft tip must NOT fire.
+assert_not_contains "$S10a/.upgrade.log" "ask Claude to reconcile" \
+    "Scenario A: no soft reconcile tip when CLAUDE.md was not preserved (5.17)"
 
 # Scenario B — user deleted CONTINUITY.md, kept CLAUDE.md.
 # Mirror of Scenario A.
@@ -459,7 +475,11 @@ rm -f "$S10b/CONTINUITY.md"
 run_setup "$S10b" "$S10b/.upgrade.log" --upgrade
 assert_equals "$?" "0" "Scenario B: --upgrade exits 0"
 assert_contains "$S10b/.upgrade.log" "CLAUDE.template.md" \
-    "Scenario B: drift hint references CLAUDE.template.md"
+    "Scenario B: soft tip references CLAUDE.template.md"
+assert_contains "$S10b/.upgrade.log" "ask Claude to reconcile your CLAUDE.md" \
+    "Scenario B: soft tip fires when CLAUDE.md is preserved (5.17)"
+assert_not_contains "$S10b/.upgrade.log" "Template may have drifted" \
+    "Scenario B: legacy drift hint is gone (5.17)"
 assert_contains "$S10b/.upgrade.log" "Your CLAUDE.md was preserved (user content)" \
     "Scenario B: final summary = only-CLAUDE variant"
 assert_not_contains "$S10b/.upgrade.log" "Your CLAUDE.md and CONTINUITY.md were preserved" \
@@ -478,7 +498,9 @@ rm -f "$S10c/CLAUDE.md" "$S10c/CONTINUITY.md"
 run_setup "$S10c" "$S10c/.upgrade.log" --upgrade
 assert_equals "$?" "0" "Scenario C: --upgrade exits 0"
 assert_not_contains "$S10c/.upgrade.log" "Template may have drifted" \
-    "Scenario C: no drift block when nothing was preserved"
+    "Scenario C: no legacy drift block when nothing was preserved"
+assert_not_contains "$S10c/.upgrade.log" "ask Claude to reconcile" \
+    "Scenario C: no soft reconcile tip when CLAUDE.md was not preserved (5.17)"
 assert_not_contains "$S10c/.upgrade.log" "was preserved" \
     "Scenario C: final summary does NOT claim 'was preserved'"
 assert_not_contains "$S10c/.upgrade.log" "were preserved" \


### PR DESCRIPTION
## Summary

PR #571 (5.16) removed the consolidated cry-wolf drift preamble. The per-file inline `print_template_drift_hint` helper still fired when CLAUDE.md was preserved — same cry-wolf at a different layer.

This drops the inline hint entirely. Replaces with a single soft tip at end of upgrade summary using the full Variant B prompt (consistent with the migration script's 5.16 wording, including the `@CONTINUITY.md` dangling-import clause).

## Codex review-driven corrections

This is the second attempt; the first (`dec389f`, now reset out) had two P2 issues Codex caught:

1. The soft tip dropped the `@CONTINUITY.md` clause from Variant B → users without legacy CONTINUITY.md but with the dangling import (pre-5.15 upgrades) wouldn't be told to clean it up. Fixed: the tip now matches the migration script's full Variant B wording.

2. The "Full guide: docs/guides/upgrading.md" reference used a relative path → resolves under the user's project (where the guide doesn't exist), not the Forge clone. Fixed: uses `$SCRIPT_DIR/docs/guides/upgrading.md` absolute path (and `$ScriptDir/...` on PowerShell).

## Test plan

- [x] Removed inline drift hint invocations + helpers in setup.sh + setup.ps1
- [x] Added soft tip at end of upgrade summary with full Variant B prompt + absolute-path guide reference
- [x] Updated test assertions: legacy drift string banned, new soft tip + clauses asserted
- [x] `bash tests/template/run-all.sh`: all 8 suites green (370 assertions, 0 failed)
- [x] Manual smoke test against ../mcpgateway snapshot confirmed correct soft tip output (absolute path resolves to Forge clone)
- [x] CHANGELOG 5.17 entry added
- [x] README badge + version history bumped to 5.17

🤖 Generated with [Claude Code](https://claude.com/claude-code)