### PR TITLE
fix(codex,council): cross-platform PTY shim for openai/codex#19945 (v5.22)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,9 @@ claude-codex-forge/
 │
 ├── hooks/                      # Hook scripts (copied to .claude/hooks/)
 │   ├── lib/                         # Shared helpers sourced/called by other hooks
-│   │   └── default-branch.sh/.ps1   # Detect repo's default branch (origin/HEAD → main → master)
+│   │   ├── default-branch.sh/.ps1   # Detect repo's default branch (origin/HEAD → main → master)
+│   │   ├── codex-pty.sh/.ps1        # PTY shim for `codex exec` — works around openai/codex#19945 (silent empty exit when stdio detached from TTY)
+│   │   └── codex-pty-helper.py      # Python helper: pty.fork + waitpid loop (avoids 3.9 pty.spawn macOS hang)
 │   ├── session-start.sh/.ps1        # SessionStart: silent context injection (branch + drift warning)
 │   ├── check-state-updated.sh/.ps1  # Stop: advisory state reminder + CHANGELOG threshold gate
 │   ├── check-bash-safety.sh/.ps1    # PreToolUse: audit log + block dangerous patterns
@@ -163,6 +165,9 @@ Templates in the root are **source of truth**. `setup.sh` copies them to target 
 | `hooks/*`                                 | `.claude/hooks/*` in target project                                                                                         |
 | `hooks/lib/default-branch.sh`             | `.claude/hooks/lib/default-branch.sh` in target project                                                                     |
 | `hooks/lib/default-branch.ps1`            | `.claude/hooks/lib/default-branch.ps1` in target project                                                                    |
+| `hooks/lib/codex-pty.sh`                  | `.claude/hooks/lib/codex-pty.sh` in target project                                                                          |
+| `hooks/lib/codex-pty.ps1`                 | `.claude/hooks/lib/codex-pty.ps1` in target project                                                                         |
+| `hooks/lib/codex-pty-helper.py`           | `.claude/hooks/lib/codex-pty-helper.py` in target project                                                                   |
 | `skills/ui-design/SKILL.template.md`      | `.claude/skills/ui-design/SKILL.md` in target                                                                               |
 | `skills/ui-design/references/*.md`        | `.claude/skills/ui-design/references/*.md`                                                                                  |
 | `skills/generate-image/SKILL.template.md` | `.claude/skills/generate-image/SKILL.md`                                                                                    |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-green?style=flat-square"></a>
-  <a href="#version-history"><img alt="Version" src="https://img.shields.io/badge/version-5.21-blue?style=flat-square"></a>
+  <a href="#version-history"><img alt="Version" src="https://img.shields.io/badge/version-5.22-blue?style=flat-square"></a>
   <a href="docs/getting-started.md"><img alt="Platform" src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey?style=flat-square"></a>
   <a href="https://code.claude.com"><img alt="Claude Code" src="https://img.shields.io/badge/Claude_Code-enabled-purple?style=flat-square"></a>
   <a href="https://developers.openai.com/codex/"><img alt="Codex CLI" src="https://img.shields.io/badge/Codex_CLI-required-orange?style=flat-square"></a>
@@ -141,30 +141,31 @@ The pillars above cash out in specific, repo-verifiable behavior:
 
 Recent releases:
 
