### PR TITLE
fix(codex,council): bump Codex CLI model gpt-5.4 → gpt-5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-green?style=flat-square"></a>
-  <a href="#version-history"><img alt="Version" src="https://img.shields.io/badge/version-5.19-blue?style=flat-square"></a>
+  <a href="#version-history"><img alt="Version" src="https://img.shields.io/badge/version-5.20-blue?style=flat-square"></a>
   <a href="docs/getting-started.md"><img alt="Platform" src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey?style=flat-square"></a>
   <a href="https://code.claude.com"><img alt="Claude Code" src="https://img.shields.io/badge/Claude_Code-enabled-purple?style=flat-square"></a>
   <a href="https://developers.openai.com/codex/"><img alt="Codex CLI" src="https://img.shields.io/badge/Codex_CLI-required-orange?style=flat-square"></a>
@@ -143,6 +143,7 @@ Recent releases:
 
 | Version | Date       | Highlights                                                                                                                     |
 | ------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| 5.20    | 2026-04-29 | Bump Codex CLI model `gpt-5.4` → `gpt-5.5` in `/codex` and `/council` (OpenAI released GPT-5.5 on 2026-04-23)                  |
 | 5.19    | 2026-04-29 | Allow `Write`/`Edit` on `.claude/local/**` without prompting (workaround for Claude Code v2.1.80+ bare-tool regression)        |
 | 5.18    | 2026-04-28 | Tighten reconcile prompt — enumerate all CONTINUITY reference types (tree diagrams, prose pointers, labels)                    |
 | 5.17    | 2026-04-28 | Drop per-file template-drift cry-wolf hint; soft "ask Claude to reconcile" tip                                                 |

--- a/commands/codex.md
+++ b/commands/codex.md
@@ -46,7 +46,7 @@ Use `AskUserQuestion` with these options:
 
 ```bash
 codex exec review \
-  -m "gpt-5.4" \
+  -m "gpt-5.5" \
   -c model_reasoning_effort="xhigh" \
   -c service_tier="fast" \
   -c developer_instructions="Focus on: correctness, security vulnerabilities, performance bottlenecks, error handling gaps, and maintainability. Flag anything that could break in production." \
@@ -58,7 +58,7 @@ codex exec review \
 
 ```bash
 codex exec review \
-  -m "gpt-5.4" \
+  -m "gpt-5.5" \
   -c model_reasoning_effort="xhigh" \
   -c service_tier="fast" \
   -c developer_instructions="Focus on: correctness, security vulnerabilities, performance bottlenecks, error handling gaps, and maintainability. Flag anything that could break in production." \
@@ -95,7 +95,7 @@ Also check if there's a plan in the current conversation context. If the user sp
 
 ```bash
 codex exec \
-  -m "gpt-5.4" \
+  -m "gpt-5.5" \
   -c model_reasoning_effort="xhigh" \
   -c service_tier="fast" \
   --sandbox read-only \
@@ -143,7 +143,7 @@ Construct the prompt by combining the user's instruction with the gathered conte
 
 ```bash
 codex exec \
-  -m "gpt-5.4" \
+  -m "gpt-5.5" \
   -c model_reasoning_effort="xhigh" \
   -c service_tier="fast" \
   --sandbox read-only \
@@ -200,11 +200,11 @@ These work on **both** `codex exec` and `codex exec review`:
 
 | Config key                | Purpose                                                    | Example                                                                 |
 | ------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------- |
-| `model`                   | Override the session model                                 | `-c model="gpt-5.4"`                                                    |
+| `model`                   | Override the session model                                 | `-c model="gpt-5.5"`                                                    |
 | `model_reasoning_effort`  | Depth of reasoning                                         | `-c model_reasoning_effort="xhigh"` (minimal\|low\|medium\|high\|xhigh) |
 | `model_reasoning_summary` | Reasoning output detail                                    | `-c model_reasoning_summary="detailed"` (auto\|concise\|detailed\|none) |
 | `developer_instructions`  | Inject guidance (works WITH preset review flags)           | `-c developer_instructions="Focus on SQL injection"`                    |
-| `review_model`            | Model override just for `/review`                          | `-c review_model="gpt-5.4"`                                             |
+| `review_model`            | Model override just for `/review`                          | `-c review_model="gpt-5.5"`                                             |
 | `web_search`              | Allow live docs lookup during review                       | `-c web_search=live` (disabled\|cached\|live)                           |
 | `service_tier`            | Processing tier                                            | `-c service_tier="fast"` (flex\|fast)                                   |
 | `approval_policy`         | When to pause for confirmation (plain `exec` only)         | `-c approval_policy="on-request"` (untrusted\|on-request\|never)        |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to claude-codex-forge.
 
