### PR TITLE
docs(rules): add migration discipline rule (additive-only + expand-contract) (v5.26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-green?style=flat-square"></a>
-  <a href="#version-history"><img alt="Version" src="https://img.shields.io/badge/version-5.25-blue?style=flat-square"></a>
+  <a href="#version-history"><img alt="Version" src="https://img.shields.io/badge/version-5.26-blue?style=flat-square"></a>
   <a href="docs/getting-started.md"><img alt="Platform" src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey?style=flat-square"></a>
   <a href="https://code.claude.com"><img alt="Claude Code" src="https://img.shields.io/badge/Claude_Code-enabled-purple?style=flat-square"></a>
   <a href="https://developers.openai.com/codex/"><img alt="Codex CLI" src="https://img.shields.io/badge/Codex_CLI-required-orange?style=flat-square"></a>
@@ -142,6 +142,7 @@ Recent releases:
 
 | Version | Date       | Highlights                                                                                                                                                                                                                                                                                      |
 | ------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 5.26    | 2026-05-10 | `rules/database.md` gains a "Migrations — additive-only discipline" section: ✅/❌ patterns matrix + 3-release expand-contract pattern for destructive changes + escape-hatch language. Closes a real gap (forge previously had zero migration guidance for teams running rolling deploys).     |
 | 5.25    | 2026-05-10 | STATE-INIT diagnoses downstream-gitignored `.claude/` — emits new `STATE_TEMPLATE_DOWNSTREAM_GITIGNORED` sentinel pointing at the actual fix (edit `.gitignore`, commit `.claude/`) instead of misleading "re-run setup". Bonus: anchors AC-2 redirect regex to fix prose-scan false positives. |
 | 5.24    | 2026-05-09 | State-init via Write tool — `/new-feature` & `/fix-bug` zero prompts on the state-init path. STATE-INIT block now truly read-only; agent uses Read+Write tools (auto-approved by v5.21 hook, Write creates missing parents per [ADR 0006](docs/adr/0006-write-tool-creates-missing-parents.md)) |
 | 5.23    | 2026-05-07 | Switch superpowers identity to `superpowers@claude-plugins-official` (Anthropic's marketplace, since 2026-01-15) — one-step install, avoids the `obra/superpowers-marketplace#11` name-conflict bug                                                                                             |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to claude-codex-forge.
 
+## 5.26 — 2026-05-10 · Database migration discipline rule (additive-only + expand-contract)
+
+`rules/database.md` had no migration guidance — a real gap for any team running rolling deploys with image rollback. Surfaced when `msai-v2` codified its own deploy-pipeline-specific version and the question came up: "is this generally applicable?" Yes — it's the standard production-hygiene pattern (any team whose deploy pipeline rolls back image SHAs but not DB schema wants additive-only migrations so old code can talk to the newer schema after a rollback).
+
+**What's new in `rules/database.md`:**
+
+- "Migrations — additive-only discipline" section with the ✅/❌ patterns matrix (ADD column/table/index/nullable FK = safe; DROP/RENAME/NOT-NULL-without-backfill/type-narrowing = unsafe).
+- The 3-release expand-contract pattern for destructive changes (Expand → Backfill+cutover → Contract).
+- Escape hatch language for genuine emergencies: coordinate with team, disable auto-rollback for that deploy, treat as one-way with a maintenance window.
+- Rule #5 added to the numbered rules list: `ALWAYS write additive-only migrations — use expand-contract for destructive changes`.
+
+**Files:**
+
+- `rules/database.md` — new "Migrations" section + new rule #5; existing rules renumbered 6→9.
+- `docs/CHANGELOG.md` + `README.md` — version bump 5.25 → 5.26.
+
+**Existing installs:** run `./setup.sh --upgrade` from your Forge clone to pick up the updated rule. No code changes; no behavior changes; just guidance Claude (and humans) will read when designing migrations.
+
 ## 5.25 — 2026-05-10 · Diagnose downstream-gitignored `.claude/` in STATE-INIT
 
 When a downstream project gitignores `.claude/` wholesale (instead of only `.claude/local/` per Forge convention), `/new-feature` and `/fix-bug` create worktrees based on `origin/<default-branch>` that don't have any Forge files (no template, no hooks, no rules in the worktree's tracked tree). The STATE-INIT block emitted `STATE_TEMPLATE_NOT_FOUND_AT:<path>` with remediation "re-run `setup.sh --upgrade`" — but setup writes to the parent's working tree, which still won't propagate to the worktree branch under the same gitignore rule. Field-confirmed in `msai-v2` (`.gitignore:2` had `.claude/` from initial commit, pre-Forge adoption); the agent improvised an off-script `cp -R .claude/` from the parent into the worktree to recover.

--- a/rules/database.md
+++ b/rules/database.md
@@ -9,30 +9,33 @@ paths:
 # Database
 
 ## Naming
+
 - Tables: plural snake_case (`users`, `order_items`)
 - Foreign keys: `{singular}_id` (`user_id`)
 - Timestamps: always add `created_at`, `updated_at`
 
 ## Model Pattern (SQLAlchemy 2.0)
+
 ```python
 class User(Base):
     __tablename__ = "users"
-    
+
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
     email: Mapped[str] = mapped_column(String(255), unique=True, index=True)
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(server_default=func.now(), onupdate=func.now())
-    
+
     # Relationship with eager loading default
     orders: Mapped[list["Order"]] = relationship(back_populates="user", lazy="selectin")
 
 class Order(Base):
     __tablename__ = "orders"
-    
+
     user_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"), index=True)  # ALWAYS index FKs
 ```
 
 ## Prevent N+1 Queries
+
 ```python
 # WRONG: triggers N queries
 users = (await session.execute(select(User))).scalars().all()
@@ -44,6 +47,7 @@ users = await session.execute(select(User).options(selectinload(User.orders)))
 ```
 
 ## Use Database Aggregations
+
 ```python
 # WRONG: loads all rows into memory
 count = len((await session.execute(select(User))).scalars().all())
@@ -53,6 +57,7 @@ count = (await session.execute(select(func.count()).select_from(User))).scalar_o
 ```
 
 ## Transactions
+
 ```python
 async with session.begin():
     # All operations here are atomic
@@ -61,12 +66,37 @@ async with session.begin():
     # Auto-commits on exit, auto-rollbacks on exception
 ```
 
+## Migrations — additive-only discipline
+
+If your deploy pipeline rolls back image SHAs but not DB schema (a common production pattern, since DB downgrades are rarely reversible), migrations must be **additive-only** — old code from the prior release must be able to safely talk to the newer schema after a rollback.
+
+- ✅ ADD column with DEFAULT or NULL (old code ignores the new column)
+- ✅ ADD table (old code ignores the new table)
+- ✅ ADD index (transparent to old code)
+- ✅ ADD nullable foreign key
+- ❌ DROP column / DROP table — old code may still reference it
+- ❌ RENAME column / RENAME table — old code can't find it
+- ❌ NOT-NULL constraint added without backfill+default — old code's INSERTs may break
+- ❌ Type narrowing (e.g. `VARCHAR(255)` → `VARCHAR(64)`) — old code's longer strings break
+
+For a destructive change, use the **expand-contract pattern** across three releases:
+
+1. **Expand** (release N): add the new column/table; old code keeps writing the old shape; new code dual-writes to both.
+2. **Backfill + cutover** (release N+1): new code reads from the new shape only; old shape still exists but unused.
+3. **Contract** (release N+2): drop the old column/table.
+
+Each release is purely additive over the previous one, so a rollback within any single release stays safe.
+
+If a destructive change is genuinely required (e.g. emergency security fix), coordinate with the team to disable auto-rollback for that deploy — treat it as a one-way migration with a maintenance window.
+
 ## Rules
+
 1. ALWAYS add `created_at` and `updated_at` columns
 2. ALWAYS index foreign key columns
 3. ALWAYS use eager loading (`selectinload`/`joinedload`) to prevent N+1
 4. ALWAYS use parameterized queries (ORMs do this automatically)
-5. NEVER use `len()` on query results — use `func.count()`
-6. NEVER build SQL with string concatenation
-7. PREFER UUID primary keys for distributed systems
-8. PREFER storing money as integers (cents)
+5. ALWAYS write additive-only migrations — use expand-contract for destructive changes (see "Migrations" section above)
+6. NEVER use `len()` on query results — use `func.count()`
+7. NEVER build SQL with string concatenation
+8. PREFER UUID primary keys for distributed systems
+9. PREFER storing money as integers (cents)


### PR DESCRIPTION
## Summary

- `rules/database.md` had no migration guidance — a real gap for any team running rolling deploys with image rollback. Surfaced when `msai-v2` codified its own deploy-pipeline-specific version of the rule. The pattern is generic enough to belong in the Forge: if your deploy pipeline rolls back image SHAs but not DB schema (common, since DB downgrades are rarely reversible), old code from the prior release must be able to safely talk to the newer schema after a rollback — which requires additive-only migrations.
- Adds a new "Migrations — additive-only discipline" section: safe/unsafe patterns matrix (ADD column/table/index/nullable FK = safe; DROP/RENAME/NOT-NULL-without-backfill/type-narrowing = unsafe), 3-release expand-contract pattern (Expand → Backfill+cutover → Contract), escape-hatch language for emergencies.
- Adds rule #5 to the numbered rules list. Existing rules 5-8 renumber to 6-9.

## Test plan

- [x] `bash tests/template/test-contracts.sh` — 121/121, 0 failed
- [x] Markdown renders correctly (✅/❌ list, expand-contract numbered list)
- [x] `setup.sh --upgrade` will pick up the rule via existing rule-copy logic — no setup.sh changes required

## Existing installs

Run `./setup.sh --upgrade` from your Forge clone. No code changes; no behavior changes; just guidance Claude (and humans) read when designing migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)