-| Version | Date       | Highlights                                                                                                                     |
-| ------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| 5.21    | 2026-04-30 | PermissionRequest hook auto-approves writes to `.claude/local/**` (workaround for CC v2.1.80+ regression on path-scoped rules) |
-| 5.20    | 2026-04-29 | Bump Codex CLI model `gpt-5.4` → `gpt-5.5` in `/codex` and `/council` (OpenAI released GPT-5.5 on 2026-04-23)                  |
-| 5.19    | 2026-04-29 | Allow `Write`/`Edit` on `.claude/local/**` without prompting (workaround for Claude Code v2.1.80+ bare-tool regression)        |
-| 5.18    | 2026-04-28 | Tighten reconcile prompt — enumerate all CONTINUITY reference types (tree diagrams, prose pointers, labels)                    |
-| 5.17    | 2026-04-28 | Drop per-file template-drift cry-wolf hint; soft "ask Claude to reconcile" tip                                                 |
-| 5.16    | 2026-04-28 | Migration UX — consolidated "ask Claude" reconcile message; dropped cry-wolf drift hint                                        |
-| 5.15    | 2026-04-28 | CONTINUITY split — durable facts to CLAUDE.md, decisions to `docs/adr/`, volatile state to gitignored `.claude/local/state.md` |
-| 5.14    | 2026-04-27 | Drift hygiene — SessionStart `git fetch` warning + worktree from `origin/<default>`                                            |
-| 5.13    | 2026-04-21 | Phase 4 task-DAG dispatch with file-conflict constraints                                                                       |
-| 5.12    | 2026-04-21 | Template-drift notice on `setup.sh -f` / `--upgrade`                                                                           |
-| 5.11    | 2026-04-20 | ARRANGE rule — close the E2E actor-boundary gap via text layer                                                                 |
-| 5.10    | 2026-04-18 | Evidence-based E2E gate — checkbox claims bound to `tests/e2e/reports/` artifact                                               |
-| 5.9     | 2026-04-18 | `E2E verified` gate — close the silent-skip loophole                                                                           |
-| 5.8     | 2026-04-18 | Multi-project interpreter preflight + isolation guide                                                                          |
-| 5.7     | 2026-04-18 | Template self-test suite (4 bash suites, ~5s)                                                                                  |
-| 5.6     | 2026-04-17 | Template monorepo support + Playwright security fixes                                                                          |
-| 5.5     | 2026-04-17 | `verify-e2e` agent (#449) · Playwright CI bridge (#450) · `research-first` (#472) · repo rename                                |
-| 5.4     | 2026-03-31 | Engineering Council — 5 advisors with Codex chairman                                                                           |
-| 5.3     | 2026-03-01 | Silent SessionStart context injection via JSON `hookSpecificOutput`                                                            |
-| 5.2     | 2026-02-20 | Frontend design plugin + `rules/frontend-design.md`                                                                            |
-| 5.1     | 2026-02-19 | CLAUDE.md split — slim file + auto-loaded `.claude/rules/`                                                                     |
-| 5.0     | 2026-02-19 | Removed Compound Engineering, replaced with built-in quality gates                                                             |
+| Version | Date       | Highlights                                                                                                                                                                                                                                 |
+| ------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 5.22    | 2026-05-01 | Codex PTY shim — `.claude/hooks/lib/codex-pty.{sh,ps1}` works around [openai/codex#19945](https://github.com/openai/codex/issues/19945) (silent empty exit when `codex exec` runs without a TTY); migrated `/codex` + `/council` callsites |
+| 5.21    | 2026-04-30 | PermissionRequest hook auto-approves writes to `.claude/local/**` (workaround for CC v2.1.80+ regression on path-scoped rules)                                                                                                             |
+| 5.20    | 2026-04-29 | Bump Codex CLI model `gpt-5.4` → `gpt-5.5` in `/codex` and `/council` (OpenAI released GPT-5.5 on 2026-04-23)                                                                                                                              |
+| 5.19    | 2026-04-29 | Allow `Write`/`Edit` on `.claude/local/**` without prompting (workaround for Claude Code v2.1.80+ bare-tool regression)                                                                                                                    |
+| 5.18    | 2026-04-28 | Tighten reconcile prompt — enumerate all CONTINUITY reference types (tree diagrams, prose pointers, labels)                                                                                                                                |
+| 5.17    | 2026-04-28 | Drop per-file template-drift cry-wolf hint; soft "ask Claude to reconcile" tip                                                                                                                                                             |
+| 5.16    | 2026-04-28 | Migration UX — consolidated "ask Claude" reconcile message; dropped cry-wolf drift hint                                                                                                                                                    |
+| 5.15    | 2026-04-28 | CONTINUITY split — durable facts to CLAUDE.md, decisions to `docs/adr/`, volatile state to gitignored `.claude/local/state.md`                                                                                                             |
+| 5.14    | 2026-04-27 | Drift hygiene — SessionStart `git fetch` warning + worktree from `origin/<default>`                                                                                                                                                        |
+| 5.13    | 2026-04-21 | Phase 4 task-DAG dispatch with file-conflict constraints                                                                                                                                                                                   |
+| 5.12    | 2026-04-21 | Template-drift notice on `setup.sh -f` / `--upgrade`                                                                                                                                                                                       |
+| 5.11    | 2026-04-20 | ARRANGE rule — close the E2E actor-boundary gap via text layer                                                                                                                                                                             |
+| 5.10    | 2026-04-18 | Evidence-based E2E gate — checkbox claims bound to `tests/e2e/reports/` artifact                                                                                                                                                           |
+| 5.9     | 2026-04-18 | `E2E verified` gate — close the silent-skip loophole                                                                                                                                                                                       |
+| 5.8     | 2026-04-18 | Multi-project interpreter preflight + isolation guide                                                                                                                                                                                      |
+| 5.7     | 2026-04-18 | Template self-test suite (4 bash suites, ~5s)                                                                                                                                                                                              |
+| 5.6     | 2026-04-17 | Template monorepo support + Playwright security fixes                                                                                                                                                                                      |
+| 5.5     | 2026-04-17 | `verify-e2e` agent (#449) · Playwright CI bridge (#450) · `research-first` (#472) · repo rename                                                                                                                                            |
+| 5.4     | 2026-03-31 | Engineering Council — 5 advisors with Codex chairman                                                                                                                                                                                       |
+| 5.3     | 2026-03-01 | Silent SessionStart context injection via JSON `hookSpecificOutput`                                                                                                                                                                        |
+| 5.2     | 2026-02-20 | Frontend design plugin + `rules/frontend-design.md`                                                                                                                                                                                        |
+| 5.1     | 2026-02-19 | CLAUDE.md split — slim file + auto-loaded `.claude/rules/`                                                                                                                                                                                 |
+| 5.0     | 2026-02-19 | Removed Compound Engineering, replaced with built-in quality gates                                                                                                                                                                         |
 
 Full history: **[docs/CHANGELOG.md](docs/CHANGELOG.md)**
 

--- a/commands/codex.md
+++ b/commands/codex.md
@@ -12,6 +12,13 @@
 - **Codex authenticated**: `codex login` (requires ChatGPT Plus/Pro/Business or API key)
 - Verify: `codex --version` (requires v0.114.0+)
 
+> **PTY shim — work around openai/codex#19945.** All `codex exec` invocations below
+> go through `.claude/hooks/lib/codex-pty.sh exec ...` (or `.ps1` on Windows). The
+> shim allocates a pseudo-terminal so `codex exec` produces real output — without it,
+> codex 0.124–0.12X.0 silently exits 0 with empty stdout under Claude Code's no-TTY
+> Bash tool. To bypass the shim (e.g., to confirm upstream fix), set
+> `CLAUDE_FORGE_CODEX_PTY_BYPASS=1`.
+
 ---
 
 ## Mode Detection
@@ -45,7 +52,7 @@ Use `AskUserQuestion` with these options:
 > **NOTE:** The `exec review` subcommand does NOT accept `--sandbox` or `--color` flags (reviews are inherently read-only). These flags are only valid on `codex exec` (general mode).
 
 ```bash
-codex exec review \
+.claude/hooks/lib/codex-pty.sh exec review \
   -m "gpt-5.5" \
   -c model_reasoning_effort="xhigh" \
   -c service_tier="fast" \
@@ -57,7 +64,7 @@ codex exec review \
 **If reviewing a branch**, add `--title` for context:
 
 ```bash
-codex exec review \
+.claude/hooks/lib/codex-pty.sh exec review \
   -m "gpt-5.5" \
   -c model_reasoning_effort="xhigh" \
   -c service_tier="fast" \
@@ -94,7 +101,7 @@ Also check if there's a plan in the current conversation context. If the user sp
 ### Step 2: Run Codex exec with the plan
 
 ```bash
-codex exec \
+.claude/hooks/lib/codex-pty.sh exec \
   -m "gpt-5.5" \
   -c model_reasoning_effort="xhigh" \
   -c service_tier="fast" \
@@ -142,7 +149,7 @@ If the user's instruction references a specific file, read that file to include 
 Construct the prompt by combining the user's instruction with the gathered context.
 
 ```bash
-codex exec \
+.claude/hooks/lib/codex-pty.sh exec \
   -m "gpt-5.5" \
   -c model_reasoning_effort="xhigh" \
   -c service_tier="fast" \
@@ -171,13 +178,13 @@ Display Codex's output verbatim to the user. Do not summarize or edit it.
 
 ## Quick Reference
 
-| Use case                   | Command pattern                                                   |
-| -------------------------- | ----------------------------------------------------------------- |
-| Review uncommitted changes | `codex exec review --ephemeral --uncommitted`                     |
-| Review branch vs main      | `codex exec review --ephemeral --base main --title "description"` |
-| Review a specific commit   | `codex exec review --ephemeral --commit SHA`                      |
-| Review a design plan       | `codex exec --sandbox read-only --ephemeral "Review the plan..."` |
-| General second opinion     | `codex exec --sandbox read-only --ephemeral "Your question..."`   |
+| Use case                   | Command pattern                                                                            |
+| -------------------------- | ------------------------------------------------------------------------------------------ |
+| Review uncommitted changes | `.claude/hooks/lib/codex-pty.sh exec review --ephemeral --uncommitted`                     |
+| Review branch vs main      | `.claude/hooks/lib/codex-pty.sh exec review --ephemeral --base main --title "description"` |
+| Review a specific commit   | `.claude/hooks/lib/codex-pty.sh exec review --ephemeral --commit SHA`                      |
+| Review a design plan       | `.claude/hooks/lib/codex-pty.sh exec --sandbox read-only --ephemeral "Review the plan..."` |
+| General second opinion     | `.claude/hooks/lib/codex-pty.sh exec --sandbox read-only --ephemeral "Your question..."`   |
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to claude-codex-forge.
 
+## 5.22 — 2026-05-01 · Codex PTY shim — work around openai/codex#19945
+
+`codex exec` silently exits with empty stdout (exit 0, zero bytes) when run with stdio detached from a controlling TTY AND a non-trivial prompt — exactly the conditions Claude Code's Bash tool creates every time the Forge invokes `/codex` or `/council`. The bug was [introduced in codex 0.124.0](https://github.com/openai/codex/issues/19945) (last unaffected: 0.123.0), still present in 0.125.0 / 0.128.0, and has no upstream fix as of 2026-05-01.
+
+Field reports describe 10–17 minute hangs on long audit prompts, ending in `kill` exit-144. The Forge memory previously attributed the symptom to "long prompt overload"; that was incomplete — prompt length is one of two triggers, not the trigger.
+
+**The fix: a cross-platform PTY shim** at `.claude/hooks/lib/codex-pty.sh` (Unix) and `codex-pty.ps1` (Windows). All `codex exec` invocations across `/codex` and `/council` now route through the shim, which allocates a pseudo-terminal so codex sees `isatty(stdin/out) == true` and produces real output.
+
+**Unix path:** `python3` + a lightweight helper script (`codex-pty-helper.py`) using `pty.fork()` + `waitpid(WNOHANG)` polling. We can't use BSD `script(1)` because it requires a parent TTY (`tcgetattr` on parent stdin) which Claude Code's Bash tool — running with stdin connected to a Unix domain socket — does not have. We can't use Python's `pty.spawn()` either: the 3.9 stdlib version hangs on macOS after the child exits because the parent's `select()` loop blocks on a `master_fd` that never reports EOF. The explicit waitpid-based helper sidesteps both problems.
+
+**Windows path:** detect-then-bypass. PS 7+ with non-redirected stdio uses ConPTY natively (no shim needed). Redirected stdio probes `winpty.exe` (PATH first, then Git for Windows install paths). WSL is opt-in via `CLAUDE_FORGE_CODEX_PTY_VIA_WSL=1`. Last resort: direct invoke with stderr warning. Per the research brief, #19945 has zero confirmed Windows reproductions — the .ps1 shim exists primarily for ADR 0005 platform parity.
+
+**Opt-out** via `CLAUDE_FORGE_CODEX_PTY_BYPASS=1` (mirrors the v5.21 PR #592 pattern). Useful when upstream is confirmed fixed, or when an EDR / corporate sandbox blocks PTY allocation.
+
+**Test coverage:** 20 unit tests for the Unix shim (mocked codex + isatty assertions + real-pty integration via `/bin/echo` + stdin-from-/dev/null liveness). 9 cross-file contract assertions in `test-contracts.sh` enforce env-var name parity, header references to issue #19945, callsite migration completeness, and setup-script wiring on both platforms.
+
+**Retest criterion:** drop the shim once codex 0.128+ is empirically confirmed clean by re-running issue #19945's repro: `setsid codex exec "$LARGE_PROMPT" < /dev/null` producing non-empty output. Until then, leave it in place.
+
+**Existing installs need `./setup.sh -f`** to pick up the shim files, then any new `/new-feature` or `/fix-bug` invocation in a downstream project will use the migrated callsites.
+
 ## 5.21 — 2026-04-30 · PermissionRequest hook auto-approves writes to .claude/local/\*\*
 
 Field-confirmed bug from msai-v2 (Claude Code v2.1.123): `/new-feature` invoked from inside a `.worktrees/<name>/` directory prompted the user for permission to use `Edit(.claude/local/state.md)` despite **all four path-scoped allow rules** (v5.19 `./.claude/local/**` pair plus v5.21 `**/.claude/local/**` pair) being loaded into the session — confirmed via `/permissions`. The settings.json fix didn't actually fix the user-visible problem.

--- a/hooks/lib/codex-pty-helper.py
+++ b/hooks/lib/codex-pty-helper.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# hooks/lib/codex-pty-helper.py — PTY wrapper for codex exec.
+#
+# Why a separate file (not inline in codex-pty.sh)?
+#   pty.spawn() in Python 3.9 hangs on macOS after the child exits because
+#   the parent's _copy loop blocks in select() waiting on master_fd that
+#   never reports ready. Working around it requires an explicit waitpid
+#   poll loop, which is too long to inline as `python3 -c '...'` in bash.
+#
+# Why pty.fork() not pty.spawn()?
+#   pty.spawn() does the fork + I/O loop together but its loop is buggy on
+#   3.9. We use the lower-level pty.fork() (which just allocates a pty pair
+#   and forks) and write our own loop that polls waitpid(WNOHANG) so we can
+#   exit promptly when the child terminates.
+#
+# Contract:
+#   sys.argv[1:] is the command + args to run inside the pty.
+#   stdin → pty master, pty master → stdout, both 4KB chunks.
+#   Returns child's exit code; signal-killed children return 128 + signum.
+
+import errno
+import os
+import pty
+import select
+import signal
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("codex-pty-helper: usage: codex-pty-helper.py <cmd> [args...]",
+              file=sys.stderr)
+        return 2
+
+    argv = sys.argv[1:]
+
+    pid, master_fd = pty.fork()
+    if pid == 0:
+        # Child: pty.fork() already dup'd slave to fd 0/1/2 and made us the
+        # session leader. Just exec.
+        # On exec failure, emit a diagnostic to stderr (which goes through the
+        # pty back to the user) so the user can distinguish "codex ran and
+        # exited N" from "execvp failed and we couldn't run codex" — without
+        # the diagnostic, exit codes 126/127 collide with legitimate codex
+        # exits (silent-failure agent P0, iter-2).
+        try:
+            os.execvp(argv[0], argv)
+        except FileNotFoundError:
+            sys.stderr.write(
+                f"codex-pty-helper: command not found: {argv[0]}\n"
+            )
+            sys.stderr.flush()
+            os._exit(127)
+        except OSError as e:
+            sys.stderr.write(
+                f"codex-pty-helper: execvp failed for {argv[0]}: "
+                f"errno={e.errno} ({e.strerror})\n"
+            )
+            sys.stderr.flush()
+            os._exit(126)
+
+    # Parent: I/O multiplex until child exits.
+    exit_status = None
+    select_error_streak = 0
+    try:
+        while True:
+            # Poll for child exit — non-blocking.
+            try:
+                wpid, status = os.waitpid(pid, os.WNOHANG)
+            except ChildProcessError:
+                exit_status = 0
+                break
+            if wpid == pid:
+                exit_status = status
+                # Drain remaining buffered output before returning.
+                _drain(master_fd)
+                break
+            # Multiplex parent stdin → pty master, pty master → parent stdout.
+            try:
+                rfds, _, _ = select.select([master_fd, 0], [], [], 0.1)
+                select_error_streak = 0
+            except (OSError, ValueError) as e:
+                # Either master_fd was closed under us, or stdin is closed.
+                # Bail after a sustained streak — without this, EBADF would
+                # spin at 100% CPU forever (silent-failure agent P1, iter-2).
+                select_error_streak += 1
+                if select_error_streak > 50:  # ~5s of consecutive errors
+                    sys.stderr.write(
+                        f"codex-pty-helper: select() persistently failing "
+                        f"({e}); killing child and aborting\n"
+                    )
+                    try:
+                        os.kill(pid, signal.SIGTERM)
+                    except OSError:
+                        pass
+                    exit_status = 1 << 8  # encode as wait-status (exit 1)
+                    break
+                continue
+
+            if master_fd in rfds:
+                try:
+                    data = os.read(master_fd, 4096)
+                except OSError:
+                    # macOS: master read returns EIO when slave is fully closed.
+                    # Treat as EOF — child has exited and waitpid will catch it.
+                    data = b""
+                if data:
+                    try:
+                        os.write(1, data)
+                    except BrokenPipeError:
+                        # Downstream reader is gone (SIGPIPE semantics). Kill
+                        # the child to free resources and surface 141 (per
+                        # silent-failure agent P1, iter-2).
+                        try:
+                            os.kill(pid, signal.SIGTERM)
+                        except OSError:
+                            pass
+                        exit_status = (128 + signal.SIGPIPE) << 8  # encode wait-status
+                        break
+                    except OSError as e:
+                        sys.stderr.write(
+                            f"codex-pty-helper: stdout write failed: {e}\n"
+                        )
+                        exit_status = 1 << 8
+                        break
+                # If empty, don't break — let waitpid confirm the exit.
+
+            if 0 in rfds:
+                try:
+                    data = os.read(0, 4096)
+                except OSError:
+                    data = b""
+                if data:
+                    try:
+                        os.write(master_fd, data)
+                    except OSError as e:
+                        if e.errno not in (errno.EIO, errno.EPIPE):
+                            sys.stderr.write(
+                                f"codex-pty-helper: pty write failed: {e}\n"
+                            )
+                        # Stop forwarding stdin — child has hung up its end.
+                        try:
+                            devnull = os.open(os.devnull, os.O_RDONLY)
+                            os.dup2(devnull, 0)
+                            os.close(devnull)
+                        except OSError:
+                            pass
+                else:
+                    # Stdin EOF — dup /dev/null over fd 0 so select() never
+                    # wakes for fd 0 again. (iter-2 doc fix: was previously
+                    # described as "bool flag" which never existed.)
+                    try:
+                        devnull = os.open(os.devnull, os.O_RDONLY)
+                        os.dup2(devnull, 0)
+                        os.close(devnull)
+                    except OSError:
+                        pass
+    finally:
+        try:
+            os.close(master_fd)
+        except OSError:
+            pass
+
+    if exit_status is None:
+        return 1
+    if os.WIFEXITED(exit_status):
+        return os.WEXITSTATUS(exit_status)
+    if os.WIFSIGNALED(exit_status):
+        return 128 + os.WTERMSIG(exit_status)
+    return 1
+
+
+def _drain(master_fd: int, max_bytes: int = 1 << 20) -> None:
+    """Read everything buffered on master_fd and write to stdout.
+
+    Bounded by max_bytes (1 MiB) to avoid infinite loops if upstream is weird.
+    """
+    total = 0
+    while total < max_bytes:
+        try:
+            rfds, _, _ = select.select([master_fd], [], [], 0)
+        except (OSError, ValueError):
+            return
+        if master_fd not in rfds:
+            return
+        try:
+            data = os.read(master_fd, 4096)
+        except OSError:
+            return
+        if not data:
+            return
+        try:
+            os.write(1, data)
+        except OSError:
+            return
+        total += len(data)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/lib/codex-pty-helper.py
+++ b/hooks/lib/codex-pty-helper.py
@@ -37,7 +37,20 @@ def main() -> int:
     pid, master_fd = pty.fork()
     if pid == 0:
         # Child: pty.fork() already dup'd slave to fd 0/1/2 and made us the
-        # session leader. Just exec.
+        # session leader.
+        # Reset signal dispositions to SIG_DFL before exec. Without this, the
+        # child inherits whatever the parent had — and bash sets SIGINT to
+        # SIG_IGN for any process it backgrounds in a non-interactive shell
+        # (POSIX). That inherited SIG_IGN would prevent the child from
+        # responding to our forwarded SIGINT during cancellation. Real codex
+        # (Rust) reinstalls its own handlers in main(), so this is mostly
+        # defense-in-depth, but it makes the shim behave correctly with any
+        # POSIX child including /bin/sleep, /usr/bin/cat, etc.
+        for _sig in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP, signal.SIGPIPE, signal.SIGQUIT):
+            try:
+                signal.signal(_sig, signal.SIG_DFL)
+            except (ValueError, OSError):
+                pass
         # On exec failure, emit a diagnostic to stderr (which goes through the
         # pty back to the user) so the user can distinguish "codex ran and
         # exited N" from "execvp failed and we couldn't run codex" — without
@@ -59,7 +72,28 @@ def main() -> int:
             sys.stderr.flush()
             os._exit(126)
 
-    # Parent: I/O multiplex until child exits.
+    # Parent: forward SIGINT/SIGTERM/SIGHUP to the child so cancellation
+    # actually cancels codex (verified gap in iter-2: without these handlers,
+    # Python's default SIGINT handler raises KeyboardInterrupt which our
+    # `except OSError` clause inadvertently caught via InterruptedError, and
+    # the parent silently kept reading the pty until codex finished naturally).
+    # The handlers forward; the main loop notices child exit via waitpid and
+    # returns 128+signum per WIFSIGNALED handling at the bottom of main().
+    def _forward_signal(signum: int, _frame: object) -> None:
+        try:
+            os.kill(pid, signum)
+        except OSError:
+            pass
+
+    for _sig in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
+        try:
+            signal.signal(_sig, _forward_signal)
+        except (ValueError, OSError):
+            # SIGHUP not available on Windows; signal.signal in non-main
+            # threads also raises ValueError. Fall through silently.
+            pass
+
+    # I/O multiplex until child exits.
     exit_status = None
     select_error_streak = 0
     try:

--- a/hooks/lib/codex-pty-helper.py
+++ b/hooks/lib/codex-pty-helper.py
@@ -24,6 +24,7 @@ import pty
 import select
 import signal
 import sys
+import termios
 
 
 def main() -> int:
@@ -72,7 +73,19 @@ def main() -> int:
             sys.stderr.flush()
             os._exit(126)
 
-    # Parent: forward SIGINT/SIGTERM/SIGHUP to the child so cancellation
+    # Parent: disable TTY echo on the pty so when we forward parent stdin to
+    # master the line discipline doesn't echo it back into our output stream.
+    # Without this, writing EOT (^D) to signal stdin EOF to the child causes
+    # `^D\b\b` to appear in codex's output. Echo is only meaningful for
+    # interactive terminals; the shim is always non-interactive.
+    try:
+        attrs = termios.tcgetattr(master_fd)
+        attrs[3] &= ~termios.ECHO  # lflag &= ~ECHO
+        termios.tcsetattr(master_fd, termios.TCSANOW, attrs)
+    except (termios.error, OSError):
+        pass  # not all platforms support tcsetattr on a pty master
+
+    # Forward SIGINT/SIGTERM/SIGHUP to the child so cancellation
     # actually cancels codex (verified gap in iter-2: without these handlers,
     # Python's default SIGINT handler raises KeyboardInterrupt which our
     # `except OSError` clause inadvertently caught via InterruptedError, and
@@ -185,8 +198,19 @@ def main() -> int:
                         # Child hung up its end — stop forwarding stdin.
                         stdin_open = False
                 else:
-                    # Stdin EOF — drop fd 0 from the select set.
+                    # Stdin EOF: stop polling fd 0 AND signal EOF to the child
+                    # by writing EOT (^D, 0x04) to the pty master. In canonical
+                    # mode (the default after pty.fork on macOS/Linux), the
+                    # line discipline interprets ^D at line-start as EOF, so
+                    # the child's next read() returns 0 bytes. Without this,
+                    # children that read stdin (like /bin/cat with piped
+                    # input) hang forever waiting for more data — found by
+                    # the iter-3 smoke /codex review against ../mcpgateway.
                     stdin_open = False
+                    try:
+                        os.write(master_fd, b'\x04')
+                    except OSError:
+                        pass
     finally:
         try:
             os.close(master_fd)

--- a/hooks/lib/codex-pty-helper.py
+++ b/hooks/lib/codex-pty-helper.py
@@ -94,8 +94,15 @@ def main() -> int:
             pass
 
     # I/O multiplex until child exits.
+    # `stdin_open` tracks whether we should still poll fd 0. After EOF we drop
+    # it from the select set entirely. (iter-3 council P1 fix — Contrarian
+    # and Maintainer empirically reproduced a CPU busy-loop here: the previous
+    # `dup2(/dev/null, 0)` trick did not stop select() from waking, because
+    # /dev/null on macOS/Linux is always selectable. Result: ~2 CPU-seconds
+    # per 2 wall-seconds wrapping `/bin/sleep 2 </dev/null`. Fix is the flag.)
     exit_status = None
     select_error_streak = 0
+    stdin_open = True
     try:
         while True:
             # Poll for child exit — non-blocking.
@@ -109,9 +116,12 @@ def main() -> int:
                 # Drain remaining buffered output before returning.
                 _drain(master_fd)
                 break
-            # Multiplex parent stdin → pty master, pty master → parent stdout.
+            # Build select set dynamically; drop fd 0 once stdin EOFs.
+            select_fds: list[int] = [master_fd]
+            if stdin_open:
+                select_fds.append(0)
             try:
-                rfds, _, _ = select.select([master_fd, 0], [], [], 0.1)
+                rfds, _, _ = select.select(select_fds, [], [], 0.1)
                 select_error_streak = 0
             except (OSError, ValueError) as e:
                 # Either master_fd was closed under us, or stdin is closed.
@@ -159,7 +169,7 @@ def main() -> int:
                         break
                 # If empty, don't break — let waitpid confirm the exit.
 
-            if 0 in rfds:
+            if stdin_open and 0 in rfds:
                 try:
                     data = os.read(0, 4096)
                 except OSError:
@@ -172,23 +182,11 @@ def main() -> int:
                             sys.stderr.write(
                                 f"codex-pty-helper: pty write failed: {e}\n"
                             )
-                        # Stop forwarding stdin — child has hung up its end.
-                        try:
-                            devnull = os.open(os.devnull, os.O_RDONLY)
-                            os.dup2(devnull, 0)
-                            os.close(devnull)
-                        except OSError:
-                            pass
+                        # Child hung up its end — stop forwarding stdin.
+                        stdin_open = False
                 else:
-                    # Stdin EOF — dup /dev/null over fd 0 so select() never
-                    # wakes for fd 0 again. (iter-2 doc fix: was previously
-                    # described as "bool flag" which never existed.)
-                    try:
-                        devnull = os.open(os.devnull, os.O_RDONLY)
-                        os.dup2(devnull, 0)
-                        os.close(devnull)
-                    except OSError:
-                        pass
+                    # Stdin EOF — drop fd 0 from the select set.
+                    stdin_open = False
     finally:
         try:
             os.close(master_fd)
@@ -204,10 +202,14 @@ def main() -> int:
     return 1
 
 
-def _drain(master_fd: int, max_bytes: int = 1 << 20) -> None:
+def _drain(master_fd: int, max_bytes: int = 16 << 20) -> None:
     """Read everything buffered on master_fd and write to stdout.
 
-    Bounded by max_bytes (1 MiB) to avoid infinite loops if upstream is weird.
+    Bounded by max_bytes (16 MiB) to avoid infinite loops if upstream is weird.
+    The cap is sized for council-chairman synthesis output (multi-advisor raw
+    outputs at xhigh effort can plausibly exceed 1 MiB; 16 MiB is comfortably
+    above any realistic single codex turn). Truncation emits an unconditional
+    stderr warning so silent half-output is impossible (iter-3 council P2 fix).
     """
     total = 0
     while total < max_bytes:
@@ -228,6 +230,13 @@ def _drain(master_fd: int, max_bytes: int = 1 << 20) -> None:
         except OSError:
             return
         total += len(data)
+    # Reached cap without seeing EOF — surface the truncation loudly so the
+    # user knows the response was clipped.
+    sys.stderr.write(
+        f"codex-pty-helper: drain cap reached ({max_bytes} bytes); "
+        f"output truncated. File a bug if reproducible.\n"
+    )
+    sys.stderr.flush()
 
 
 if __name__ == "__main__":

--- a/hooks/lib/codex-pty.ps1
+++ b/hooks/lib/codex-pty.ps1
@@ -1,0 +1,152 @@
+# hooks/lib/codex-pty.ps1 — work around openai/codex#19945 (Windows side).
+#
+# Mirrors hooks/lib/codex-pty.sh. See that file's header for the bug and the
+# unified contract; the docs below cover only Windows-specific concerns.
+#
+# Status of #19945 on Windows: zero confirmed reproductions as of 2026-05-01.
+# This shim exists primarily for parity (ADR 0005) — its default action is
+# detect-then-bypass: on PS 7+ with non-redirected stdio (native ConPTY host),
+# we just exec codex directly. Only when stdio is redirected (e.g., the user
+# pipes / redirects / spawns from a no-tty parent) do we escalate to winpty,
+# WSL, or fall through with a warning.
+#
+# Contract:
+#   - First arg MUST be "exec"
+#   - All args after "exec" forwarded to codex verbatim
+#   - Stdout = codex's stdout
+#   - Stderr = codex's stderr + shim diagnostics prefixed `codex-pty: ` written
+#     via [Console]::Error.WriteLine (NOT Write-Warning, which uses PS warning
+#     stream #3 — would violate the cross-shim stderr contract)
+#   - Exit codes: 2 = bad usage, 127 = codex not found, otherwise codex's exit
+#
+# Opt-out env vars (mirror codex-pty.sh):
+#   $env:CLAUDE_FORGE_CODEX_PTY_BYPASS = '1'       skip the shim entirely
+#   $env:CLAUDE_FORGE_CODEX_PTY_VIA_WSL = '1'      escalate via WSL when other strategies fail
+#
+# Dual-mode (mirrors default-branch.ps1):
+#   Script-call:   & "$libPath" exec --foo bar
+#   Dot-source:    . "$libPath" ; Invoke-CodexPty exec --foo bar
+#   The dual-mode is critical because the shipped Claude Code launcher on
+#   Windows is `powershell.exe` (5.1), not `pwsh` (7+), so consumers should
+#   prefer dot-sourcing to avoid spawning a 7+ subprocess that may not exist.
+
+function Invoke-CodexPty {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]]$Args
+    )
+
+    # Usage check — first arg must be 'exec'
+    if ($Args.Count -lt 1 -or $Args[0] -ne 'exec') {
+        $first = if ($Args.Count -ge 1) { $Args[0] } else { '<empty>' }
+        [Console]::Error.WriteLine("codex-pty: usage: Invoke-CodexPty exec [codex-exec-args...]")
+        [Console]::Error.WriteLine("codex-pty: first argument must be 'exec' (the codex subcommand); got: $first")
+        return 2
+    }
+
+    # codex availability check
+    $codex = Get-Command codex -ErrorAction SilentlyContinue
+    if (-not $codex) {
+        [Console]::Error.WriteLine("codex-pty: codex not found on PATH")
+        [Console]::Error.WriteLine("codex-pty: install with 'npm i -g @openai/codex' or 'scoop install codex'")
+        return 127
+    }
+
+    # Bypass: skip shim logic entirely.
+    if ($env:CLAUDE_FORGE_CODEX_PTY_BYPASS -eq '1') {
+        & codex @Args
+        return $LASTEXITCODE
+    }
+
+    # If stdio is not redirected AND we're on PS 7+, the shell's console host
+    # is ConPTY-backed. Spawning codex with no redirection gives the child a
+    # console-attached stdio, isatty() returns true, bug condition not met.
+    $outRedirected = [Console]::IsOutputRedirected
+    $inRedirected  = [Console]::IsInputRedirected
+    if (-not $outRedirected -and -not $inRedirected -and
+        $PSVersionTable.PSVersion.Major -ge 7) {
+        & codex @Args
+        return $LASTEXITCODE
+    }
+
+    # Stdio is redirected (or we're on PS 5.1). Probe for winpty.exe — bundled
+    # with Git for Windows and installable via scoop.
+    $winpty = Get-Command winpty.exe -ErrorAction SilentlyContinue
+    if (-not $winpty) {
+        $candidates = @(
+            (Join-Path $env:ProgramFiles 'Git\usr\bin\winpty.exe'),
+            (Join-Path $env:ProgramFiles 'Git\mingw64\bin\winpty.exe')
+        )
+        foreach ($cand in $candidates) {
+            if (Test-Path -LiteralPath $cand) {
+                $winpty = Get-Item -LiteralPath $cand
+                break
+            }
+        }
+    }
+
+    if ($winpty) {
+        & $winpty.Source codex @Args
+        return $LASTEXITCODE
+    }
+
+    # WSL opt-in: shell out to WSL Linux + python3 + Linux codex. Only viable
+    # when the user has a working WSL distro with codex installed.
+    if ($env:CLAUDE_FORGE_CODEX_PTY_VIA_WSL -eq '1') {
+        $wsl = Get-Command wsl.exe -ErrorAction SilentlyContinue
+        if ($wsl) {
+            # Invoke the canonical helper (avoids drift between this file and
+            # codex-pty-helper.py — iter-2 fix). Translate the Windows path to
+            # a WSL-mount path via `wsl.exe wslpath -u`; pass it to the WSL-
+            # side python3.
+            $helperWin = Join-Path (Split-Path -Parent $PSCommandPath) 'codex-pty-helper.py'
+            $helperWsl = & wsl.exe wslpath -u "$helperWin" 2>$null
+            if ($LASTEXITCODE -ne 0 -or -not $helperWsl) {
+                [Console]::Error.WriteLine("codex-pty: wsl.exe wslpath failed; cannot translate helper path. Falling through.")
+            }
+            else {
+                # Capture stderr to distinguish wsl.exe infrastructure errors
+                # from codex's own exit codes (silent-failure agent P1, iter-2).
+                $errFile = [System.IO.Path]::GetTempFileName()
+                try {
+                    & wsl.exe -- python3 $helperWsl codex @Args 2>$errFile
+                    $rc = $LASTEXITCODE
+                    $errText = (Get-Content -Raw -ErrorAction SilentlyContinue $errFile)
+                    if ($rc -eq -1 -or ($errText -and $errText -match '^wsl(\.exe)?:')) {
+                        # WSL itself failed (distro stopped, kernel update needed,
+                        # python3/codex missing inside WSL). Don't masquerade
+                        # wsl.exe's exit as codex's — fall through to next strategy.
+                        [Console]::Error.WriteLine("codex-pty: WSL escalation failed (exit=$rc): $($errText.Trim())")
+                        [Console]::Error.WriteLine("codex-pty: falling through to direct invoke")
+                    }
+                    else {
+                        # Forward helper's stderr (codex errors, exec failures)
+                        if ($errText) { [Console]::Error.Write($errText) }
+                        return $rc
+                    }
+                }
+                finally {
+                    Remove-Item -ErrorAction SilentlyContinue $errFile
+                }
+            }
+        }
+        else {
+            [Console]::Error.WriteLine("codex-pty: CLAUDE_FORGE_CODEX_PTY_VIA_WSL=1 but wsl.exe not on PATH; falling through")
+        }
+    }
+
+    # Last-resort fallback: direct invoke with a stderr warning.
+    [Console]::Error.WriteLine("codex-pty: winpty.exe not found and stdio is redirected; falling back to direct invoke (may hit openai/codex#19945)")
+    [Console]::Error.WriteLine("codex-pty: install via 'scoop install winpty' or Git for Windows; or set `$env:CLAUDE_FORGE_CODEX_PTY_BYPASS='1' to silence")
+    & codex @Args
+    return $LASTEXITCODE
+}
+
+# Dual-mode entry point — same pattern as default-branch.ps1.
+# When dot-sourced: $MyInvocation.InvocationName == '.' → just define the function.
+# When invoked as script: call the function with $args, exit with its return.
+if ($MyInvocation.InvocationName -ne '.') {
+    $rc = Invoke-CodexPty @args
+    exit $rc
+}

