### PR TITLE
fix(settings): allow Write/Edit on .claude/local/** without prompting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-green?style=flat-square"></a>
-  <a href="#version-history"><img alt="Version" src="https://img.shields.io/badge/version-5.18-blue?style=flat-square"></a>
+  <a href="#version-history"><img alt="Version" src="https://img.shields.io/badge/version-5.19-blue?style=flat-square"></a>
   <a href="docs/getting-started.md"><img alt="Platform" src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey?style=flat-square"></a>
   <a href="https://code.claude.com"><img alt="Claude Code" src="https://img.shields.io/badge/Claude_Code-enabled-purple?style=flat-square"></a>
   <a href="https://developers.openai.com/codex/"><img alt="Codex CLI" src="https://img.shields.io/badge/Codex_CLI-required-orange?style=flat-square"></a>
@@ -143,6 +143,7 @@ Recent releases:
 
 | Version | Date       | Highlights                                                                                                                     |
 | ------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| 5.19    | 2026-04-29 | Allow `Write`/`Edit` on `.claude/local/**` without prompting (workaround for Claude Code v2.1.80+ bare-tool regression)        |
 | 5.18    | 2026-04-28 | Tighten reconcile prompt — enumerate all CONTINUITY reference types (tree diagrams, prose pointers, labels)                    |
 | 5.17    | 2026-04-28 | Drop per-file template-drift cry-wolf hint; soft "ask Claude to reconcile" tip                                                 |
 | 5.16    | 2026-04-28 | Migration UX — consolidated "ask Claude" reconcile message; dropped cry-wolf drift hint                                        |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to claude-codex-forge.
 
+## 5.19 — 2026-04-29 · Allow Write/Edit on .claude/local/\*\* without prompting
+
+Field bug from msai-v2: `/new-feature` workflow prompted the user for permission to use `Write(.claude/local/state.md)` despite `"Write"` being in the project's `permissions.allow` list. Three converging causes:
+
+1. **`.claude/` directory has elevated protection** — per the [official Claude Code permissions docs](https://code.claude.com/docs/en/permissions#permission-modes), writes to `.claude/` prompt even in `bypassPermissions` mode (anti-corruption guard). `.claude/commands`, `.claude/agents`, `.claude/skills` are documented as exempt; `.claude/local/` is NOT.
+2. **Bare-tool-name regression** — [GitHub issue #36593](https://github.com/anthropics/claude-code/issues/36593) documents Claude Code v2.1.80+ failing to auto-approve under blanket `"Write"` / `"Edit"` allow rules. Workaround per docs: pair the bare entry with explicit `Tool(path)` patterns.
+3. **State.md is the only `.claude/local/` artifact today** but the canonical workflow file is written to on every `/new-feature`, `/fix-bug`, and Phase update — frequent prompting kills the workflow's "feel autonomous" goal.
+
+Fix adds two explicit allow rules per template, sitting alongside the bare entries so behavior degrades gracefully on older Claude Code versions where bare worked.
+
+- `settings/settings.template.json` — added `Write(./.claude/local/**)` and `Edit(./.claude/local/**)` to `allow`.
+- `settings/settings-windows.template.json` — same two additions for parity.
+- `README.md` — version badge bump 5.18 → 5.19, prepend version-history row.
+
+**Existing installs:** the new rules land on next `setup.sh --upgrade` (settings.json gets merged; user customizations preserved).
+
 ## 5.18 — 2026-04-28 · Tighten reconcile prompt — enumerate all CONTINUITY reference types
 
 The 5.17 soft tip and 5.16 migration warning shipped a single-clause prompt that only addressed the `@CONTINUITY.md` dangling-import line at the top of CLAUDE.md. Field bug from msai-v2: leftover references at line 102 (file-tree diagram listing CONTINUITY.md as a project file) and line 212 (`(see CONTINUITY)` deferred-followup pointer) survived running the v5.17 prompt because the wording only covered the @-import case AND the "preserving my project-specific content" clause actively pushed Claude to keep them.

--- a/settings/settings-windows.template.json
+++ b/settings/settings-windows.template.json
@@ -9,6 +9,8 @@
       "Read",
       "Edit",
       "Write",
+      "Write(./.claude/local/**)",
+      "Edit(./.claude/local/**)",
       "Bash",
       "Bash(codex:*)",
       "Skill",

--- a/settings/settings.template.json
+++ b/settings/settings.template.json
@@ -9,6 +9,8 @@
       "Read",
       "Edit",
       "Write",
+      "Write(./.claude/local/**)",
+      "Edit(./.claude/local/**)",
       "Bash",
       "Bash(codex:*)",
       "Skill",


### PR DESCRIPTION
## Summary

- **Field bug from msai-v2:** `/new-feature` workflow prompted the user for permission to use `Write(.claude/local/state.md)` despite `"Write"` being in the project's `permissions.allow` list.
- **Three converging causes** confirmed via official docs + GitHub issue research:
  1. `.claude/` directory has elevated protection per [Claude Code permissions docs](https://code.claude.com/docs/en/permissions#permission-modes) — writes prompt even in `bypassPermissions` mode (anti-corruption guard). `.claude/commands`, `.claude/agents`, `.claude/skills` are documented as exempt; `.claude/local/` is NOT.
  2. [anthropics/claude-code#36593](https://github.com/anthropics/claude-code/issues/36593) documents Claude Code v2.1.80+ failing to auto-approve under blanket `"Write"` / `"Edit"` allow rules. Documented workaround: pair the bare entry with explicit `Tool(path)` patterns.
  3. `state.md` is written on every workflow phase update — frequent prompting kills the autonomous-feel goal.
- **Fix:** add two explicit allow rules per template, sitting alongside the bare entries so behavior degrades gracefully on older Claude Code versions where bare worked.

## Files changed

- `settings/settings.template.json` — added `Write(./.claude/local/**)` and `Edit(./.claude/local/**)` to `allow`
- `settings/settings-windows.template.json` — same two additions for parity
- `docs/CHANGELOG.md` — 5.19 entry with full root-cause writeup
- `README.md` — badge bump 5.18 → 5.19 + version-history row

## Test plan

- [x] Both settings JSON files validated with `python3 -m json.tool` (parse cleanly)
- [x] `tests/template/run-all.sh` — 233/233 passing across all 5 suites (no test asserts on the `permissions.allow` shape, so additions are non-breaking)
- [x] Platform parity preserved (Linux/Mac template ↔ Windows template)
- [x] Pattern syntax verified against [docs/permissions wildcard rules](https://code.claude.com/docs/en/permissions#wildcard-patterns) — `./` cwd-relative + `**` recursive glob both documented as supported

## Backwards compatibility

Existing installs pick up automatically via `setup.sh --upgrade` (settings.json gets merged; user customizations preserved). On older Claude Code versions where bare `"Write"` worked, the new rules are redundant but harmless. On v2.1.80+ where bare regressed, the new rules eliminate the prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)