+## 5.20 — 2026-04-29 · Bump Codex CLI model gpt-5.4 → gpt-5.5
+
+OpenAI shipped GPT-5.5 on 2026-04-23 and Codex CLI now accepts it as a model identifier (`developers.openai.com/codex/models` lists it as the recommended choice). Codex CLI's default is still `gpt-5.4` as of `rust-v0.125.0`, so the upgrade requires an explicit model-string swap — automation doesn't get gpt-5.5 by accident.
+
+Researched the CLI release notes (`rust-v0.124.0` → `rust-v0.125.0`) for any breaking changes — there are none. All flags and config keys we use (`-m`/`--model`, `-c key=value`, `--sandbox`, `--ephemeral`, `--uncommitted`, `--base`, `--commit`, `--full-auto`, `--skip-git-repo-check`, `model`, `review_model`, `model_reasoning_effort`) remain supported on the same subcommands. The `xhigh` reasoning level is still valid and inherits onto gpt-5.5 per the model catalog.
+
+So this is a pure model-name swap.
+
+- `commands/codex.md` — 5 invocation strings updated (`-m "gpt-5.4"` → `-m "gpt-5.5"`, plus `-c model=` and `-c review_model=` config-key examples in the reference table).
+- `skills/council/references/peer-review-protocol.md` — 3 council-advisor invocation strings updated.
+- `README.md` — version badge bump 5.19 → 5.20, prepend version-history row.
+
+**Existing installs:** the new model lands on next `setup.sh --upgrade` (commands and skills are refreshed; user customizations in `settings.json` are preserved).
+
 ## 5.19 — 2026-04-29 · Allow Write/Edit on .claude/local/\*\* without prompting
 
 Field bug from msai-v2: `/new-feature` workflow prompted the user for permission to use `Write(.claude/local/state.md)` despite `"Write"` being in the project's `permissions.allow` list. Three converging causes:

--- a/skills/council/references/peer-review-protocol.md
+++ b/skills/council/references/peer-review-protocol.md
@@ -40,7 +40,7 @@ Run via `codex exec` with:
 
 ```bash
 codex exec \
-  -m "gpt-5.4" \
+  -m "gpt-5.5" \
   -c model_reasoning_effort="high" \
   -c service_tier="fast" \
   --sandbox read-only \
@@ -59,7 +59,7 @@ After all advisors complete, construct the chairman prompt:
 
 ```bash
 codex exec \
-  -m "gpt-5.4" \
+  -m "gpt-5.5" \
   -c model_reasoning_effort="xhigh" \
   -c service_tier="fast" \
   --sandbox read-only \
@@ -113,7 +113,7 @@ Before firing the full council, the Contrarian/Codex validates the "default wins
 
 ```bash
 codex exec \
-  -m "gpt-5.4" \
+  -m "gpt-5.5" \
   -c model_reasoning_effort="high" \
   -c service_tier="fast" \
   --sandbox read-only \


### PR DESCRIPTION
## Summary

OpenAI shipped GPT-5.5 on 2026-04-23 and Codex CLI now accepts it as a model identifier. Codex CLI's default is still `gpt-5.4` as of `rust-v0.125.0`, so the upgrade requires an explicit model-string swap — automation doesn't get gpt-5.5 by accident.

Researched CLI release notes (`rust-v0.124.0` → `rust-v0.125.0`) for breaking changes — there are none. All flags and config keys we use (`-m`/`--model`, `-c key=value`, `--sandbox`, `--ephemeral`, `--uncommitted`, `--base`, `--commit`, `--full-auto`, `--skip-git-repo-check`, `model`, `review_model`, `model_reasoning_effort`) remain supported. The `xhigh` reasoning level is still valid on gpt-5.5 per the model catalog.

So this is a **pure model-name swap, no syntax changes**.

## Files changed

- `commands/codex.md` — 5 invocation strings (`-m "gpt-5.4"` → `-m "gpt-5.5"` on `codex exec`/`codex exec review`, plus `-c model=` and `-c review_model=` examples in the reference table)
- `skills/council/references/peer-review-protocol.md` — 3 council-advisor invocation strings
- `docs/CHANGELOG.md` — 5.20 entry with research notes
- `README.md` — version badge bump 5.19 → 5.20 + version-history row

## Test plan

- [x] `tests/template/run-all.sh` — 233/233 passing across all 5 suites (no test asserts on model strings)
- [x] All 9 `gpt-5.4` references swept via `grep` — 0 stragglers remaining
- [x] CLI invocation strings unchanged in shape (only the literal `gpt-5.4` → `gpt-5.5` swap inside quoted args)

## Sources

- [OpenAI GPT-5.5 release announcement](https://openai.com/index/introducing-gpt-5-5/) (2026-04-23)
- [Codex CLI changelog](https://developers.openai.com/codex/changelog) — gpt-5.5 availability + default still gpt-5.4
- [Codex CLI reference](https://developers.openai.com/codex/cli) — flag inventory (unchanged)
- [Codex config reference](https://developers.openai.com/codex/config-reference) — `model_reasoning_effort` levels including `xhigh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)