--- a/hooks/lib/codex-pty.sh
+++ b/hooks/lib/codex-pty.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# hooks/lib/codex-pty.sh — work around openai/codex#19945.
+#
+# THE BUG: codex 0.124.0+ (last unaffected: 0.123.0) silently exits with empty
+# stdout when `codex exec` runs with stdio detached from a controlling TTY AND
+# the prompt is non-trivial in length (~2KB+). Both triggers fire any time
+# Claude Code's Bash tool spawns codex, because that tool pipes stdio without
+# allocating a pseudo-terminal. Issue tracker:
+#   https://github.com/openai/codex/issues/19945  (open as of 2026-05-01)
+# Companion (macOS): https://github.com/openai/codex/issues/8690
+#
+# THE FIX: allocate a pseudo-tty for codex's stdio so isatty(stdin/out) returns
+# true. We delegate to a Python helper (codex-pty-helper.py) that uses
+# `pty.fork()` plus an explicit `waitpid(WNOHANG)` loop. We do NOT use BSD
+# `script(1)` (it requires a parent tty — calls `tcgetattr` on parent stdin —
+# which Claude Code's Bash tool, running with stdin connected to a Unix domain
+# socket, does not have). We do NOT use Python's `pty.spawn()` either: 3.9's
+# stdlib version hangs on macOS after the child exits because the parent's
+# `select()` loop blocks on a master_fd that never reports EOF. The explicit
+# waitpid-based helper sidesteps both problems. python3 ships with macOS 10.13+
+# and essentially all Linux distros.
+#
+# RETEST CRITERION: drop this shim once codex 0.128+ is empirically confirmed
+# clean on Linux + macOS + Windows. Verify by running the original repro from
+# issue #19945:  setsid codex exec "$LARGE_PROMPT" < /dev/null   producing
+# non-empty output. Until then, leave the shim in place.
+#
+# Contract:
+#   - First arg MUST be "exec" (or "exec review", which becomes "exec" + "review")
+#   - All args after "exec" are forwarded to codex verbatim, in order
+#   - Stdout = codex's stdout (PTY-merged with stderr per script(1) semantics)
+#   - Stderr = the shim's own diagnostics, prefixed `codex-pty: `
+#   - Exit codes: 2 = bad usage, 127 = codex not found, otherwise codex's exit
+#
+# Opt-out env vars (mirror PR #592 pattern):
+#   CLAUDE_FORGE_CODEX_PTY_BYPASS=1     skip the PTY wrapping entirely
+#   CLAUDE_FORGE_CODEX_PTY_VIA_WSL=1    (Windows only) escalate via WSL
+#
+# Invocation: this is a script-only file. Always invoke it directly via
+#   bash "$REPO/.claude/hooks/lib/codex-pty.sh" exec [codex-args...]
+# Sourcing is NOT supported because the function uses `exec` to chain into
+# python3/codex; sourcing it into your shell and then calling the function
+# would replace your shell. (iter-2 fix — earlier docstring described a
+# source-mode that would crash the caller.)
+
+codex_pty_exec() {
+    # Usage check
+    if [ "${1:-}" != "exec" ]; then
+        echo "codex-pty: usage: codex_pty_exec exec [codex-exec-args...]" >&2
+        echo "codex-pty: first argument must be 'exec' (the codex subcommand); got: ${1:-<empty>}" >&2
+        return 2
+    fi
+
+    # Bypass: skip PTY wrapping entirely. Check this BEFORE the codex
+    # availability check so a user with a `codex` shell alias (invisible
+    # to `command -v`) can still exec it via bypass (silent-failure agent
+    # P2, iter-2).
+    if [ "${CLAUDE_FORGE_CODEX_PTY_BYPASS:-}" = "1" ]; then
+        exec codex "$@"
+    fi
+
+    # codex availability check (only reached when not bypassing)
+    if ! command -v codex >/dev/null 2>&1; then
+        echo "codex-pty: codex not found on PATH" >&2
+        echo "codex-pty: install with 'npm i -g @openai/codex' or 'brew install --cask codex'" >&2
+        return 127
+    fi
+
+    # OS-specific PTY wrapping
+    case "$(uname -s 2>/dev/null)" in
+        Darwin|Linux)
+            if ! command -v python3 >/dev/null 2>&1; then
+                echo "codex-pty: python3 not found; falling back to direct invoke (may hit openai/codex#19945)" >&2
+                echo "codex-pty: install via 'brew install python' or 'apt install python3', or set CLAUDE_FORGE_CODEX_PTY_BYPASS=1" >&2
+                exec codex "$@"
+            fi
+            # Resolve the helper path relative to this shim.
+            local helper
+            helper="$(dirname "${BASH_SOURCE[0]}")/codex-pty-helper.py"
+            if [ ! -f "$helper" ]; then
+                # Missing helper is an installation defect, not graceful
+                # degradation. Falling through to direct invoke would silently
+                # re-introduce openai/codex#19945 — exactly what the shim
+                # exists to prevent. Surface it loudly with a non-zero exit
+                # (silent-failure agent P1, iter-2).
+                echo "codex-pty: helper not found at $helper" >&2
+                echo "codex-pty: this is an installation defect — re-run setup.sh -f to repair" >&2
+                echo "codex-pty: or set CLAUDE_FORGE_CODEX_PTY_BYPASS=1 to deliberately skip the workaround" >&2
+                return 3
+            fi
+            # The helper runs codex in a pty.fork()'d child and uses an
+            # explicit waitpid(WNOHANG) loop to exit promptly when codex
+            # terminates — pty.spawn() in Python 3.9 hangs on macOS in this
+            # role, see helper file header for details.
+            exec python3 "$helper" codex "$@"
+            ;;
+        MINGW*|MSYS*|CYGWIN*)
+            # Git Bash / MSYS / Cygwin on Windows. mintty talks to console
+            # programs through winpty. winpty is bundled with Git for Windows.
+            if command -v winpty >/dev/null 2>&1; then
+                exec winpty codex "$@"
+            fi
+            echo "codex-pty: winpty not found on Git Bash; falling back to direct invoke (may hit openai/codex#19945)" >&2
+            echo "codex-pty: install Git for Windows or 'scoop install winpty', or set CLAUDE_FORGE_CODEX_PTY_BYPASS=1" >&2
+            exec codex "$@"
+            ;;
+        *)
+            echo "codex-pty: unknown OS '$(uname -s 2>/dev/null)'; falling back to direct invoke (may hit openai/codex#19945)" >&2
+            echo "codex-pty: set CLAUDE_FORGE_CODEX_PTY_BYPASS=1 to silence this warning" >&2
+            exec codex "$@"
+            ;;
+    esac
+}
+
+# Dual-mode: when invoked as a script (not sourced), call the function and
+# exit with its status. When sourced, just expose codex_pty_exec.
+#
+# Idiom: BASH_SOURCE[0] equals $0 only when this file is the entry point
+# (i.e., invoked as `bash this-file.sh`). When sourced, BASH_SOURCE[0] is
+# this file's path while $0 is the parent script's name.
+if [[ "${BASH_SOURCE[0]:-}" == "${0}" ]]; then
+    codex_pty_exec "$@"
+    exit $?
+else
+    echo "codex-pty: this script must be invoked directly (bash codex-pty.sh ...), not sourced." >&2
+    echo "codex-pty: sourcing it would replace your shell when codex_pty_exec runs 'exec'." >&2
+    # shellcheck disable=SC2317  # exit 2 is reachable when `return` is invalid (script-mode)
+    return 2 2>/dev/null || exit 2
+fi

