### PR TITLE
fix(settings,hooks): work around CC v2.1.80+ permission regression for .claude/local/** writes (v5.21)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ claude-codex-forge/
 │   ├── check-state-updated.sh/.ps1  # Stop: advisory state reminder + CHANGELOG threshold gate
 │   ├── check-bash-safety.sh/.ps1    # PreToolUse: audit log + block dangerous patterns
 │   ├── check-workflow-gates.sh/.ps1 # PreToolUse: block commit/push/PR if quality gates incomplete
+│   ├── auto-approve-local-writes.sh/.ps1  # PermissionRequest: auto-approve Write/Edit on .claude/local/** (workaround for CC v2.1.80+ regression)
 │   ├── post-tool-format.sh/.ps1     # PostToolUse: auto-format on save
 │   ├── pre-compact-memory.sh/.ps1   # PreCompact: save learnings before compression
 │   └── check-config-change.sh/.ps1  # ConfigChange: log config modifications
@@ -193,6 +194,7 @@ Every hook has both `.sh` (Unix) and `.ps1` (Windows) versions. **Always update 
 - **SessionStart hooks** (`session-start.sh`): Output JSON with `hookSpecificOutput.additionalContext` for silent context injection. Source-gated: drift-detection fetch fires only on `startup`/`resume` subtypes, not `clear`/`compact`. Cannot block (exit 2 is advisory) — drift surfaces as a warning string in additionalContext only.
 - **Stop hooks** (`check-state-updated.sh`): Use `exit 2` + stderr message to block
 - **PreToolUse hooks** (`check-bash-safety.sh`): Audit log + `exit 2` to block dangerous Bash patterns
+- **PermissionRequest hooks** (`auto-approve-local-writes.sh`): Output `hookSpecificOutput.decision.behavior=allow` to skip prompt; fires only when CC is about to show a permission dialog. Used to work around CC v2.1.80+ regression on path-scoped allow rules. Fail-open: print nothing on parse error or path-validation failure. Opt-out via `CLAUDE_FORGE_AUTO_APPROVE_LOCAL_WRITES=0`.
 - **PostToolUse hooks**: Match file extensions, run formatters, `exit 0` always
 - **PreCompact hooks**: Use `exit 0` (non-blocking) — just reminders
 - **ConfigChange hooks** (`check-config-change.sh`): Log config changes, optional `exit 2` strict mode

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Recent releases:
 
 | Version | Date       | Highlights                                                                                                                     |
 | ------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| 5.21    | 2026-04-30 | Allow `Write`/`Edit` on `.claude/local/**` from worktrees too — gitignore-style `**/.claude/local/**` covers any depth         |
+| 5.21    | 2026-04-30 | PermissionRequest hook auto-approves writes to `.claude/local/**` (workaround for CC v2.1.80+ regression on path-scoped rules) |
 | 5.20    | 2026-04-29 | Bump Codex CLI model `gpt-5.4` → `gpt-5.5` in `/codex` and `/council` (OpenAI released GPT-5.5 on 2026-04-23)                  |
 | 5.19    | 2026-04-29 | Allow `Write`/`Edit` on `.claude/local/**` without prompting (workaround for Claude Code v2.1.80+ bare-tool regression)        |
 | 5.18    | 2026-04-28 | Tighten reconcile prompt — enumerate all CONTINUITY reference types (tree diagrams, prose pointers, labels)                    |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-green?style=flat-square"></a>
-  <a href="#version-history"><img alt="Version" src="https://img.shields.io/badge/version-5.20-blue?style=flat-square"></a>
+  <a href="#version-history"><img alt="Version" src="https://img.shields.io/badge/version-5.21-blue?style=flat-square"></a>
   <a href="docs/getting-started.md"><img alt="Platform" src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey?style=flat-square"></a>
   <a href="https://code.claude.com"><img alt="Claude Code" src="https://img.shields.io/badge/Claude_Code-enabled-purple?style=flat-square"></a>
   <a href="https://developers.openai.com/codex/"><img alt="Codex CLI" src="https://img.shields.io/badge/Codex_CLI-required-orange?style=flat-square"></a>
@@ -143,6 +143,7 @@ Recent releases:
 
 | Version | Date       | Highlights                                                                                                                     |
 | ------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| 5.21    | 2026-04-30 | Allow `Write`/`Edit` on `.claude/local/**` from worktrees too — gitignore-style `**/.claude/local/**` covers any depth         |
 | 5.20    | 2026-04-29 | Bump Codex CLI model `gpt-5.4` → `gpt-5.5` in `/codex` and `/council` (OpenAI released GPT-5.5 on 2026-04-23)                  |
 | 5.19    | 2026-04-29 | Allow `Write`/`Edit` on `.claude/local/**` without prompting (workaround for Claude Code v2.1.80+ bare-tool regression)        |
 | 5.18    | 2026-04-28 | Tighten reconcile prompt — enumerate all CONTINUITY reference types (tree diagrams, prose pointers, labels)                    |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,27 +2,32 @@
 
 All notable changes to claude-codex-forge.
 
-## 5.21 — 2026-04-30 · Allow Write/Edit on .claude/local/\*\* from worktrees too
+## 5.21 — 2026-04-30 · PermissionRequest hook auto-approves writes to .claude/local/\*\*
 
-Field bug from msai-v2 (follow-up to PR #574 / v5.19): `/new-feature` invoked from inside a `.worktrees/<name>/` directory still prompted the user for permission to use `Write(.claude/local/state.md)` despite the v5.19 patterns being present.
+Field-confirmed bug from msai-v2 (Claude Code v2.1.123): `/new-feature` invoked from inside a `.worktrees/<name>/` directory prompted the user for permission to use `Edit(.claude/local/state.md)` despite **all four path-scoped allow rules** (v5.19 `./.claude/local/**` pair plus v5.21 `**/.claude/local/**` pair) being loaded into the session — confirmed via `/permissions`. The settings.json fix didn't actually fix the user-visible problem.
 
-Root cause is path-pattern scope, not the v2.1.80+ bare-tool regression that PR #574 addressed:
+Root cause is the broader [v2.1.80+ permission regression](https://github.com/anthropics/claude-code/issues/36593): both bare and path-scoped Write/Edit allow rules fail to auto-approve in recent Claude Code versions. PR #574 (v5.19) addressed it with explicit path-scoped patterns; this release accepts that the regression hits both bare AND path-scoped rules and pivots to the documented escape hatch — a hook.
 
-1. **Claude Code's permission patterns are gitignore-style.** Per the [permissions docs](https://code.claude.com/docs/en/permissions#read-and-edit), `path` or `./path` is matched against the **current working directory**, while `**/path` matches at any depth. v5.19's `Write(./.claude/local/**)` only covers the project-root case — when Claude Code resolves the canonical absolute path of a worktree-root state.md, it falls outside the cwd-scoped pattern.
-2. **Worktrees nest under `.worktrees/<name>/`** so the file path becomes `.worktrees/<name>/.claude/local/state.md` — same `.claude/local/**` segment, different depth.
-3. **The `/new-feature` and `/fix-bug` STATE-INIT script copies the canonical template into the worktree's `.claude/local/state.md`** during Pre-Flight, then writes the `## Workflow` section. That Write call runs against the worktree path and fired the prompt.
+**The fix: a PermissionRequest hook** that auto-approves Write/Edit on `.claude/local/**`. PermissionRequest fires only when Claude Code is about to show a permission dialog (narrower than PreToolUse, which fires on every tool call) and emits `hookSpecificOutput.decision.behavior=allow` to skip the prompt. Hooks bypass the broken permission engine entirely.
 
-Fix adds two gitignore-style "any depth" patterns that match `.claude/local/**` regardless of where it sits in the tree (project root, worktree, nested checkout). Existing v5.19 cwd-relative patterns are kept as belt-and-suspenders for older Claude Code versions.
+**Path validation, per Codex design review:**
 
-**Why not broaden to all of `.claude/`?** The narrow `.claude/local/**` scope is intentional. `.claude/settings.json`, `.claude/hooks/*`, `.claude/rules/*` are settings and code that Claude Code's docs specifically protect from accidental tampering. Opening Write to all of `.claude/` would let a poisoned tool output rewrite hooks or settings without prompting.
+- Substring match would be exploitable (`.claude/local/../../etc/passwd`). The hook normalizes separators (Windows `\` → `/`), rejects any `..` path segment, resolves relative paths against hook-provided `cwd`, lexically collapses `.` and empty segments, then segment-matches `*/.claude/local/*` (requires `/` boundary on both sides — rejects substring spoofs like `/foo.claude/localbar/`).
+- **Fail-open by design**: parse failures, missing `jq`, malformed paths, traversal attempts, empty paths, and unknown tools all exit silently with no allow JSON — Claude Code falls back to its default permission flow and prompts the user. The hook is a UX improvement, not a security boundary.
+- **Opt-out** via `CLAUDE_FORGE_AUTO_APPROVE_LOCAL_WRITES=0` env var.
 
-**Why not Bash patterns?** Field transcripts confirm bare `"Bash"` already covers `mkdir -p` / `cp` operations into `.claude/local/`. The Bash side was never the prompting tool — the v5.19 retrospective mis-attributed the prompt to Bash; the actual prompter was the Write tool overwriting state.md with the populated `## Workflow` section.
+**Why PermissionRequest, not PreToolUse?** PermissionRequest fires only when CC is about to show a dialog — the hook adds zero overhead to Write/Edit calls that are already auto-approved by other rules. PreToolUse would run on every Write/Edit, which is unnecessary work.
 
-- `settings/settings.template.json` — added `Write(**/.claude/local/**)` and `Edit(**/.claude/local/**)` to `allow`.
+**v5.21 also keeps the v5.19 + v5.21 patterns in `permissions.allow`** as belt-and-suspenders. They're not effective today (regression), but they're correct gitignore-style patterns that will start working the day Anthropic resolves [#36593](https://github.com/anthropics/claude-code/issues/36593) — at which point the hook becomes redundant fallback.
+
+- `hooks/auto-approve-local-writes.sh` + `.ps1` — new PermissionRequest hook scripts (cross-platform parity).
+- `settings/settings.template.json` — added `PermissionRequest` event with `Write|Edit` matcher; kept the v5.21 `**/.claude/local/**` allow patterns alongside v5.19's.
 - `settings/settings-windows.template.json` — same two additions for parity.
+- `setup.sh` + `setup.ps1` — copy the new hook scripts on install/upgrade.
+- `CLAUDE.md` — file-tree comment + Hook Design section updated.
 - `README.md` — version badge bump 5.20 → 5.21, prepend version-history row.
 
-**Existing installs:** the new rules land on next `setup.sh --upgrade` (settings.json gets merged; user customizations preserved).
+**Existing installs:** run `setup.sh --upgrade`. The new hook script lands in `.claude/hooks/`; settings.json gets merged (PermissionRequest event added; user customizations preserved). **Restart any running Claude Code session in the project** — settings.json loads at session start, so a mid-session upgrade doesn't take effect until you exit and re-launch.
 
 ## 5.20 — 2026-04-29 · Bump Codex CLI model gpt-5.4 → gpt-5.5
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to claude-codex-forge.
 
+## 5.21 — 2026-04-30 · Allow Write/Edit on .claude/local/\*\* from worktrees too
+
+Field bug from msai-v2 (follow-up to PR #574 / v5.19): `/new-feature` invoked from inside a `.worktrees/<name>/` directory still prompted the user for permission to use `Write(.claude/local/state.md)` despite the v5.19 patterns being present.
+
+Root cause is path-pattern scope, not the v2.1.80+ bare-tool regression that PR #574 addressed:
+
+1. **Claude Code's permission patterns are gitignore-style.** Per the [permissions docs](https://code.claude.com/docs/en/permissions#read-and-edit), `path` or `./path` is matched against the **current working directory**, while `**/path` matches at any depth. v5.19's `Write(./.claude/local/**)` only covers the project-root case — when Claude Code resolves the canonical absolute path of a worktree-root state.md, it falls outside the cwd-scoped pattern.
+2. **Worktrees nest under `.worktrees/<name>/`** so the file path becomes `.worktrees/<name>/.claude/local/state.md` — same `.claude/local/**` segment, different depth.
+3. **The `/new-feature` and `/fix-bug` STATE-INIT script copies the canonical template into the worktree's `.claude/local/state.md`** during Pre-Flight, then writes the `## Workflow` section. That Write call runs against the worktree path and fired the prompt.
+
+Fix adds two gitignore-style "any depth" patterns that match `.claude/local/**` regardless of where it sits in the tree (project root, worktree, nested checkout). Existing v5.19 cwd-relative patterns are kept as belt-and-suspenders for older Claude Code versions.
+
+**Why not broaden to all of `.claude/`?** The narrow `.claude/local/**` scope is intentional. `.claude/settings.json`, `.claude/hooks/*`, `.claude/rules/*` are settings and code that Claude Code's docs specifically protect from accidental tampering. Opening Write to all of `.claude/` would let a poisoned tool output rewrite hooks or settings without prompting.
+
+**Why not Bash patterns?** Field transcripts confirm bare `"Bash"` already covers `mkdir -p` / `cp` operations into `.claude/local/`. The Bash side was never the prompting tool — the v5.19 retrospective mis-attributed the prompt to Bash; the actual prompter was the Write tool overwriting state.md with the populated `## Workflow` section.
+
+- `settings/settings.template.json` — added `Write(**/.claude/local/**)` and `Edit(**/.claude/local/**)` to `allow`.
+- `settings/settings-windows.template.json` — same two additions for parity.
+- `README.md` — version badge bump 5.20 → 5.21, prepend version-history row.
+
+**Existing installs:** the new rules land on next `setup.sh --upgrade` (settings.json gets merged; user customizations preserved).
+
 ## 5.20 — 2026-04-29 · Bump Codex CLI model gpt-5.4 → gpt-5.5
 
 OpenAI shipped GPT-5.5 on 2026-04-23 and Codex CLI now accepts it as a model identifier (`developers.openai.com/codex/models` lists it as the recommended choice). Codex CLI's default is still `gpt-5.4` as of `rust-v0.125.0`, so the upgrade requires an explicit model-string swap — automation doesn't get gpt-5.5 by accident.

--- a/hooks/auto-approve-local-writes.ps1
+++ b/hooks/auto-approve-local-writes.ps1
@@ -1,0 +1,78 @@
+# .claude/hooks/auto-approve-local-writes.ps1
+# PermissionRequest hook: auto-approve Write/Edit on .claude/local/**
+#
+# Workaround for anthropics/claude-code#36593 — Claude Code v2.1.80+
+# regression where path-scoped Write/Edit allow rules in settings.json
+# don't auto-approve. The workflow file .claude/local/state.md is written
+# on every /new-feature, /fix-bug, and Phase update; without this hook,
+# CC v2.1.80+ prompts the user on every state-md write.
+#
+# PermissionRequest fires only when CC is about to show a permission
+# dialog, so this hook adds no overhead to Write/Edit calls that are
+# already allowed by other rules.
+#
+# Input (JSON via stdin): {tool_name, tool_input: {file_path}, cwd, ...}
+# Allow:  emit hookSpecificOutput JSON to stdout, exit 0
+# Defer:  print nothing, exit 0 (CC falls back to default permission flow)
+#
+# Opt-out: set CLAUDE_FORGE_AUTO_APPROVE_LOCAL_WRITES=0 to disable.
+#
+# Fail-open philosophy: any parse error, malformed path, traversal segment,
+# or unknown tool → silent defer (no allow emitted).
+
+$ErrorActionPreference = "SilentlyContinue"
+
+# Honor opt-out
+if ($env:CLAUDE_FORGE_AUTO_APPROVE_LOCAL_WRITES -eq "0") { exit 0 }
+
+$RawInput = $input | Out-String
+$Data = $RawInput | ConvertFrom-Json -ErrorAction SilentlyContinue
+if (-not $Data) { exit 0 }
+
+$Tool = $Data.tool_name
+$FilePath = $Data.tool_input.file_path
+$Cwd = $Data.cwd
+
+# Only act on Write|Edit
+if ($Tool -ne "Write" -and $Tool -ne "Edit") { exit 0 }
+if ([string]::IsNullOrEmpty($FilePath)) { exit 0 }
+
+# Normalize separators
+$Normalized = $FilePath -replace '\\', '/'
+
+# Reject traversal segments (segment match, not substring)
+if (("/" + $Normalized + "/") -match '/\.\./') { exit 0 }
+
+# Resolve relative paths against hook-provided cwd
+if ($Normalized -match '^([A-Za-z]:)?/') {
+    $Abs = $Normalized
+} else {
+    if ([string]::IsNullOrEmpty($Cwd)) { exit 0 }
+    $CwdNorm = $Cwd -replace '\\', '/'
+    $Abs = "$CwdNorm/$Normalized"
+}
+
+# Lexically collapse '.' and empty segments
+$Segments = $Abs -split '/' | Where-Object { $_ -ne "" -and $_ -ne "." }
+# Preserve absolute-path leading slash (Unix) or drive-letter (Windows)
+if ($Abs -match '^/') {
+    $Collapsed = "/" + ($Segments -join "/")
+} else {
+    $Collapsed = ($Segments -join "/")
+}
+
+# Segment match: must contain /.claude/local/ as a directory boundary.
+# Case-insensitive on Windows file systems.
+if ($Collapsed -imatch '/\.claude/local/') {
+    $Output = @{
+        hookSpecificOutput = @{
+            hookEventName = "PermissionRequest"
+            decision = @{
+                behavior = "allow"
+            }
+        }
+    } | ConvertTo-Json -Depth 5 -Compress
+    Write-Output $Output
+}
+
+exit 0

--- a/hooks/auto-approve-local-writes.sh
+++ b/hooks/auto-approve-local-writes.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# .claude/hooks/auto-approve-local-writes.sh
+# PermissionRequest hook: auto-approve Write/Edit on .claude/local/**
+#
+# Workaround for anthropics/claude-code#36593 — Claude Code v2.1.80+
+# regression where path-scoped Write/Edit allow rules in settings.json
+# don't auto-approve. The workflow file .claude/local/state.md is written
+# on every /new-feature, /fix-bug, and Phase update; without this hook,
+# CC v2.1.80+ prompts the user on every state-md write.
+#
+# PermissionRequest fires only when CC is about to show a permission
+# dialog, so this hook adds no overhead to Write/Edit calls that are
+# already allowed by other rules.
+#
+# Input (JSON via stdin): {tool_name, tool_input: {file_path}, cwd, ...}
+# Allow:  emit hookSpecificOutput JSON to stdout, exit 0
+# Defer:  print nothing, exit 0 (CC falls back to default permission flow)
+#
+# Opt-out: set CLAUDE_FORGE_AUTO_APPROVE_LOCAL_WRITES=0 to disable.
+#
+# Fail-open philosophy: any parse error, missing jq, malformed path,
+# traversal segment, or unknown tool → silent defer (no allow emitted).
+# This hook is a UX improvement, not a security boundary.
+
+# Honor opt-out
+if [ "${CLAUDE_FORGE_AUTO_APPROVE_LOCAL_WRITES:-1}" = "0" ]; then
+    exit 0
+fi
+
+INPUT=$(cat)
+
+# Require jq for safe JSON parsing; defer if absent
+command -v jq >/dev/null 2>&1 || exit 0
+
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+
+# Only act on Write|Edit; defer everything else
+case "$TOOL" in
+    Write|Edit) ;;
+    *) exit 0 ;;
+esac
+
+# Defer on empty path
+[ -z "$FILE_PATH" ] && exit 0
+
+# Normalize separators: Windows-style backslashes → forward slashes
+NORMALIZED=$(printf '%s' "$FILE_PATH" | tr '\\' '/')
+
+# Reject any traversal segment in the input path (defense in depth).
+# Must match '..' as a path segment, not as a substring (so '..foo' is fine).
+case "/$NORMALIZED/" in
+    *"/../"*) exit 0 ;;
+esac
+
+# Resolve relative paths against hook-provided cwd
+case "$NORMALIZED" in
+    /*) ABS="$NORMALIZED" ;;
+    *)  [ -z "$CWD" ] && exit 0; ABS="$CWD/$NORMALIZED" ;;
+esac
+
+# Lexically collapse '.' and empty segments. ('..' was already rejected.)
+COLLAPSED=$(printf '%s' "$ABS" | awk -F/ '
+{
+    n = 0
+    for (i = 1; i <= NF; i++) {
+        if ($i == "" || $i == ".") continue
+        out[++n] = $i
+    }
+    result = ""
+    for (i = 1; i <= n; i++) result = result "/" out[i]
+    if (result == "") result = "/"
+    print result
+}')
+
+# Segment match: path must contain /.claude/local/ as a directory boundary.
+# This rejects substring matches like /foo.claude/localbar/ (no leading slash
+# before .claude or trailing slash after local).
+case "$COLLAPSED" in
+    */.claude/local/*)
+        cat <<'EOF'
+{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}
+EOF
+        ;;
+esac
+
+exit 0

--- a/settings/settings-windows.template.json
+++ b/settings/settings-windows.template.json
@@ -119,6 +119,17 @@
         ]
       }
     ],
+    "PermissionRequest": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell -ExecutionPolicy Bypass -File \"$CLAUDE_PROJECT_DIR/.claude/hooks/auto-approve-local-writes.ps1\""
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",

--- a/settings/settings-windows.template.json
+++ b/settings/settings-windows.template.json
@@ -11,6 +11,8 @@
       "Write",
       "Write(./.claude/local/**)",
       "Edit(./.claude/local/**)",
+      "Write(**/.claude/local/**)",
+      "Edit(**/.claude/local/**)",
       "Bash",
       "Bash(codex:*)",
       "Skill",

--- a/settings/settings.template.json
+++ b/settings/settings.template.json
@@ -11,6 +11,8 @@
       "Write",
       "Write(./.claude/local/**)",
       "Edit(./.claude/local/**)",
+      "Write(**/.claude/local/**)",
+      "Edit(**/.claude/local/**)",
       "Bash",
       "Bash(codex:*)",
       "Skill",

--- a/settings/settings.template.json
+++ b/settings/settings.template.json
@@ -116,6 +116,17 @@
         ]
       }
     ],
+    "PermissionRequest": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/auto-approve-local-writes.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",

--- a/setup.ps1
+++ b/setup.ps1
@@ -564,6 +564,7 @@ Copy-TemplateFile (Join-Path (Join-Path $ScriptDir "hooks") "pre-compact-memory.
 Copy-TemplateFile (Join-Path (Join-Path $ScriptDir "hooks") "check-config-change.ps1") ".claude\hooks\check-config-change.ps1" ".claude\hooks\check-config-change.ps1"
 Copy-TemplateFile (Join-Path (Join-Path $ScriptDir "hooks") "check-bash-safety.ps1") ".claude\hooks\check-bash-safety.ps1" ".claude\hooks\check-bash-safety.ps1"
 Copy-TemplateFile (Join-Path (Join-Path $ScriptDir "hooks") "check-workflow-gates.ps1") ".claude\hooks\check-workflow-gates.ps1" ".claude\hooks\check-workflow-gates.ps1"
+Copy-TemplateFile (Join-Path (Join-Path $ScriptDir "hooks") "auto-approve-local-writes.ps1") ".claude\hooks\auto-approve-local-writes.ps1" ".claude\hooks\auto-approve-local-writes.ps1"
 
 # Hook lib helpers
 # Install BOTH the .ps1 and .sh helpers on Windows because:

--- a/setup.sh
+++ b/setup.sh
@@ -542,6 +542,7 @@ copy_file "$SCRIPT_DIR/hooks/pre-compact-memory.sh" ".claude/hooks/pre-compact-m
 copy_file "$SCRIPT_DIR/hooks/check-config-change.sh" ".claude/hooks/check-config-change.sh" ".claude/hooks/check-config-change.sh"
 copy_file "$SCRIPT_DIR/hooks/check-bash-safety.sh" ".claude/hooks/check-bash-safety.sh" ".claude/hooks/check-bash-safety.sh"
 copy_file "$SCRIPT_DIR/hooks/check-workflow-gates.sh" ".claude/hooks/check-workflow-gates.sh" ".claude/hooks/check-workflow-gates.sh"
+copy_file "$SCRIPT_DIR/hooks/auto-approve-local-writes.sh" ".claude/hooks/auto-approve-local-writes.sh" ".claude/hooks/auto-approve-local-writes.sh"
 
 # Hook lib helpers (shared across hooks and command Pre-Flight blocks)
 mkdir -p .claude/hooks/lib
@@ -555,6 +556,7 @@ chmod +x .claude/hooks/pre-compact-memory.sh 2>/dev/null || true
 chmod +x .claude/hooks/check-config-change.sh 2>/dev/null || true
 chmod +x .claude/hooks/check-bash-safety.sh 2>/dev/null || true
 chmod +x .claude/hooks/check-workflow-gates.sh 2>/dev/null || true
+chmod +x .claude/hooks/auto-approve-local-writes.sh 2>/dev/null || true
 
 # ADRs — ship template + README + seed ADRs (existing-file-skip semantics).
 mkdir -p docs/adr


### PR DESCRIPTION
## Summary

Field-confirmed bug from msai-v2 (Claude Code v2.1.123): `/new-feature` inside a worktree prompted for `Edit(.claude/local/state.md)` despite **all four** path-scoped allow rules being loaded into the session (verified via `/permissions`). The settings.json fix didn't actually fix the user-visible problem.

**Root cause:** the broader [v2.1.80+ permission regression](https://github.com/anthropics/claude-code/issues/36593) — both bare AND path-scoped `Write`/`Edit` allow rules fail to auto-approve in recent Claude Code versions. PR #574 / v5.19 thought it had worked around this via explicit path-scoped patterns; field testing in v2.1.123 proves otherwise.

**Two-part fix on the same branch:**

### Commit 1 (v5.21 patterns, original PR scope)
Added `Write(**/.claude/local/**)` and `Edit(**/.claude/local/**)` gitignore-style "any depth" patterns alongside v5.19's cwd-relative ones. **Kept as belt-and-suspenders** — they're correct and will start working the day Anthropic resolves #36593.

### Commit 2 (the actual fix)
**PermissionRequest hook** that auto-approves Write/Edit on `.claude/local/**`:

- Fires only when CC is about to show a permission dialog (narrower than PreToolUse on Codex's recommendation)
- Returns `hookSpecificOutput.decision.behavior=allow` to skip the prompt
- Bypasses the broken permission engine entirely

**Path validation** (per Codex design review, gpt-5.5):
- Normalizes separators (Windows `\` → `/`)
- Rejects any `..` path segment (defense vs `.claude/local/../../etc/passwd`)
- Resolves relative paths against hook-provided `cwd`
- Lexically collapses `.` / empty segments
- Segment-matches `*/.claude/local/*` (rejects substring spoofs like `/foo.claude/localbar/`)

**Fail-open** by design: parse failures, missing `jq`, malformed paths, traversal attempts, empty paths, and unknown tools all silently exit 0 with no allow JSON — CC falls back to its default permission flow.

**Opt-out** via `CLAUDE_FORGE_AUTO_APPROVE_LOCAL_WRITES=0`.

## Why PermissionRequest, not PreToolUse?

Codex flagged this. PermissionRequest fires only when a permission dialog is about to show; PreToolUse runs on every Write/Edit. Same outcome, less overhead.

## Test plan

- [x] 8 smoke-test cases against bash hook (happy path × 3 incl. worktree + absolute, traversal attack, substring spoof, wrong tool, opt-out, empty path) — all pass
- [x] `tests/template/run-all.sh` — 379/379 tests pass across 8 suites
- [x] JSON validity for both settings templates (`jq .` clean)
- [x] `bash -n hooks/auto-approve-local-writes.sh` — clean
- [x] `setup.sh --upgrade` against `../mcpgateway` — hook copied + executable + settings merged correctly
- [x] Live-ran installed hook in mcpgateway against worktree-style payload — emitted correct allow JSON
- [ ] **Live-test in msai-v2 CC session** — pending: user runs `setup.sh --upgrade` in msai-v2, **restarts the CC session** (settings load at session start), confirms next `Edit(.claude/local/state.md)` does NOT prompt
- [ ] PowerShell parity — relied on logic review; pwsh not installed locally. Needs Windows runner verification before merge

## Codex design review

Codex (gpt-5.5, xhigh reasoning) reviewed the design and pushed back on three things:
1. Recommended PermissionRequest over PreToolUse — adopted
2. Flagged substring path-match as exploitable — tightened to segment match + traversal rejection + cwd-resolution + lexical normalization
3. Suggested `CLAUDE_FORGE_AUTO_APPROVE_LOCAL_WRITES=0` opt-out — adopted

🤖 Generated with [Claude Code](https://claude.com/claude-code)