### PR TITLE
fix(setup,migrate): tighten reconcile prompt — enumerate ALL CONTINUITY reference types

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-green?style=flat-square"></a>
-  <a href="#version-history"><img alt="Version" src="https://img.shields.io/badge/version-5.17-blue?style=flat-square"></a>
+  <a href="#version-history"><img alt="Version" src="https://img.shields.io/badge/version-5.18-blue?style=flat-square"></a>
   <a href="docs/getting-started.md"><img alt="Platform" src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey?style=flat-square"></a>
   <a href="https://code.claude.com"><img alt="Claude Code" src="https://img.shields.io/badge/Claude_Code-enabled-purple?style=flat-square"></a>
   <a href="https://developers.openai.com/codex/"><img alt="Codex CLI" src="https://img.shields.io/badge/Codex_CLI-required-orange?style=flat-square"></a>
@@ -143,6 +143,7 @@ Recent releases:
 
 | Version | Date       | Highlights                                                                                                                     |
 | ------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| 5.18    | 2026-04-28 | Tighten reconcile prompt — enumerate all CONTINUITY reference types (tree diagrams, prose pointers, labels)                    |
 | 5.17    | 2026-04-28 | Drop per-file template-drift cry-wolf hint; soft "ask Claude to reconcile" tip                                                 |
 | 5.16    | 2026-04-28 | Migration UX — consolidated "ask Claude" reconcile message; dropped cry-wolf drift hint                                        |
 | 5.15    | 2026-04-28 | CONTINUITY split — durable facts to CLAUDE.md, decisions to `docs/adr/`, volatile state to gitignored `.claude/local/state.md` |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to claude-codex-forge.
 
+## 5.18 — 2026-04-28 · Tighten reconcile prompt — enumerate all CONTINUITY reference types
+
+The 5.17 soft tip and 5.16 migration warning shipped a single-clause prompt that only addressed the `@CONTINUITY.md` dangling-import line at the top of CLAUDE.md. Field bug from msai-v2: leftover references at line 102 (file-tree diagram listing CONTINUITY.md as a project file) and line 212 (`(see CONTINUITY)` deferred-followup pointer) survived running the v5.17 prompt because the wording only covered the @-import case AND the "preserving my project-specific content" clause actively pushed Claude to keep them.
+
+Prompt expanded to (a) instruct Claude to scan the ENTIRE file, (b) enumerate four concrete reference types (`@CONTINUITY.md` import lines, file-tree diagrams, prose pointers like `see CONTINUITY` / `in CONTINUITY.md` / `(CONTINUITY)`, comments/labels referencing CONTINUITY.md), and (c) explicitly carve CONTINUITY pointers OUT of the "preserve project-specific content" rule by labeling them "stale infrastructure references."
+
+> Reconcile my CLAUDE.md against `$SCRIPT_DIR/CLAUDE.template.md`. Port any new template sections, preserving my project-specific content. Then scan the ENTIRE file and remove every dangling reference to CONTINUITY.md left over from before the 5.15 migration. Look for: `@CONTINUITY.md` import lines (usually at the top); file-tree diagrams that list CONTINUITY.md as a project file; prose pointers like `see CONTINUITY`, `in CONTINUITY.md`, `(CONTINUITY)`; comments or labels that reference CONTINUITY.md as a location. CONTINUITY.md no longer exists — its content moved to CLAUDE.md (durable), `docs/adr/` (decisions), and `.claude/local/state.md` (volatile). Remove these references; the "preserve project-specific content" rule does NOT apply to CONTINUITY pointers — they are stale infrastructure references.
+
+- `setup.sh` + `setup.ps1` — soft tip body expanded; closing-quote position preserved on last echo line; ASCII-only output for cross-platform byte-parity (per migration-script gotcha).
+- `scripts/migrate-continuity.sh` + `scripts/migrate-continuity.ps1` — Variant B warning body matches setup.sh/setup.ps1 exactly (parity).
+- `tests/template/test-setup.sh` + `test-contracts.sh` — assertions updated: legacy `@CONTINUITY.md line on top` exact-phrase check replaced with `@CONTINUITY.md import lines` (5.18 wording); three new lock-in assertions per platform (`scan the ENTIRE file`, `File-tree diagrams`, `stale infrastructure references`) so the broader scope cannot silently regress.
+- `README.md` — version badge bump 5.17 → 5.18, prepend version-history row.
+
+**Existing installs:** the new wording lands on next `setup.sh --upgrade`. No content migration needed. Re-run the recommended prompt against your CLAUDE.md to clean up any leftover CONTINUITY references that survived the v5.17 pass.
+
 ## 5.17 — 2026-04-28 · Drop per-file template-drift cry-wolf hint; soft "ask Claude to reconcile" tip
 
 Removes the per-file inline `Template may have drifted. To review: git diff --no-index ...` hint that fired every time CLAUDE.md was preserved during `--upgrade`. Same cry-wolf problem as the consolidated preamble dropped in 5.16, just at a different layer.