--- a/setup.ps1
+++ b/setup.ps1
@@ -577,6 +577,12 @@ $libDir = ".claude\hooks\lib"
 if (-not (Test-Path $libDir)) { New-Item -ItemType Directory -Path $libDir -Force | Out-Null }
 Copy-TemplateFile (Join-Path (Join-Path (Join-Path $ScriptDir "hooks") "lib") "default-branch.ps1") "$libDir\default-branch.ps1" "$libDir\default-branch.ps1 (default-branch detection helper, PowerShell)"
 Copy-TemplateFile (Join-Path (Join-Path (Join-Path $ScriptDir "hooks") "lib") "default-branch.sh") "$libDir\default-branch.sh" "$libDir\default-branch.sh (default-branch detection helper, bash — used by commands/*.md preflight)"
+# codex-pty shim — work around openai/codex#19945 (silent empty exit when codex
+# exec runs without a controlling TTY). Both .ps1 + .sh + helper.py ship for
+# cross-platform parity (ADR 0005).
+Copy-TemplateFile (Join-Path (Join-Path (Join-Path $ScriptDir "hooks") "lib") "codex-pty.ps1") "$libDir\codex-pty.ps1" "$libDir\codex-pty.ps1 (codex PTY shim, openai/codex#19945)"
+Copy-TemplateFile (Join-Path (Join-Path (Join-Path $ScriptDir "hooks") "lib") "codex-pty.sh") "$libDir\codex-pty.sh" "$libDir\codex-pty.sh (codex PTY shim, bash — used by commands/codex.md callsites)"
+Copy-TemplateFile (Join-Path (Join-Path (Join-Path $ScriptDir "hooks") "lib") "codex-pty-helper.py") "$libDir\codex-pty-helper.py" "$libDir\codex-pty-helper.py (Python pty.fork helper for the shim)"
 
 # ADRs -- ship template + README + seed ADRs (existing-file-skip semantics).
 if (-not (Test-Path "docs\adr")) { New-Item -ItemType Directory -Path "docs\adr" -Force | Out-Null }

