### PR TITLE
fix(workflow): diagnose downstream-gitignored .claude/ in STATE-INIT (v5.25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-green?style=flat-square"></a>
-  <a href="#version-history"><img alt="Version" src="https://img.shields.io/badge/version-5.24-blue?style=flat-square"></a>
+  <a href="#version-history"><img alt="Version" src="https://img.shields.io/badge/version-5.25-blue?style=flat-square"></a>
   <a href="docs/getting-started.md"><img alt="Platform" src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey?style=flat-square"></a>
   <a href="https://code.claude.com"><img alt="Claude Code" src="https://img.shields.io/badge/Claude_Code-enabled-purple?style=flat-square"></a>
   <a href="https://developers.openai.com/codex/"><img alt="Codex CLI" src="https://img.shields.io/badge/Codex_CLI-required-orange?style=flat-square"></a>
@@ -142,6 +142,7 @@ Recent releases:
 
 | Version | Date       | Highlights                                                                                                                                                                                                                                                                                      |
 | ------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 5.25    | 2026-05-10 | STATE-INIT diagnoses downstream-gitignored `.claude/` — emits new `STATE_TEMPLATE_DOWNSTREAM_GITIGNORED` sentinel pointing at the actual fix (edit `.gitignore`, commit `.claude/`) instead of misleading "re-run setup". Bonus: anchors AC-2 redirect regex to fix prose-scan false positives. |
 | 5.24    | 2026-05-09 | State-init via Write tool — `/new-feature` & `/fix-bug` zero prompts on the state-init path. STATE-INIT block now truly read-only; agent uses Read+Write tools (auto-approved by v5.21 hook, Write creates missing parents per [ADR 0006](docs/adr/0006-write-tool-creates-missing-parents.md)) |
 | 5.23    | 2026-05-07 | Switch superpowers identity to `superpowers@claude-plugins-official` (Anthropic's marketplace, since 2026-01-15) — one-step install, avoids the `obra/superpowers-marketplace#11` name-conflict bug                                                                                             |
 | 5.22    | 2026-05-07 | Codex PTY shim — `.claude/hooks/lib/codex-pty.{sh,ps1}` works around [openai/codex#19945](https://github.com/openai/codex/issues/19945) (silent empty exit when `codex exec` runs without a TTY); migrated `/codex` + `/council` callsites                                                      |

--- a/commands/fix-bug.md
+++ b/commands/fix-bug.md
@@ -209,12 +209,24 @@ done
 # v5.21 PermissionRequest hook on .claude/local/**). The Write tool creates missing
 # parent dirs in one call — verified empirically against Claude Code 2.1.138.
 ROOT="$(git rev-parse --show-toplevel)"
+# Resolve parent working tree (== ROOT in main repo; == main repo working tree from
+# a worktree). git rev-parse --git-common-dir returns ".git" (relative) in main repo,
+# and absolute path to main repo's .git dir from inside a worktree. Strip trailing
+# /.git only when the path is absolute — relative ".git" means we're already in main.
+COMMON_DIR="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+case "$COMMON_DIR" in
+    /*) PARENT_ROOT="${COMMON_DIR%/.git}" ;;
+    *)  PARENT_ROOT="$ROOT" ;;
+esac
 TEMPLATE="$ROOT/.claude/state.template.md"
 [ ! -f "$TEMPLATE" ] && TEMPLATE="$ROOT/state.template.md"  # Forge-internal fallback
 if [ -f "$ROOT/.claude/local/state.md" ]; then
     echo "STATE_EXISTS"
 elif [ -f "$TEMPLATE" ]; then
     echo "STATE_NEEDS_INIT_FROM:$TEMPLATE"
+elif [ -f "$PARENT_ROOT/.gitignore" ] && grep -qE '^[[:space:]]*/?\.claude/?[[:space:]]*$' "$PARENT_ROOT/.gitignore"; then
+    echo "STATE_TEMPLATE_DOWNSTREAM_GITIGNORED:$PARENT_ROOT"
+    echo "  ⚠ .claude/ is gitignored in $PARENT_ROOT/.gitignore — Forge files never reach worktrees." >&2
 else
     echo "STATE_TEMPLATE_NOT_FOUND_AT:$TEMPLATE"
     echo "  ⚠ state template not found — workflow tracking cannot proceed without it." >&2
@@ -228,6 +240,12 @@ fi
 - `STATE_NEEDS_INIT_FROM:<path>` →
   1. Use the **Read** tool on `<path>` (the template path from the sentinel line)
   2. Use the **Write** tool to create `.claude/local/state.md` with the template's content. Write creates the missing `.claude/local/` parent directory in the same call. The v5.21 PermissionRequest hook auto-approves writes to `.claude/local/**`, so this won't prompt.
+- `STATE_TEMPLATE_DOWNSTREAM_GITIGNORED:<parent_root>` → STOP. The downstream repo at `<parent_root>` gitignores `.claude/` (the entire directory). The Forge convention gitignores only `.claude/local/`, so worktrees based on `origin/<default-branch>` reach a tree without any Forge files. Tell the user to fix the gitignore and commit `.claude/`:
+  1. Edit `<parent_root>/.gitignore` — remove the bare `.claude/` line. Keep `.claude/local/` (it should already be there from setup; if not, add it).
+  2. `cd <parent_root> && git add .gitignore .claude/ && git commit -m "chore: track .claude/ per Forge convention" && git push origin <default-branch>`
+  3. From inside the active worktree: `git fetch origin && git rebase origin/<default-branch>` to pick up the new commit.
+  4. Retry `/new-feature` (or `/fix-bug`).
+     Don't synthesize a state.md, and don't copy `.claude/` from the parent into the worktree — that's a band-aid that masks the misconfiguration; future worktrees will need the same workaround AND other Forge surfaces (hooks, settings) still won't reach the worktree's tracked tree.
 - `STATE_TEMPLATE_NOT_FOUND_AT:<path>` → STOP and tell the user that the Forge state template is missing — their checkout looks incomplete. Tell them to re-run `setup.sh --upgrade` from their Forge clone (typically `~/claude-codex-forge`; on Windows: `setup.ps1 -Upgrade`). Don't synthesize a state.md; the workflow tracking gates depend on the template's structure.
 
 **Step 2c: read state.md** via the Read tool.

--- a/commands/new-feature.md
+++ b/commands/new-feature.md
@@ -209,12 +209,24 @@ done
 # v5.21 PermissionRequest hook on .claude/local/**). The Write tool creates missing
 # parent dirs in one call — verified empirically against Claude Code 2.1.138.
 ROOT="$(git rev-parse --show-toplevel)"
+# Resolve parent working tree (== ROOT in main repo; == main repo working tree from
+# a worktree). git rev-parse --git-common-dir returns ".git" (relative) in main repo,
+# and absolute path to main repo's .git dir from inside a worktree. Strip trailing
+# /.git only when the path is absolute — relative ".git" means we're already in main.
+COMMON_DIR="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+case "$COMMON_DIR" in
+    /*) PARENT_ROOT="${COMMON_DIR%/.git}" ;;
+    *)  PARENT_ROOT="$ROOT" ;;
+esac
 TEMPLATE="$ROOT/.claude/state.template.md"
 [ ! -f "$TEMPLATE" ] && TEMPLATE="$ROOT/state.template.md"  # Forge-internal fallback
 if [ -f "$ROOT/.claude/local/state.md" ]; then
     echo "STATE_EXISTS"
 elif [ -f "$TEMPLATE" ]; then
     echo "STATE_NEEDS_INIT_FROM:$TEMPLATE"
+elif [ -f "$PARENT_ROOT/.gitignore" ] && grep -qE '^[[:space:]]*/?\.claude/?[[:space:]]*$' "$PARENT_ROOT/.gitignore"; then
+    echo "STATE_TEMPLATE_DOWNSTREAM_GITIGNORED:$PARENT_ROOT"
+    echo "  ⚠ .claude/ is gitignored in $PARENT_ROOT/.gitignore — Forge files never reach worktrees." >&2
 else
     echo "STATE_TEMPLATE_NOT_FOUND_AT:$TEMPLATE"
     echo "  ⚠ state template not found — workflow tracking cannot proceed without it." >&2
@@ -228,6 +240,12 @@ fi
 - `STATE_NEEDS_INIT_FROM:<path>` →
   1. Use the **Read** tool on `<path>` (the template path from the sentinel line)
   2. Use the **Write** tool to create `.claude/local/state.md` with the template's content. Write creates the missing `.claude/local/` parent directory in the same call. The v5.21 PermissionRequest hook auto-approves writes to `.claude/local/**`, so this won't prompt.
+- `STATE_TEMPLATE_DOWNSTREAM_GITIGNORED:<parent_root>` → STOP. The downstream repo at `<parent_root>` gitignores `.claude/` (the entire directory). The Forge convention gitignores only `.claude/local/`, so worktrees based on `origin/<default-branch>` reach a tree without any Forge files. Tell the user to fix the gitignore and commit `.claude/`:
+  1. Edit `<parent_root>/.gitignore` — remove the bare `.claude/` line. Keep `.claude/local/` (it should already be there from setup; if not, add it).
+  2. `cd <parent_root> && git add .gitignore .claude/ && git commit -m "chore: track .claude/ per Forge convention" && git push origin <default-branch>`
+  3. From inside the active worktree: `git fetch origin && git rebase origin/<default-branch>` to pick up the new commit.
+  4. Retry `/new-feature` (or `/fix-bug`).
+     Don't synthesize a state.md, and don't copy `.claude/` from the parent into the worktree — that's a band-aid that masks the misconfiguration; future worktrees will need the same workaround AND other Forge surfaces (hooks, settings) still won't reach the worktree's tracked tree.
 - `STATE_TEMPLATE_NOT_FOUND_AT:<path>` → STOP and tell the user that the Forge state template is missing — their checkout looks incomplete. Tell them to re-run `setup.sh --upgrade` from their Forge clone (typically `~/claude-codex-forge`; on Windows: `setup.ps1 -Upgrade`). Don't synthesize a state.md; the workflow tracking gates depend on the template's structure.
 
 **Step 2c: read state.md** via the Read tool.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to claude-codex-forge.
 
+## 5.25 — 2026-05-10 · Diagnose downstream-gitignored `.claude/` in STATE-INIT
+
+When a downstream project gitignores `.claude/` wholesale (instead of only `.claude/local/` per Forge convention), `/new-feature` and `/fix-bug` create worktrees based on `origin/<default-branch>` that don't have any Forge files (no template, no hooks, no rules in the worktree's tracked tree). The STATE-INIT block emitted `STATE_TEMPLATE_NOT_FOUND_AT:<path>` with remediation "re-run `setup.sh --upgrade`" — but setup writes to the parent's working tree, which still won't propagate to the worktree branch under the same gitignore rule. Field-confirmed in `msai-v2` (`.gitignore:2` had `.claude/` from initial commit, pre-Forge adoption); the agent improvised an off-script `cp -R .claude/` from the parent into the worktree to recover.
+
+**Root cause:** STATE-INIT only checked the worktree path for the template, then fell through to a generic "missing template" message that pointed at the wrong fix.
+
+**The fix:** STATE-INIT now resolves the parent working tree via `git rev-parse --git-common-dir` (relative `.git` in main repo, absolute path to main's `.git` from a worktree — strip `/.git` only when absolute) and inspects the parent's `.gitignore`. If a bare `.claude/` line is present, it emits a new sentinel `STATE_TEMPLATE_DOWNSTREAM_GITIGNORED:<parent_root>` with the correct remediation: edit `.gitignore` to keep only `.claude/local/`, then `git add .gitignore .claude/ && git commit && git push`, then `git fetch && git rebase` from inside the worktree, then retry. Don't `cp -R` from the parent — that masks the misconfiguration and other Forge surfaces (hooks paths in `settings.json`, `default-branch.sh` lookup, workflow-gate hook reading `.claude/local/state.md`) still won't reach the worktree's tracked tree.
+
+**Codex independent investigation** confirmed the diagnosis and recommended option C (loud preflight with correct remediation message) over option B (auto-mirror the parent's `.claude/` into the worktree): auto-mirror would silently paper over the contract violation while leaving ~6 other surfaces silently broken at downstream-PR-review time.
+
+**Bonus fix — AC-2e false positive:** the Step 2b prose-scanning regex (`tests/template/test-contracts.sh`) for "redirect to .claude/" was missing the `(^|[[:space:]])` anchor that its sibling cp/mv and sed regexes have. As a result, any literal `>` in prose (e.g. inside `<placeholder>` syntax) followed eventually by `.claude/` on the same line falsely matched. Tightened all three call sites (AC-2b shell-block scan, AC-2c self-test, AC-2e prose scan) to use the anchored form, and added AC-2d — a negative self-test that asserts known-good `<placeholder>` prose patterns are NOT matched. AC-2c still passes its 16 synthetic positives.
+
+**Files:**
+
+- `commands/new-feature.md`, `commands/fix-bug.md` — STATE-INIT block adds parent-root resolution + `.gitignore` detection + new sentinel branch (block remains byte-identical between the two files); Step 2b prose adds bullet for the new sentinel with the structural fix.
+- `tests/template/test-contracts.sh` — three redirect regexes anchored consistently; AC-2d negative-test added with 2 false-positive fixtures.
+- `docs/CHANGELOG.md` + `README.md` — version bump 5.24 → 5.25.
+
+**Existing installs:** run `./setup.sh --upgrade` from your Forge checkout to pick up the updated commands. Restart Claude Code afterward — slash-command definitions reload at session start. **If your downstream `.gitignore` has a bare `.claude/` line** (deviating from Forge convention), fix that next: replace with `.claude/local/`, `git add .claude/ .mcp.json`, commit, push.
+
 ## 5.24 — 2026-05-09 · State-init via Write tool — zero prompts on `/new-feature` & `/fix-bug`
 
 `/new-feature` and `/fix-bug` were prompting users for permission on `cp` commands writing to `.claude/local/state.md` — both the script-level `cp` on first init AND agent-improvised `cp main_state worktree_state` on every state write. Field-confirmed in `msai-v2`.

--- a/tests/template/test-contracts.sh
+++ b/tests/template/test-contracts.sh
@@ -743,7 +743,10 @@ for cmd_file in "$REPO_ROOT/commands/new-feature.md" "$REPO_ROOT/commands/fix-bu
     #    so it covers all quoting forms: `> .claude/x`, `> "$VAR/.claude/x"`,
     #    and `> "$VAR"/.claude/x` (the close-quote-then-unquoted-path form).
     #    [^|&]* still stops at pipes/chains. Note: 2>&1 doesn't match (no .claude/).
-    elif echo "$code" | grep -qE '[12]?>>?[[:space:]]*[^|&]*\.claude/'; then
+    #    Anchor: (^|[[:space:]]) before [12]? — same as the cp/mv and sed regexes
+    #    above. Without it, any literal `>` (e.g. inside `<placeholder>` syntax in
+    #    prose) followed eventually by `.claude/` on the same line falsely matches.
+    elif echo "$code" | grep -qE '(^|[[:space:]])[12]?>>?[[:space:]]*[^|&]*\.claude/'; then
         found_violation="stdout/stderr redirect to .claude/"
     fi
     if [ -n "$found_violation" ]; then
@@ -783,7 +786,7 @@ for line in "${synthetic_violations[@]}"; do
     matched=""
     if echo "$line" | grep -qE '(^|[[:space:]])(cp|mv|ln|install|dd|touch|tee|rm|rmdir|mkdir)[[:space:]][^|&]*\.claude/'; then matched=1
     elif echo "$line" | grep -qE '(^|[[:space:]])sed[[:space:]]+-i[^|&]*\.claude/'; then matched=1
-    elif echo "$line" | grep -qE '[12]?>>?[[:space:]]*[^|&]*\.claude/'; then matched=1
+    elif echo "$line" | grep -qE '(^|[[:space:]])[12]?>>?[[:space:]]*[^|&]*\.claude/'; then matched=1
     fi
     if [ -z "$matched" ]; then
         fail "AC-2b detector missed known-bad pattern: $line"
@@ -791,6 +794,29 @@ for line in "${synthetic_violations[@]}"; do
     fi
 done
 [ $detector_failures -eq 0 ] && pass "AC-2b detector catches all ${#synthetic_violations[@]} synthetic violations"
+
+# AC-2d Negative self-test: prose patterns that LOOK like they could trip the
+# redirect regex (e.g. `<placeholder>` syntax with `.claude/` later in the line)
+# must NOT match. Without the (^|[[:space:]]) anchor on the redirect regex,
+# these false positives broke AC-2e. Locked in here so a future regex change
+# that drops the anchor surfaces immediately.
+start_test "state-init-write-detector-rejects-known-false-positives"
+false_positives=(
+    # Markdown placeholder syntax where `>` is preceded by alphanumerics,
+    # not whitespace — appears legitimately in prose like Step 2b bullets.
+    '`STATE_TEMPLATE_DOWNSTREAM_GITIGNORED:<parent_root>` → STOP. Edit `.claude/local/state.md`'
+    'worktrees based on `origin/<default-branch>` reach a tree without any Forge files; commit `.claude/`'
+)
+fp_failures=0
+for line in "${false_positives[@]}"; do
+    if echo "$line" | grep -qE '(^|[[:space:]])(cp|mv|ln|install|dd|touch|tee|rm|rmdir|mkdir)[[:space:]][^|&]*\.claude/' \
+       || echo "$line" | grep -qE '(^|[[:space:]])sed[[:space:]]+-i[^|&]*\.claude/' \
+       || echo "$line" | grep -qE '(^|[[:space:]])[12]?>>?[[:space:]]*[^|&]*\.claude/'; then
+        fail "AC-2d detector falsely matched non-violation: $line"
+        fp_failures=$((fp_failures+1))
+    fi
+done
+[ $fp_failures -eq 0 ] && pass "AC-2d detector rejects all ${#false_positives[@]} known false positives"
 
 # AC-2e: the Step 2b prose section (after STATE-INIT-END through the next "###"
 # subsection or "**Step 2c") must instruct the agent to use Read+Write tools and
@@ -832,7 +858,7 @@ for cmd_file in "$REPO_ROOT/commands/new-feature.md" "$REPO_ROOT/commands/fix-bu
         fail "$name Step 2b prose contains a banned write command targeting .claude/"
     elif echo "$step2b_code" | grep -qE '(^|[[:space:]])sed[[:space:]]+-i[^|&]*\.claude/'; then
         fail "$name Step 2b prose contains sed -i targeting .claude/"
-    elif echo "$step2b_code" | grep -qE '[12]?>>?[[:space:]]*[^|&]*\.claude/'; then
+    elif echo "$step2b_code" | grep -qE '(^|[[:space:]])[12]?>>?[[:space:]]*[^|&]*\.claude/'; then
         fail "$name Step 2b prose contains a redirect to .claude/"
     else
         pass "$name Step 2b prose uses Read+Write tools, no banned writes"


### PR DESCRIPTION
## Summary

- Field-confirmed bug in `msai-v2`: when a downstream project gitignores `.claude/` wholesale (instead of only `.claude/local/` per Forge convention), `/new-feature` worktrees based on `origin/<default-branch>` reach a tree without any Forge files. STATE-INIT emitted `STATE_TEMPLATE_NOT_FOUND_AT` with remediation "re-run `setup.sh --upgrade`" — but setup writes to the parent working tree, which still won't propagate under the same gitignore rule. Agent improvised an off-script `cp -R .claude/` to recover.
- The fix: STATE-INIT now resolves the parent working tree via `git rev-parse --git-common-dir` and inspects the parent's `.gitignore`. If a bare `.claude/` line is present, it emits a new sentinel `STATE_TEMPLATE_DOWNSTREAM_GITIGNORED:<parent_root>` with the structural-fix remediation. Codex independent investigation confirmed option C (loud preflight) over option B (auto-mirror) — auto-mirror would silently paper over the contract violation while leaving ~6 other Forge surfaces (settings hook paths, default-branch lookup, workflow-gate hook) silently broken.
- Bonus fix: the AC-2e Step 2b prose-scanning regex was missing the `(^|[[:space:]])` anchor that its sibling cp/mv/sed regexes have. Any `>` in prose (e.g. `<placeholder>` syntax) followed by `.claude/` on the same line falsely matched. Tightened all three call sites and added AC-2d negative test (2 fixtures). 466 tests pass.

## Test plan

- [x] `bash tests/template/test-contracts.sh` — 121 passed, 0 failed (incl. new AC-2d)
- [x] `verify-app` agent — 466 passed across 9 suites, 0 failed
- [x] End-to-end smoke: `git init` + `.gitignore` `.claude/` + `git worktree add` → new STATE-INIT block correctly emits `STATE_TEMPLATE_DOWNSTREAM_GITIGNORED:/path/to/parent`
- [x] STATE-INIT block byte-identical between `commands/new-feature.md` and `commands/fix-bug.md` (existing AC-2 contract)

## Existing installs

Run `./setup.sh --upgrade` from your Forge checkout, then restart Claude Code. **If your downstream `.gitignore` has a bare `.claude/` line** (deviating from Forge convention), fix that next: replace with `.claude/local/`, `git add .claude/ .mcp.json`, commit, push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)