--- a/scripts/migrate-continuity.ps1
+++ b/scripts/migrate-continuity.ps1
@@ -304,9 +304,20 @@ if ((Test-Path "CLAUDE.md") -and (Select-String -Path "CLAUDE.md" -Pattern '^@CO
         "`n" +
         "      Reconcile my CLAUDE.md against $ScriptDir/CLAUDE.template.md.`n" +
         "      Port any new template sections I'm missing, preserving my`n" +
-        "      project-specific content. If you see an @CONTINUITY.md line`n" +
-        "      on top, remove it -- it's a dangling import from before the`n" +
-        "      5.15 migration.`n" +
+        "      project-specific content.`n" +
+        "`n" +
+        "      Then scan the ENTIRE file and remove every dangling reference to`n" +
+        "      CONTINUITY.md left over from before the 5.15 migration. Look for:`n" +
+        "        - @CONTINUITY.md import lines (usually at the top)`n" +
+        "        - File-tree diagrams that list CONTINUITY.md as a project file`n" +
+        "        - Prose pointers like 'see CONTINUITY', 'in CONTINUITY.md', '(CONTINUITY)'`n" +
+        "        - Comments or labels that reference CONTINUITY.md as a location`n" +
+        "`n" +
+        "      CONTINUITY.md no longer exists -- its content moved to CLAUDE.md`n" +
+        "      (durable), docs/adr/ (decisions), and .claude/local/state.md`n" +
+        "      (volatile). Remove these references; the 'preserve project-specific`n" +
+        "      content' rule does NOT apply to CONTINUITY pointers -- they are`n" +
+        "      stale infrastructure references.`n" +
         "`n" +
         "    (Not in Claude Code? See docs/guides/upgrading.md `"Manual fallback`".)"
     [void]$warnings.Add($reconcilePrompt)

--- a/scripts/migrate-continuity.sh
+++ b/scripts/migrate-continuity.sh
@@ -292,9 +292,20 @@ if [ -f "CLAUDE.md" ] && grep -qE '^@CONTINUITY\.md\b' CLAUDE.md; then
 
       Reconcile my CLAUDE.md against $SCRIPT_DIR/CLAUDE.template.md.
       Port any new template sections I'm missing, preserving my
-      project-specific content. If you see an @CONTINUITY.md line
-      on top, remove it -- it's a dangling import from before the
-      5.15 migration.
+      project-specific content.
+
+      Then scan the ENTIRE file and remove every dangling reference to
+      CONTINUITY.md left over from before the 5.15 migration. Look for:
+        - @CONTINUITY.md import lines (usually at the top)
+        - File-tree diagrams that list CONTINUITY.md as a project file
+        - Prose pointers like 'see CONTINUITY', 'in CONTINUITY.md', '(CONTINUITY)'
+        - Comments or labels that reference CONTINUITY.md as a location
+
+      CONTINUITY.md no longer exists -- its content moved to CLAUDE.md
+      (durable), docs/adr/ (decisions), and .claude/local/state.md
+      (volatile). Remove these references; the 'preserve project-specific
+      content' rule does NOT apply to CONTINUITY pointers -- they are
+      stale infrastructure references.
 
     (Not in Claude Code? See docs/guides/upgrading.md \"Manual fallback\".)")
 fi

--- a/setup.ps1
+++ b/setup.ps1
@@ -1006,6 +1006,10 @@ if ($Upgrade) {
     # including the @CONTINUITY.md dangling-import cleanup clause. The "Full
     # guide" reference uses an absolute path to the Forge clone so it resolves
     # correctly when users run setup.ps1 -Upgrade from inside their project.
+    # 5.18: prompt expanded to enumerate ALL CONTINUITY reference types
+    # (tree diagrams, prose pointers, labels) -- field bug where msai-v2
+    # leftover refs at line 102 (tree) and line 212 (prose) survived because
+    # the prior single-clause prompt only addressed the @-import line.
     if ($hadClaude) {
         Write-Host ""
         Write-Host "Tip:" -ForegroundColor Blue -NoNewline
@@ -1013,8 +1017,19 @@ if ($Upgrade) {
         Write-Host ""
         Write-Host "  `"Reconcile my CLAUDE.md against $ScriptDir/CLAUDE.template.md."
         Write-Host "   Port any new template sections, preserving my project-specific content."
-        Write-Host "   If you see an @CONTINUITY.md line on top, remove it -- it's a dangling"
-        Write-Host "   import from before the 5.15 migration.`""
+        Write-Host ""
+        Write-Host "   Then scan the ENTIRE file and remove every dangling reference to"
+        Write-Host "   CONTINUITY.md left over from before the 5.15 migration. Look for:"
+        Write-Host "     - @CONTINUITY.md import lines (usually at the top)"
+        Write-Host "     - File-tree diagrams that list CONTINUITY.md as a project file"
+        Write-Host "     - Prose pointers like 'see CONTINUITY', 'in CONTINUITY.md', '(CONTINUITY)'"
+        Write-Host "     - Comments or labels that reference CONTINUITY.md as a location"
+        Write-Host ""
+        Write-Host "   CONTINUITY.md no longer exists -- its content moved to CLAUDE.md"
+        Write-Host "   (durable), docs/adr/ (decisions), and .claude/local/state.md"
+        Write-Host "   (volatile). Remove these references; the 'preserve project-specific"
+        Write-Host "   content' rule does NOT apply to CONTINUITY pointers -- they are"
+        Write-Host "   stale infrastructure references.`""
         Write-Host ""
         Write-Host "  (Full guide: $ScriptDir/docs/guides/upgrading.md)"
         Write-Host ""

--- a/setup.sh
+++ b/setup.sh
@@ -930,14 +930,29 @@ if [[ "$UPGRADE" == true ]]; then
     # including the @CONTINUITY.md dangling-import cleanup clause. The "Full
     # guide" reference uses an absolute path to the Forge clone so it resolves
     # correctly when users run setup.sh --upgrade from inside their project.
+    # 5.18: prompt expanded to enumerate ALL CONTINUITY reference types
+    # (tree diagrams, prose pointers, labels) -- field bug where msai-v2
+    # leftover refs at line 102 (tree) and line 212 (prose) survived because
+    # the prior single-clause prompt only addressed the @-import line.
     if [[ "$had_claude_md" == true ]]; then
         echo ""
         echo -e "${BLUE}Tip:${NC} ask Claude to reconcile your CLAUDE.md against the latest template:"
         echo ""
         echo "  \"Reconcile my CLAUDE.md against $SCRIPT_DIR/CLAUDE.template.md."
         echo "   Port any new template sections, preserving my project-specific content."
-        echo "   If you see an @CONTINUITY.md line on top, remove it -- it's a dangling"
-        echo "   import from before the 5.15 migration.\""
+        echo ""
+        echo "   Then scan the ENTIRE file and remove every dangling reference to"
+        echo "   CONTINUITY.md left over from before the 5.15 migration. Look for:"
+        echo "     - @CONTINUITY.md import lines (usually at the top)"
+        echo "     - File-tree diagrams that list CONTINUITY.md as a project file"
+        echo "     - Prose pointers like 'see CONTINUITY', 'in CONTINUITY.md', '(CONTINUITY)'"
+        echo "     - Comments or labels that reference CONTINUITY.md as a location"
+        echo ""
+        echo "   CONTINUITY.md no longer exists -- its content moved to CLAUDE.md"
+        echo "   (durable), docs/adr/ (decisions), and .claude/local/state.md"
+        echo "   (volatile). Remove these references; the 'preserve project-specific"
+        echo "   content' rule does NOT apply to CONTINUITY pointers -- they are"
+        echo "   stale infrastructure references.\""
         echo ""
         echo "  (Full guide: $SCRIPT_DIR/docs/guides/upgrading.md)"
         echo ""

--- a/tests/template/test-contracts.sh
+++ b/tests/template/test-contracts.sh
@@ -234,18 +234,35 @@ assert_contains "$SETUP_PS1" "ask Claude to reconcile your CLAUDE.md against the
 # dangling-import cleanup clause (matches migration script wording from 5.16).
 # Codex-flagged P2 #1 from the v1 attempt: dropping this clause leaves users on
 # a non-migrate path without instructions to remove the dangling import.
+# 5.18: prompt expanded to enumerate ALL CONTINUITY reference types (tree
+# diagrams, prose pointers, labels). Field bug origin: msai-v2 retained
+# line-102 tree-diagram and line-212 prose-pointer references after running
+# the v5.17 prompt because the prior wording only addressed the @-import line.
+# Lock in the broader scope so it cannot silently regress.
 assert_contains "$SETUP_SH"  "Reconcile my CLAUDE.md against" \
     "setup.sh soft tip includes Variant B 'Reconcile my CLAUDE.md against' prompt"
-assert_contains "$SETUP_SH"  "@CONTINUITY.md line on top" \
-    "setup.sh soft tip includes @CONTINUITY.md dangling-import cleanup clause"
+assert_contains "$SETUP_SH"  "@CONTINUITY.md import lines" \
+    "setup.sh soft tip includes @CONTINUITY.md cleanup clause (5.18 wording)"
 assert_contains "$SETUP_SH"  "dangling" \
-    "setup.sh soft tip explains the @CONTINUITY.md line is a dangling import"
+    "setup.sh soft tip describes leftover CONTINUITY refs as dangling"
+assert_contains "$SETUP_SH"  "scan the ENTIRE file" \
+    "setup.sh soft tip instructs full-file scan (5.18)"
+assert_contains "$SETUP_SH"  "File-tree diagrams" \
+    "setup.sh soft tip names tree-diagram references as a target (5.18)"
+assert_contains "$SETUP_SH"  "stale infrastructure references" \
+    "setup.sh soft tip frames CONTINUITY refs as not-user-content (5.18)"
 assert_contains "$SETUP_PS1" "Reconcile my CLAUDE.md against" \
     "setup.ps1 soft tip includes Variant B 'Reconcile my CLAUDE.md against' prompt"
-assert_contains "$SETUP_PS1" "@CONTINUITY.md line on top" \
-    "setup.ps1 soft tip includes @CONTINUITY.md dangling-import cleanup clause"
+assert_contains "$SETUP_PS1" "@CONTINUITY.md import lines" \
+    "setup.ps1 soft tip includes @CONTINUITY.md cleanup clause (5.18 wording)"
 assert_contains "$SETUP_PS1" "dangling" \
-    "setup.ps1 soft tip explains the @CONTINUITY.md line is a dangling import"
+    "setup.ps1 soft tip describes leftover CONTINUITY refs as dangling"
+assert_contains "$SETUP_PS1" "scan the ENTIRE file" \
+    "setup.ps1 soft tip instructs full-file scan (5.18)"
+assert_contains "$SETUP_PS1" "File-tree diagrams" \
+    "setup.ps1 soft tip names tree-diagram references as a target (5.18)"
+assert_contains "$SETUP_PS1" "stale infrastructure references" \
+    "setup.ps1 soft tip frames CONTINUITY refs as not-user-content (5.18)"
 
 # (v) "Full guide" reference uses absolute path semantics ($SCRIPT_DIR / $ScriptDir)
 # so the link resolves to the Forge clone's docs/guides/upgrading.md, not the

--- a/tests/template/test-setup.sh
+++ b/tests/template/test-setup.sh
@@ -287,8 +287,19 @@ assert_contains "$LOG8b" "ask Claude to reconcile your CLAUDE.md" \
     "UC1: --upgrade shows soft reconcile tip (5.17)"
 assert_contains "$LOG8b" "Reconcile my CLAUDE.md against" \
     "UC1: --upgrade soft tip includes full Variant B prompt"
-assert_contains "$LOG8b" "@CONTINUITY.md line on top" \
-    "UC1: --upgrade soft tip includes @CONTINUITY.md cleanup clause"
+assert_contains "$LOG8b" "@CONTINUITY.md import lines" \
+    "UC1: --upgrade soft tip includes @CONTINUITY.md cleanup clause (5.18 wording)"
+# 5.18: tightened prompt asks Claude to scan the whole file for ALL leftover
+# CONTINUITY references (tree diagrams, prose pointers, labels) -- not just
+# the @-import line. Lock in the new tokens so the broader scope cannot
+# silently regress. Field bug origin: msai-v2 retained line-102 tree-diagram
+# and line-212 prose pointer after running the v5.17 prompt.
+assert_contains "$LOG8b" "scan the ENTIRE file" \
+    "UC1: --upgrade soft tip instructs full-file scan (5.18)"
+assert_contains "$LOG8b" "File-tree diagrams" \
+    "UC1: --upgrade soft tip names tree-diagram references (5.18)"
+assert_contains "$LOG8b" "stale infrastructure references" \
+    "UC1: --upgrade soft tip frames CONTINUITY refs as not-user-content (5.18)"
 assert_contains "$LOG8b" "Full guide:" \
     "UC1: --upgrade soft tip includes 'Full guide:' reference"
 assert_contains "$LOG8b" "/docs/guides/upgrading.md" \


### PR DESCRIPTION
## Summary

- **Field bug from msai-v2:** leftover `@CONTINUITY` references at line 102 (file-tree diagram listing `CONTINUITY.md`) and line 212 (prose pointer `(see CONTINUITY)`) survived the v5.17 reconcile prompt — the wording only addressed the @-import line at the top AND the "preserving my project-specific content" clause actively pushed Claude to keep them.
- **Fix:** prompt now (a) instructs full-file scan, (b) enumerates four concrete reference types (`@CONTINUITY.md` imports, file-tree diagrams, prose pointers, labels), and (c) explicitly carves CONTINUITY pointers OUT of the preserve-project-specific-content rule by labeling them "stale infrastructure references."

## Files changed

- **4 source locations** — `setup.sh`, `setup.ps1`, `scripts/migrate-continuity.sh`, `scripts/migrate-continuity.ps1` (platform parity)
- **2 test files** — `tests/template/test-setup.sh`, `tests/template/test-contracts.sh`: replaced exact-phrase assertion `@CONTINUITY.md line on top` with `@CONTINUITY.md import lines` (5.18 wording); added 3 new lock-in assertions per platform (`scan the ENTIRE file`, `File-tree diagrams`, `stale infrastructure references`) so the broader scope cannot silently regress
- **`docs/CHANGELOG.md`** — 5.18 entry with full prompt body and rationale
- **`README.md`** — badge bump 5.17 → 5.18 and version-history row

## Test plan

- [x] `tests/template/run-all.sh` — 233/233 passing across 5 suites (test-contracts, test-default-branch, test-fixtures, test-hooks, test-lint, test-migrate, test-session-start, test-setup)
- [x] **E2E smoke against msai-v2 snapshot** — real `setup.sh --upgrade` against a sandbox copy of msai-v2's CLAUDE.md confirmed the new prompt body renders end-to-end with all 4 enumerated reference types, the full-file-scan instruction, and the stale-infrastructure-references framing
- [x] Platform parity preserved (setup.sh ↔ setup.ps1, migrate-continuity.sh ↔ migrate-continuity.ps1) — bash/PS line-by-line wording identical except for required syntax differences (`echo` vs `Write-Host`, `\"` vs `` `" ``)
- [x] Existing tokens (`Reconcile my CLAUDE.md against`, `@CONTINUITY.md`, `dangling`, `Full guide:`, absolute path semantics) all preserved — no regression on prior contract assertions

## Backwards compatibility

Existing installs pick up the new wording on next `setup.sh --upgrade`. No content migration needed. Users who already ran the v5.17 prompt should re-run with the tightened wording to clean up any leftover CONTINUITY references that survived the prior pass — that's exactly the msai-v2 case that motivated this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)