--- a/setup.sh
+++ b/setup.sh
@@ -548,6 +548,15 @@ copy_file "$SCRIPT_DIR/hooks/auto-approve-local-writes.sh" ".claude/hooks/auto-a
 mkdir -p .claude/hooks/lib
 copy_file "$SCRIPT_DIR/hooks/lib/default-branch.sh" ".claude/hooks/lib/default-branch.sh" ".claude/hooks/lib/default-branch.sh (default-branch detection helper)"
 chmod +x .claude/hooks/lib/default-branch.sh 2>/dev/null || true
+copy_file "$SCRIPT_DIR/hooks/lib/default-branch.ps1" ".claude/hooks/lib/default-branch.ps1" ".claude/hooks/lib/default-branch.ps1 (PowerShell mirror)"
+# codex-pty shim — work around openai/codex#19945 (silent empty exit when codex
+# exec runs without a controlling TTY). Both .sh + .ps1 + helper.py ship for
+# cross-platform parity (ADR 0005).
+copy_file "$SCRIPT_DIR/hooks/lib/codex-pty.sh" ".claude/hooks/lib/codex-pty.sh" ".claude/hooks/lib/codex-pty.sh (codex PTY shim, openai/codex#19945)"
+chmod +x .claude/hooks/lib/codex-pty.sh 2>/dev/null || true
+copy_file "$SCRIPT_DIR/hooks/lib/codex-pty-helper.py" ".claude/hooks/lib/codex-pty-helper.py" ".claude/hooks/lib/codex-pty-helper.py (Python pty.fork helper for the shim)"
+chmod +x .claude/hooks/lib/codex-pty-helper.py 2>/dev/null || true
+copy_file "$SCRIPT_DIR/hooks/lib/codex-pty.ps1" ".claude/hooks/lib/codex-pty.ps1" ".claude/hooks/lib/codex-pty.ps1 (Windows PowerShell shim)"
 
 chmod +x .claude/hooks/session-start.sh 2>/dev/null || true
 chmod +x .claude/hooks/check-state-updated.sh 2>/dev/null || true

--- a/skills/council/SKILL.template.md
+++ b/skills/council/SKILL.template.md
@@ -64,7 +64,7 @@ Read `references/advisors.md` to get the 5 advisor personas and their engine ass
 2. The question/decision + context
 3. Instruction to follow the output schema from `references/output-schema.md`
 
-**Codex advisors:** Use `codex exec` via the Bash tool with `run_in_background: true`. Each call includes:
+**Codex advisors:** Use `.claude/hooks/lib/codex-pty.sh exec` (the PTY shim — works around openai/codex#19945) via the Bash tool with `run_in_background: true`. On Windows, use `.claude/hooks/lib/codex-pty.ps1` instead. Each call includes:
 
 1. The persona text
 2. The question/decision + context
@@ -97,7 +97,7 @@ Construct the chairman prompt with:
 - Instruction to produce the Chairman Output Format from `references/output-schema.md`
 - Explicit instruction: "You MUST include a Minority Report section if any advisor OBJECTed"
 
-Run via `codex exec` with `reasoning_effort=xhigh`. Timeout: 1200000ms.
+Run via `.claude/hooks/lib/codex-pty.sh exec` with `reasoning_effort=xhigh`. Timeout: 1200000ms.
 
 See `references/peer-review-protocol.md` for the exact chairman command.
 

--- a/skills/council/references/peer-review-protocol.md
+++ b/skills/council/references/peer-review-protocol.md
@@ -36,10 +36,10 @@ All Claude advisors go in a SINGLE message with multiple Task tool calls = paral
 
 ### Codex Advisor Dispatch
 
-Run via `codex exec` with:
+Run via the codex-pty shim (`.claude/hooks/lib/codex-pty.sh`) — works around openai/codex#19945, which silently drops `codex exec` output when stdio is detached from a TTY (Claude Code's Bash tool). On Windows, use `.claude/hooks/lib/codex-pty.ps1` instead. Both forward args verbatim to `codex exec`:
 
 ```bash
-codex exec \
+.claude/hooks/lib/codex-pty.sh exec \
   -m "gpt-5.5" \
   -c model_reasoning_effort="high" \
   -c service_tier="fast" \
@@ -58,7 +58,7 @@ Run Codex advisors with `run_in_background: true` in the Bash tool so they execu
 After all advisors complete, construct the chairman prompt:
 
 ```bash
-codex exec \
+.claude/hooks/lib/codex-pty.sh exec \
   -m "gpt-5.5" \
   -c model_reasoning_effort="xhigh" \
   -c service_tier="fast" \
@@ -112,7 +112,7 @@ This is the single source of truth for what constitutes a "high-impact surface."
 Before firing the full council, the Contrarian/Codex validates the "default wins" claim:
 
 ```bash
-codex exec \
+.claude/hooks/lib/codex-pty.sh exec \
   -m "gpt-5.5" \
   -c model_reasoning_effort="high" \
   -c service_tier="fast" \

--- a/tests/template/test-codex-pty.sh
+++ b/tests/template/test-codex-pty.sh
@@ -1,0 +1,407 @@
+#!/usr/bin/env bash
+# tests/template/test-codex-pty.sh — fixture tests for hooks/lib/codex-pty.sh.
+#
+# Verifies the shim's strict contract:
+#   - Bypass env var skips PTY wrapping (direct exec, no python3 in tree)
+#   - Default Unix path uses python3 pty.fork (child sees isatty=true)
+#   - Real pty.fork integration works against a non-codex binary
+#   - Stdin from /dev/null does not hang
+#   - Bad first arg exits 2
+#   - codex binary missing exits 127
+#   - Shell metacharacters in args reach codex verbatim
+#   - Header references the issue and env var contract
+#
+# Run from repo root:  bash tests/template/test-codex-pty.sh
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+# shellcheck source=lib.sh
+source "$REPO_ROOT/tests/template/lib.sh"
+
+init_counters
+
+SHIM="$REPO_ROOT/hooks/lib/codex-pty.sh"
+
+# ---------------------------------------------------------------------------
+# Scratch fixture: builds a scratch dir with a mock `codex` binary that
+# records its argv + isatty(stdin) into a result file. Returns the result.
+#
+# Args: $1 = result file path (mock codex writes here)
+#       $2 = exit code mock codex should return
+#
+# Returns: prints the scratch dir path; caller is responsible for cleanup.
+# ---------------------------------------------------------------------------
+make_mock_codex() {
+    local resultfile="$1" exitcode="${2:-0}"
+    local scratch
+    scratch=$(mktemp -d -t codex-pty-XXXXXX)
+    cat > "$scratch/codex" <<EOF
+#!/usr/bin/env bash
+# mock codex
+# Capture isatty status BEFORE redirecting stdout to the result file,
+# otherwise [ -t 1 ] would test the redirected fd. Avoid \$(...) — the
+# subshell's fd 1 is a pipe, not the parent's fd 1.
+if [ -t 0 ]; then ATTY0=true; else ATTY0=false; fi
+if [ -t 1 ]; then ATTY1=true; else ATTY1=false; fi
+{
+    printf 'argv='
+    printf '%s\\n' "\$*"
+    printf 'isatty_stdin=%s\\n' "\$ATTY0"
+    printf 'isatty_stdout=%s\\n' "\$ATTY1"
+} > '$resultfile'
+exit $exitcode
+EOF
+    chmod +x "$scratch/codex"
+    printf '%s' "$scratch"
+}
+
+cleanup_scratch() {
+    [[ -n "${1:-}" && -d "$1" ]] && rm -rf "$1"
+}
+
+# ===========================================================================
+# Section 1: Static contract — shim file structure
+# ===========================================================================
+
+start_test "shim file exists"
+assert_file_exists "$SHIM"
+
+start_test "shim has bash shebang"
+assert_matches "$SHIM" "^#!/usr/bin/env bash"
+
+start_test "shim header references openai/codex#19945"
+assert_contains "$SHIM" "openai/codex#19945"
+
+start_test "shim defines bypass env var by name"
+assert_contains "$SHIM" "CLAUDE_FORGE_CODEX_PTY_BYPASS"
+
+start_test "shim defines wsl opt-in env var by name"
+# WSL is a Windows-side concern but Unix shim should still document the
+# cross-shim env var contract for parity.
+assert_contains "$SHIM" "CLAUDE_FORGE_CODEX_PTY_VIA_WSL"
+
+start_test "shim references python3 pty.fork (the corrected primitive)"
+# Shim header documents that the helper uses pty.fork() not pty.spawn();
+# the helper file itself is asserted in the helper-direct tests below.
+assert_contains "$SHIM" "pty.fork"
+
+start_test "shim does NOT use bash printf %q quoting (would be \$SHELL-dependent)"
+# After the iter-2 P1 correction, we don't use script(1)+%q anymore.
+assert_not_contains "$SHIM" "printf '%q "
+
+# ===========================================================================
+# Section 2: Behavioral — bypass env var
+# ===========================================================================
+
+start_test "bypass env var skips pty wrapping (mock codex sees no tty)"
+RESULT=$(mktemp)
+SCRATCH=$(make_mock_codex "$RESULT" 0)
+trap "cleanup_scratch '$SCRATCH'; rm -f '$RESULT'" EXIT
+PATH="$SCRATCH:$PATH" CLAUDE_FORGE_CODEX_PTY_BYPASS=1 bash "$SHIM" exec --foo bar </dev/null >/dev/null 2>&1
+exit_code=$?
+if [[ -f "$RESULT" ]]; then
+    if grep -q '^argv=exec --foo bar$' "$RESULT"; then
+        pass "mock codex received argv verbatim"
+    else
+        fail "mock codex argv mismatch: $(cat "$RESULT")"
+    fi
+    if grep -q '^isatty_stdin=false$' "$RESULT"; then
+        pass "stdin not a tty (bypass means no PTY allocation)"
+    else
+        fail "expected isatty_stdin=false under bypass, got: $(grep isatty_stdin "$RESULT")"
+    fi
+else
+    fail "mock codex was never invoked (resultfile absent); shim exit=$exit_code"
+fi
+
+# ===========================================================================
+# Section 3: Behavioral — default path uses python3 pty.fork
+# ===========================================================================
+
+start_test "default path on Darwin/Linux: mock codex sees isatty=true (PTY allocated)"
+RESULT=$(mktemp)
+SCRATCH=$(make_mock_codex "$RESULT" 0)
+PATH="$SCRATCH:$PATH" bash "$SHIM" exec --foo bar </dev/null >/dev/null 2>&1
+exit_code=$?
+if [[ -f "$RESULT" ]]; then
+    if grep -q '^argv=exec --foo bar$' "$RESULT"; then
+        pass "mock codex received argv verbatim under PTY wrap"
+    else
+        fail "mock codex argv mismatch: $(cat "$RESULT")"
+    fi
+    if grep -q '^isatty_stdin=true$' "$RESULT"; then
+        pass "stdin IS a tty (PTY allocation succeeded)"
+    else
+        fail "expected isatty_stdin=true under PTY wrap, got: $(grep isatty_stdin "$RESULT")"
+    fi
+    if grep -q '^isatty_stdout=true$' "$RESULT"; then
+        pass "stdout IS a tty (PTY allocation succeeded)"
+    else
+        fail "expected isatty_stdout=true under PTY wrap, got: $(grep isatty_stdout "$RESULT")"
+    fi
+else
+    fail "mock codex was never invoked under default path (resultfile absent); shim exit=$exit_code"
+fi
+cleanup_scratch "$SCRATCH"; rm -f "$RESULT"
+
+# ===========================================================================
+# Section 4: Behavioral — exit code propagation
+# ===========================================================================
+
+start_test "shim propagates mock codex exit 42"
+RESULT=$(mktemp)
+SCRATCH=$(make_mock_codex "$RESULT" 42)
+set +e
+PATH="$SCRATCH:$PATH" bash "$SHIM" exec </dev/null >/dev/null 2>&1
+shim_exit=$?
+set -e 2>/dev/null || true
+assert_equals "$shim_exit" "42" "exit code 42 propagated through pty.fork"
+cleanup_scratch "$SCRATCH"; rm -f "$RESULT"
+
+# ===========================================================================
+# Section 5: Behavioral — bad first arg
+# ===========================================================================
+
+start_test "first arg must be 'exec' — anything else exits 2"
+set +e
+bash "$SHIM" notexec --whatever </dev/null >/dev/null 2>/tmp/codex-pty-stderr.$$
+shim_exit=$?
+set -e 2>/dev/null || true
+assert_equals "$shim_exit" "2" "exit 2 on bad first arg"
+assert_matches "/tmp/codex-pty-stderr.$$" "codex-pty:.*usage" "stderr matches 'codex-pty: ...usage...'"
+rm -f "/tmp/codex-pty-stderr.$$"
+
+# ===========================================================================
+# Section 6: Behavioral — codex binary missing
+# ===========================================================================
+
+start_test "codex not on PATH exits 127"
+# Use empty PATH inside an inner bash invocation (outer bash is still located).
+set +e
+/bin/bash -c "PATH=/nonexistent /bin/bash '$SHIM' exec --whatever </dev/null >/dev/null 2>/tmp/codex-pty-127.$$"
+shim_exit=$?
+set -e 2>/dev/null || true
+assert_equals "$shim_exit" "127" "exit 127 when codex binary not found"
+assert_matches "/tmp/codex-pty-127.$$" "codex-pty:.*codex.*not found" "stderr matches 'codex-pty: codex not found'"
+rm -f "/tmp/codex-pty-127.$$"
+
+# ===========================================================================
+# Section 7: Real-pty integration (iter-2 codex P2 fix — no codex mocked,
+# real python3 + real pty.fork against /bin/echo)
+# ===========================================================================
+
+start_test "real pty.fork integration: shim wraps /bin/echo via mock 'codex' (data-path round-trip)"
+RESULT=$(mktemp)
+SCRATCH=$(mktemp -d -t codex-pty-real-XXXXXX)
+# Mock codex that just exec's /bin/echo so we go through real pty.fork machinery.
+cat > "$SCRATCH/codex" <<'EOF'
+#!/usr/bin/env bash
+# This mock proxies to /bin/echo to exercise real pty.fork end-to-end.
+shift  # drop "exec"
+exec /bin/echo "$@"
+EOF
+chmod +x "$SCRATCH/codex"
+PATH="$SCRATCH:$PATH" bash "$SHIM" exec hello world </dev/null >"$RESULT" 2>&1
+shim_exit=$?
+# PTY translates \n → \r\n. Strip CR for matching.
+output_clean=$(tr -d '\r' < "$RESULT")
+if [[ "$shim_exit" -eq 0 ]] && grep -q '^hello world$' <<<"$output_clean"; then
+    pass "real pty.fork round-trip ok (output=$(printf '%q' "$output_clean"), exit=$shim_exit)"
+else
+    fail "real pty.fork round-trip failed (output=$(printf '%q' "$output_clean"), exit=$shim_exit)"
+fi
+cleanup_scratch "$SCRATCH"; rm -f "$RESULT"
+
+start_test "data-path round-trip via PTY: child stdout reaches parent stdout (iter-2 fix — was missing assertion)"
+# Section 7 above could pass if /bin/echo got a regular pipe instead of a PTY,
+# because /bin/echo writes the same bytes either way. This test asserts that
+# bytes specifically written to the child's *stdout* arrive at the parent's
+# captured stdout — proving the master_fd → STDOUT_FILENO data path works.
+RESULT=$(mktemp)
+SCRATCH=$(mktemp -d -t codex-pty-roundtrip-XXXXXX)
+cat > "$SCRATCH/codex" <<'EOF'
+#!/usr/bin/env bash
+# Print a unique sentinel to stdout. If the parent captures it, the PTY
+# data path is intact.
+printf 'PTY_DATA_PATH_OK\n'
+exit 0
+EOF
+chmod +x "$SCRATCH/codex"
+PATH="$SCRATCH:$PATH" bash "$SHIM" exec </dev/null >"$RESULT" 2>&1
+output_clean=$(tr -d '\r' < "$RESULT")
+if grep -q '^PTY_DATA_PATH_OK$' <<<"$output_clean"; then
+    pass "child stdout flows through pty master to parent stdout"
+else
+    fail "child stdout NOT received: $(printf '%q' "$output_clean")"
+fi
+cleanup_scratch "$SCRATCH"; rm -f "$RESULT"
+
+start_test "long prompt regression test: 4KB argv survives PTY transit (#19945 repro)"
+# The bug requires BOTH no-tty AND non-trivial prompt. Earlier tests covered
+# no-tty with short args; this exercises the long-prompt trigger explicitly.
+RESULT=$(mktemp)
+SCRATCH=$(mktemp -d -t codex-pty-long-XXXXXX)
+cat > "$SCRATCH/codex" <<'EOF'
+#!/usr/bin/env bash
+shift  # drop "exec"
+# Echo back length of first arg so we can verify byte-count round-trip.
+printf 'arg1_len=%d\n' ${#1}
+EOF
+chmod +x "$SCRATCH/codex"
+LONG_PROMPT=$(printf 'x%.0s' $(seq 1 4096))
+PATH="$SCRATCH:$PATH" bash "$SHIM" exec "$LONG_PROMPT" </dev/null >"$RESULT" 2>&1
+shim_exit=$?
+output_clean=$(tr -d '\r' < "$RESULT")
+if [[ "$shim_exit" -eq 0 ]] && grep -q '^arg1_len=4096$' <<<"$output_clean"; then
+    pass "4KB prompt round-tripped intact (out=$output_clean, exit=$shim_exit)"
+else
+    fail "long-prompt PTY transit failed (out=$(printf '%q' "$output_clean"), exit=$shim_exit)"
+fi
+cleanup_scratch "$SCRATCH"; rm -f "$RESULT"
+
+start_test "signal-killed child returns 128+signum (SIGTERM=15 → 143)"
+RESULT=$(mktemp)
+SCRATCH=$(mktemp -d -t codex-pty-sig-XXXXXX)
+cat > "$SCRATCH/codex" <<'EOF'
+#!/usr/bin/env bash
+kill -TERM $$
+EOF
+chmod +x "$SCRATCH/codex"
+set +e
+PATH="$SCRATCH:$PATH" bash "$SHIM" exec </dev/null >/dev/null 2>&1
+shim_exit=$?
+set -e 2>/dev/null || true
+assert_equals "$shim_exit" "143" "exit 143 (=128+SIGTERM) for signal-killed child"
+cleanup_scratch "$SCRATCH"; rm -f "$RESULT"
+
+# ===========================================================================
+# Section 8: Stdin from /dev/null does not hang (iter-2 codex P2 fix —
+# pty.fork liveness gap)
+# ===========================================================================
+
+start_test "stdin from /dev/null does not block shim (timeout-bounded)"
+RESULT=$(mktemp)
+SCRATCH=$(mktemp -d -t codex-pty-sleep-XXXXXX)
+# Mock that exits quickly regardless of stdin
+cat > "$SCRATCH/codex" <<'EOF'
+#!/usr/bin/env bash
+exec /bin/sleep 0.5
+EOF
+chmod +x "$SCRATCH/codex"
+# Wrap the shim invocation in a bash subshell with our own watchdog.
+# If shim runs > 5s, kill it (test fails). If <= 5s, exit code reflects shim's.
+(
+    PATH="$SCRATCH:$PATH" bash "$SHIM" exec </dev/null >"$RESULT" 2>&1 &
+    pid=$!
+    # Watchdog
+    ( sleep 5 && kill -9 $pid 2>/dev/null && echo "WATCHDOG_KILLED" >&2 ) &
+    watchdog=$!
+    wait $pid 2>/dev/null
+    inner_exit=$?
+    kill $watchdog 2>/dev/null
+    exit $inner_exit
+)
+shim_exit=$?
+if [[ "$shim_exit" -eq 0 ]]; then
+    pass "shim exited cleanly with stdin from /dev/null (no hang)"
+elif [[ "$shim_exit" -eq 137 ]]; then  # SIGKILL exit
+    fail "shim hung with stdin from /dev/null — watchdog killed it"
+else
+    pass "shim exited with code $shim_exit but did not hang"
+fi
+cleanup_scratch "$SCRATCH"; rm -f "$RESULT"
+
+# ===========================================================================
+# Section 9: Shell metacharacters in args reach codex verbatim
+# ===========================================================================
+
+start_test "args with shell metachars (\$ ' \" ;) reach mock codex unchanged"
+RESULT=$(mktemp)
+SCRATCH=$(make_mock_codex "$RESULT" 0)
+# Construct an arg with awkward chars. We compare argv literally via grep -F.
+TRICKY="prompt with \$VAR 'single' \"double\" ;semi"
+PATH="$SCRATCH:$PATH" bash "$SHIM" exec "$TRICKY" </dev/null >/dev/null 2>&1
+if [[ -f "$RESULT" ]]; then
+    # Mock prints argv space-joined. We expect to see TRICKY verbatim in argv.
+    if grep -qF -- "$TRICKY" "$RESULT"; then
+        pass "tricky arg preserved through pty.fork"
+    else
+        fail "tricky arg corrupted: expected $(printf '%q' "$TRICKY"), got argv=$(grep '^argv=' "$RESULT")"
+    fi
+else
+    fail "mock codex never invoked"
+fi
+cleanup_scratch "$SCRATCH"; rm -f "$RESULT"
+
+# ===========================================================================
+# Section 10: Helper-direct unit tests (iter-2 codex P2 fix —
+# codex-pty-helper.py was previously exercised only transitively)
+# ===========================================================================
+
+HELPER="$REPO_ROOT/hooks/lib/codex-pty-helper.py"
+
+start_test "helper: missing argv exits 2"
+set +e
+python3 "$HELPER" </dev/null >/dev/null 2>/tmp/helper-stderr.$$
+helper_exit=$?
+set -e 2>/dev/null || true
+assert_equals "$helper_exit" "2" "helper exits 2 with no command argv"
+assert_matches "/tmp/helper-stderr.$$" "codex-pty-helper:.*usage" "helper stderr matches usage"
+rm -f "/tmp/helper-stderr.$$"
+
+start_test "helper: command not found exits 127 with diagnostic"
+set +e
+python3 "$HELPER" /nonexistent/binary-name </dev/null >/tmp/helper-127.$$ 2>&1
+helper_exit=$?
+set -e 2>/dev/null || true
+assert_equals "$helper_exit" "127" "helper propagates exit 127 for FileNotFoundError"
+output_clean=$(tr -d '\r' < "/tmp/helper-127.$$")
+if grep -q "command not found" <<<"$output_clean"; then
+    pass "helper emits 'command not found' diagnostic on FileNotFoundError"
+else
+    fail "helper did not emit FileNotFoundError diagnostic: $(printf '%q' "$output_clean")"
+fi
+rm -f "/tmp/helper-127.$$"
+
+start_test "helper: signal-killed child returns 128+signum"
+SCRATCH=$(mktemp -d -t codex-pty-helpsig-XXXXXX)
+cat > "$SCRATCH/suicide" <<'EOF'
+#!/usr/bin/env bash
+kill -TERM $$
+EOF
+chmod +x "$SCRATCH/suicide"
+set +e
+python3 "$HELPER" "$SCRATCH/suicide" </dev/null >/dev/null 2>&1
+helper_exit=$?
+set -e 2>/dev/null || true
+assert_equals "$helper_exit" "143" "helper returns 128+SIGTERM (=143) for signal-killed child"
+cleanup_scratch "$SCRATCH"
+
+# ===========================================================================
+# Section 11: Fallback paths (iter-2 codex P2 fix — was 100% uncovered)
+# ===========================================================================
+
+start_test "fallback: helper file missing → return 3 with installation-defect diagnostic"
+RESULT=$(mktemp)
+SCRATCH=$(mktemp -d -t codex-pty-nohelp-XXXXXX)
+SCRATCH_BIN="$SCRATCH/bin"
+mkdir -p "$SCRATCH_BIN"
+# Mock codex (so codex availability check passes)
+cat > "$SCRATCH_BIN/codex" <<'EOF'
+#!/usr/bin/env bash
+echo "MOCK_CODEX_RAN_DIRECTLY"
+exit 0
+EOF
+chmod +x "$SCRATCH_BIN/codex"
+# Copy shim WITHOUT the helper sibling
+cp "$SHIM" "$SCRATCH/codex-pty.sh"
+set +e
+PATH="$SCRATCH_BIN:$PATH" bash "$SCRATCH/codex-pty.sh" exec --foo </dev/null >/dev/null 2>"/tmp/nohelp-stderr.$$"
+shim_exit=$?
+set -e 2>/dev/null || true
+assert_equals "$shim_exit" "3" "shim exits 3 (installation defect) when helper missing"
+assert_matches "/tmp/nohelp-stderr.$$" "codex-pty:.*helper not found" "stderr matches 'codex-pty: helper not found'"
+assert_matches "/tmp/nohelp-stderr.$$" "installation defect" "stderr names it as installation defect"
+cleanup_scratch "$SCRATCH"; rm -f "$RESULT" "/tmp/nohelp-stderr.$$"
+
+# ===========================================================================
+report "test-codex-pty.sh"

--- a/tests/template/test-codex-pty.sh
+++ b/tests/template/test-codex-pty.sh
@@ -278,6 +278,34 @@ cleanup_scratch "$SCRATCH"; rm -f "$RESULT"
 # pty.fork liveness gap)
 # ===========================================================================
 
+start_test "piped stdin EOF propagates to child (iter-3 smoke P1 fix — codex found this)"
+# When parent's stdin is a pipe that closes, the child needs to see EOF on
+# its end of the pty too. Without writing EOT to master, children that read
+# stdin (e.g., /bin/cat with piped input) hang forever waiting for more data.
+# Bug found by codex review of the v5.22 PR (iter-3 mcpgateway smoke).
+HELPER="$REPO_ROOT/hooks/lib/codex-pty-helper.py"
+RESULT=$(mktemp)
+(
+    printf 'hello-from-stdin\n' | python3 "$HELPER" /bin/cat > "$RESULT" 2>&1 &
+    inner=$!
+    ( sleep 5 && kill -9 $inner 2>/dev/null ) &
+    watchdog=$!
+    wait $inner 2>/dev/null
+    rc=$?
+    kill $watchdog 2>/dev/null
+    exit $rc
+)
+piped_exit=$?
+output_clean=$(tr -d '\r' < "$RESULT")
+if [[ "$piped_exit" -eq 0 ]] && grep -q "^hello-from-stdin$" <<<"$output_clean"; then
+    pass "piped stdin EOF cleanly propagated; child saw 'hello-from-stdin' and exited"
+elif [[ "$piped_exit" -eq 137 ]]; then
+    fail "shim hung on stdin EOF (regression — child never saw EOF). watchdog SIGKILL'd."
+else
+    fail "unexpected: exit=$piped_exit output=$(printf '%q' "$output_clean")"
+fi
+rm -f "$RESULT"
+
 start_test "stdin EOF doesn't busy-loop (CPU regression test — iter-3 council P1 fix)"
 # Contrarian + Maintainer empirically reproduced: before fix, wrapping sleep 2
 # with </dev/null caused the helper to consume ~2 CPU-seconds (1.80 sys + 0.20

--- a/tests/template/test-codex-pty.sh
+++ b/tests/template/test-codex-pty.sh
@@ -278,6 +278,30 @@ cleanup_scratch "$SCRATCH"; rm -f "$RESULT"
 # pty.fork liveness gap)
 # ===========================================================================
 
+start_test "stdin EOF doesn't busy-loop (CPU regression test — iter-3 council P1 fix)"
+# Contrarian + Maintainer empirically reproduced: before fix, wrapping sleep 2
+# with </dev/null caused the helper to consume ~2 CPU-seconds (1.80 sys + 0.20
+# user) versus near-zero CPU for plain sleep. Root cause: dup2(/dev/null, 0)
+# kept fd 0 in select set; /dev/null is always selectable → busy-loop.
+# Fixed by tracking stdin_open and dropping fd 0 from the select set after EOF.
+HELPER="$REPO_ROOT/hooks/lib/codex-pty-helper.py"
+# Use /usr/bin/time -p with portable POSIX output. Capture user+sys via awk.
+# Wall: 1s. Allowed CPU budget: 0.50s (10x buffer over fixed-cost ~0.05s).
+# Pre-fix observed: ~1 CPU-second for 1s wall, FAILS this assertion.
+TIMING=$(/usr/bin/time -p python3 "$HELPER" /bin/sleep 1 </dev/null >/dev/null 2>&1; \
+         /usr/bin/time -p python3 "$HELPER" /bin/sleep 1 </dev/null >/dev/null 2>/tmp/cputest.$$.txt
+         cat /tmp/cputest.$$.txt)
+rm -f /tmp/cputest.$$.txt
+# Sum user + sys
+CPU_TIME=$(awk '/^(user|sys) / {sum+=$2} END {print sum}' <<<"$TIMING")
+# Compare as float — bash can't, but awk can
+WITHIN_BUDGET=$(awk -v c="$CPU_TIME" 'BEGIN { print (c < 0.5) ? 1 : 0 }')
+if [[ "$WITHIN_BUDGET" == "1" ]]; then
+    pass "stdin-EOF wrap of sleep 1 used ${CPU_TIME}s CPU (well under 0.5s budget)"
+else
+    fail "stdin-EOF busy-loop regression: ${CPU_TIME}s CPU for 1s wall (was: ~1.0s before iter-3 fix)"
+fi
+
 start_test "stdin from /dev/null does not block shim (timeout-bounded)"
 RESULT=$(mktemp)
 SCRATCH=$(mktemp -d -t codex-pty-sleep-XXXXXX)

--- a/tests/template/test-contracts.sh
+++ b/tests/template/test-contracts.sh
@@ -706,6 +706,82 @@ else fail "STATE-INIT block diverges between new-feature.md and fix-bug.md"
 fi
 
 # ---------------------------------------------------------------------------
+# Contract: codex-pty shim — env vars + issue refs + helper present
+# Mirrors the cross-shim contract for openai/codex#19945 workaround.
+# ---------------------------------------------------------------------------
+start_test "codex-pty-shim contract: both .sh and .ps1 reference shared env vars + issue"
+PTY_SH="$REPO_ROOT/hooks/lib/codex-pty.sh"
+PTY_PS="$REPO_ROOT/hooks/lib/codex-pty.ps1"
+PTY_HELPER="$REPO_ROOT/hooks/lib/codex-pty-helper.py"
+
+for f in "$PTY_SH" "$PTY_PS" "$PTY_HELPER"; do
+    assert_file_exists "$f" "shim file exists: $(basename "$f")"
+done
+
+# Both shim files must reference the env var contract by exact name
+for f in "$PTY_SH" "$PTY_PS"; do
+    name=$(basename "$f")
+    assert_contains "$f" "CLAUDE_FORGE_CODEX_PTY_BYPASS" "$name references CLAUDE_FORGE_CODEX_PTY_BYPASS"
+    assert_contains "$f" "CLAUDE_FORGE_CODEX_PTY_VIA_WSL" "$name references CLAUDE_FORGE_CODEX_PTY_VIA_WSL"
+    assert_contains "$f" "openai/codex#19945" "$name header references openai/codex#19945"
+done
+
+# ---------------------------------------------------------------------------
+# Contract: codex-pty callsite migration — no bare `codex exec` lines (start
+# of line + whitespace) outside the shim files themselves and out-of-scope
+# /research /plans dirs (which document codex usage as artifacts).
+# ---------------------------------------------------------------------------
+start_test "codex-pty-callsite contract: no bare 'codex exec' in fenced code blocks across templates"
+
+violations=$(grep -REn '^[[:space:]]*codex exec\b' \
+    "$REPO_ROOT/commands/" \
+    "$REPO_ROOT/skills/" \
+    "$REPO_ROOT/agents/" \
+    "$REPO_ROOT/hooks/" 2>/dev/null \
+    | grep -vE '(hooks/lib/codex-pty\.|hooks/lib/codex-pty-helper)' \
+    | grep -vE '/research/|/plans/' \
+    || true)
+
+if [[ -z "$violations" ]]; then
+    pass "no bare 'codex exec' in templates (all callsites migrated to shim)"
+else
+    fail "bare 'codex exec' found in templates (callsites must use the shim)"
+    while IFS= read -r line; do
+        echo "    $line" >&2
+    done <<<"$violations"
+fi
+
+# ---------------------------------------------------------------------------
+# Contract: codex-pty council references — both council files must reference
+# the shim path at least once (proves the migration was applied).
+# ---------------------------------------------------------------------------
+start_test "codex-pty-council contract: SKILL.template.md and peer-review-protocol.md reference the shim"
+
+COUNCIL_SKILL="$REPO_ROOT/skills/council/SKILL.template.md"
+COUNCIL_PROTOCOL="$REPO_ROOT/skills/council/references/peer-review-protocol.md"
+
+for f in "$COUNCIL_SKILL" "$COUNCIL_PROTOCOL"; do
+    assert_file_exists "$f" "council file exists: $(basename "$f")"
+    assert_contains "$f" "codex-pty.sh" "$(basename "$f") references codex-pty.sh shim"
+done
+
+# ---------------------------------------------------------------------------
+# Contract: setup.sh + setup.ps1 install the shim files via explicit copy_file
+# calls (per plan §2.5 — no auto-traversal).
+# ---------------------------------------------------------------------------
+start_test "codex-pty-setup contract: setup.sh and setup.ps1 install the shim files"
+
+SETUP_SH="$REPO_ROOT/setup.sh"
+SETUP_PS="$REPO_ROOT/setup.ps1"
+
+assert_contains "$SETUP_SH" "codex-pty.sh" "setup.sh installs codex-pty.sh"
+assert_contains "$SETUP_SH" "codex-pty-helper.py" "setup.sh installs codex-pty-helper.py"
+assert_contains "$SETUP_SH" "codex-pty.ps1" "setup.sh installs codex-pty.ps1 (cross-platform parity)"
+assert_contains "$SETUP_PS" "codex-pty.ps1" "setup.ps1 installs codex-pty.ps1"
+assert_contains "$SETUP_PS" "codex-pty.sh" "setup.ps1 installs codex-pty.sh (cross-platform parity)"
+assert_contains "$SETUP_PS" "codex-pty-helper.py" "setup.ps1 installs codex-pty-helper.py"
+
+# ---------------------------------------------------------------------------
 # Report
 # ---------------------------------------------------------------------------
 report "test-contracts.sh"


### PR DESCRIPTION
## Summary

`codex exec` silently exits with empty stdout (exit 0, zero bytes) when run with stdio detached from a controlling TTY AND a non-trivial prompt — exactly the conditions Claude Code's Bash tool creates every time the Forge invokes `/codex` or `/council`. The bug was [introduced in codex 0.124.0](https://github.com/openai/codex/issues/19945) (last unaffected: 0.123.0), still present in 0.125.0 / 0.128.0, and remains **OPEN with zero maintainer activity** as of 2026-05-07. A second related issue ([#20919](https://github.com/openai/codex/issues/20919)) was filed 2026-05-04 confirming the problem is widespread.

Field reports describe 10–17 minute hangs on long audit prompts, ending in `kill` exit-144. Forge memory previously attributed this to "long prompt overload"; that was incomplete — prompt length is one of two triggers.

**The fix:** cross-platform PTY shim at `.claude/hooks/lib/codex-pty.{sh,ps1}` + `codex-pty-helper.py`. All `codex exec` invocations across `/codex` and `/council` route through the shim, which allocates a pseudo-terminal so codex sees `isatty(stdin/out) == true` and produces real output.

- **Unix:** `python3` + `pty.fork()` + explicit `waitpid(WNOHANG)` polling. We can't use BSD `script(1)` (needs parent TTY → fails on Claude Code's socket stdin) or Python's `pty.spawn()` (3.9 stdlib hangs on macOS after child exits). The waitpid-based helper sidesteps both.
- **Windows:** detect-then-bypass. PS 7+ + non-redirected stdio uses ConPTY natively; redirected stdio probes `winpty.exe`; opt-in WSL escalation reuses the canonical helper via `wsl.exe wslpath`. Issue #19945 has zero confirmed Windows reproductions — the .ps1 shim is mostly ADR 0005 parity.
- **Opt-out:** `CLAUDE_FORGE_CODEX_PTY_BYPASS=1` (mirrors v5.21 PR #592 pattern).

## Three-iteration review trail

**Iter-1 — Codex review (manual `pty.spawn` workaround on iter-2 plan):** `REJECT` with 2 P1 + 6 P2. All addressed in plan iter-2.

**Iter-2 — 3 PR Toolkit reviewers (code-reviewer, silent-failure-hunter, pr-test-analyzer):** 2 P0 + 6 P1 + ~11 P2. All addressed in commit `6443abb`. Then Pablo asked: "did you actually test cancellation?" — I hadn't; empirical test exposed that SIGINT was being silently swallowed. Fixed in commit `ff4489c` (signal forwarding in parent + SIG_DFL reset in child).

**Iter-3 — Engineering Council (5 advisors + Codex chairman):** `CONDITIONAL` with one P1 blocker. The Contrarian and Maintainer **independently** ran `python3 helper /bin/sleep 2 </dev/null` and measured ~2 CPU-seconds — a real busy-loop. Root cause: the iter-2 stdin-EOF handling did `dup2(/dev/null, 0)` expecting `select()` to stop waking on fd 0, but `/dev/null` is always selectable on macOS/Linux. Fixed in commit `9859abb` (track `stdin_open` flag, drop fd 0 from select set after EOF). Empirically: CPU usage went from 2 sec to **0.02 sec** for 2-second wall time.

| Iter-3 P1 blocker | Status |
|---|---|
| stdin-EOF CPU busy-loop | **FIXED** in `9859abb` — verified 0.02 CPU-sec vs 2 CPU-sec before |

| Iter-3 P2 (council deferred to P2-but-fix-now) | Status |
|---|---|
| Drain truncation silent | **FIXED** in `9859abb` — cap raised 1 MiB → 16 MiB + unconditional stderr warning if hit |

| Iter-3 P3 (council deferred to follow-up) | Status |
|---|---|
| Cut WSL escalation in `.ps1` (Simplifier — dead complexity) | Deferred |
| `CLAUDE_FORGE_CODEX_PTY_DEBUG=1` stderr line per invocation (Hawk) | Deferred |
| `scripts/canary-codex-pty.sh` with version-stamped #19945 repro (Maintainer + Contrarian) | Deferred |
| Live `/codex review` + `/council` smoke vs `../mcpgateway` (Simplifier) | Pending — see Test plan |

## Test plan

### Automated (all green at HEAD)
- [x] `bash tests/template/run-all.sh` — ALL pass
  - `test-codex-pty.sh`: **32/32** (incl. PTY data-path round-trip, 4KB long-prompt regression, signal-killed → 143, helper-direct unit tests, fallback paths, **CPU regression test**)
  - `test-contracts.sh`: 115/115 (incl. 9 cross-file shim contracts)
  - `test-setup.sh`: 130/130
  - All other suites: green
- [x] `shellcheck hooks/lib/codex-pty.sh` clean
- [x] `python3 -m py_compile hooks/lib/codex-pty-helper.py` clean

### Live empirical validation (already done)
- [x] **Real-codex large-prompt smoke** — 56KB prompt via shim → 2.3KB response in 20s, exit 0 (proves bug bypassed)
- [x] **Real-codex SIGINT cancellation** — 56KB prompt, SIGINT at T+12s → exit in 1s, code 1 (codex's clean "turn interrupted"), zero orphans
- [x] **Council 3-parallel cancellation** — 3 simultaneous shims with 56KB prompts each, SIGINT all → all exit in 1s, zero orphans
- [x] **CPU busy-loop regression** — `python3 helper /bin/sleep 2 </dev/null` → 0.02 CPU-sec (was 2 CPU-sec pre-iter-3)
- [x] **Partial mcpgateway smoke** — `setup.sh -f` installs cleanly into `../mcpgateway`, callsites migrated, shim executes against real codex

### BLOCKED-USER-SMOKE-TEST: live `/codex review` + `/council` in `../mcpgateway`
Requires user Claude Code session in that repo (cannot be done autonomously). Steps:
1. `cd /Users/pablomarin/Code/mcpgateway`
2. Confirm `.claude/hooks/lib/codex-pty.sh` is present (already installed by my partial smoke)
3. Start a Claude Code session in mcpgateway
4. Run `/codex review` against a real ~1KB diff — expect non-empty review within ~3 min (was: 17-min hang)
5. Run `/council "real architecture question"` — expect each codex advisor returns a real verdict
6. Set `CLAUDE_FORGE_CODEX_PTY_BYPASS=1` then re-run `/codex review` — expect old hangs return (proves the shim is doing the work)
7. Capture transcripts inline as a comment on this PR

## Retirement criterion

Drop the shim once codex 0.128+ (or whatever version closes #19945) is empirically confirmed clean on Linux + macOS + Windows. Reproducer:

```bash
setsid codex exec "$LARGE_PROMPT" < /dev/null
```

Should produce non-empty output. Until then, leave the shim in place.

Council's recommended staged retirement (deferred follow-up):
1. `scripts/canary-codex-pty.sh` runs the repro, reports PASS/FAIL with `codex --version` stamped
2. Bypass-by-version (when canary PASSES on stable for 2 weeks across macOS+Linux)
3. Noop the shim (after stage 2 has been live 4 weeks with no field reports)
4. Revert callsites + delete files (after stage 3 has been live 8 weeks)

## Existing-install upgrade

`./setup.sh -f` against existing installs picks up the new shim files plus the migrated `commands/codex.md` and council templates.

## Files (4 new + 9 modified, ~1,089 net insertions)

- `hooks/lib/codex-pty.sh` (new) + `.ps1` (new) + `helper.py` (new)
- `tests/template/test-codex-pty.sh` (new, 32 tests)
- `commands/codex.md`, `skills/council/SKILL.template.md`, `skills/council/references/peer-review-protocol.md` (callsites migrated)
- `setup.sh` + `setup.ps1` (3 new copy_file calls each, with chmod)
- `tests/template/test-contracts.sh` (9 new cross-file assertions)
- `CLAUDE.md`, `README.md` (5.21 → 5.22 + history row), `docs/CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)