### PR TITLE
fix(workflow-gate): anchor unchecked-gate probe so prose '- [ ]' can't re-arm it

### DIFF
--- a/hooks/check-workflow-gates.ps1
+++ b/hooks/check-workflow-gates.ps1
@@ -222,7 +222,12 @@ foreach ($line in $workflowBlockLines) {
     #   "PR reviews addressed" (post-PR), "Plugins verified" (pre-flight),
     #   "Plan review loop" (design phase), "E2E use cases designed/graduated"
     #   (Phase 3.2b / 6.2b — conditional), "E2E regression passed" (Phase 5.4b).
-    if ($inChecklist -and $line -match '- \[ \]' -and $line -match '(Code review loop|Simplified|Verified \(tests|E2E verified)') {
+    # ANCHORED (mirrors check-workflow-gates.sh): the unchecked marker must be
+    # at line start AND immediately followed by a gate stem. A loose `- [ ]`
+    # match false-positives on a literal `- [ ]` inside an already-[x] line's
+    # prose (e.g. an N/A justification) and on unrelated unchecked items whose
+    # prose merely mentions a gate name. Keep this single anchored regex.
+    if ($inChecklist -and $line -match '^\s*- \[ \]\s+(Code review loop|Simplified|Verified \(tests|E2E verified)') {
         $unchecked += $line
     }
 }

--- a/hooks/check-workflow-gates.sh
+++ b/hooks/check-workflow-gates.sh
@@ -235,7 +235,14 @@ CHECKLIST=$(echo "$WORKFLOW_BLOCK" | awk '
 #   "E2E use cases designed" — Phase 3.2b, conditional on user-facing change
 #   "E2E regression passed" — Phase 5.4b, conditional on accumulated UCs
 #   "E2E use cases graduated" / "E2E specs graduated" — post-PASS housekeeping
-UNCHECKED=$(echo "$CHECKLIST" | grep '\- \[ \]' | grep -iE '(Code review loop|Simplified|Verified \(tests|E2E verified)' || true)
+# ANCHORED: the unchecked marker `- [ ]` must be at line start (modulo leading
+# whitespace) AND immediately followed by a gate stem. A two-stage match
+# (`grep '- [ ]' | grep <stem>`) false-positives twice: (1) a literal `- [ ]`
+# appearing in the *prose* of an already-[x] line (e.g. an N/A justification
+# reading "re-opens with `- [ ]` later") re-arms the gate, and (2) an unrelated
+# unchecked item whose prose merely mentions a gate name gets counted. Anchoring
+# the checkbox + stem together closes both. Keep this single anchored regex.
+UNCHECKED=$(echo "$CHECKLIST" | grep -iE '^[[:space:]]*- \[ \][[:space:]]+(Code review loop|Simplified|Verified \(tests|E2E verified)' || true)
 
 if [ -n "$UNCHECKED" ]; then
     UNCHECKED_COUNT=$(echo "$UNCHECKED" | wc -l | tr -d ' ')

--- a/tests/template/test-hooks.sh
+++ b/tests/template/test-hooks.sh
@@ -245,6 +245,30 @@ rc=$(run_hook_sh "$S7" 'git push' "$CHECKLIST_NEAR_MISS")
 assert_equals "$rc" "0" "non-gate items don't trigger the gate"
 
 # ===========================================================================
+# Test 7b: a literal `- [ ]` inside an already-[x] gate line's PROSE must NOT
+# re-arm the gate. Field bug (mcpgateway, 2026-05-28): a docs-only checkpoint
+# commit marked the 4 gates `[x] — N/A: ... Re-opens with `- [ ]` later`, and
+# the unanchored two-stage match counted those checked lines as unchecked. The
+# anchored regex (checkbox + gate stem at line start) must exit 0 here.
+# ===========================================================================
+start_test "literal '- [ ]' in an [x] line's prose does NOT re-trigger the gate"
+
+CHECKLIST_PROSE_BRACKET='- [x] Code review loop — N/A: docs-only checkpoint. Re-opens with `- [ ]` when code begins.
+- [x] Simplified — N/A: no code. Re-opens with `- [ ]` when code begins.
+- [x] Verified (tests/lint/types) — N/A: no code. Re-opens with `- [ ]` when code begins.
+- [x] E2E verified — N/A: docs-only checkpoint. Re-opens with `- [ ]` when code begins.'
+
+S7b=$(scratch_dir hooks-prose-bracket)
+rc=$(run_hook_sh "$S7b" 'git commit -m "docs checkpoint"' "$CHECKLIST_PROSE_BRACKET")
+assert_equals "$rc" "0" "prose '- [ ]' inside [x] lines does not re-arm the gate (.sh)"
+
+if command -v pwsh >/dev/null 2>&1; then
+    S7bps=$(scratch_dir hooks-prose-bracket-ps)
+    rc=$(run_hook_ps "$S7bps" 'git commit -m "docs checkpoint"' "$CHECKLIST_PROSE_BRACKET")
+    assert_equals "$rc" "0" "prose '- [ ]' inside [x] lines does not re-arm the gate (.ps1 parity)"
+fi
+
+# ===========================================================================
 # Test 8: PowerShell parity — same fixtures, same expected exit codes
 # (skipped if pwsh not installed, so this doesn't break macOS/Linux CI
 # boxes without PowerShell)


### PR DESCRIPTION
## Problem

`check-workflow-gates.{sh,ps1}` detected unchecked gates with a loose two-stage match (`grep '- [ ]' | grep <stem>`). A literal `- [ ]` appearing in the **prose** of an already-`[x]` gate line — e.g. an N/A justification reading `re-opens with \`- [ ]\` when code begins` — was counted as unchecked, **re-arming the very gate the line was clearing**. It also false-positived on unrelated unchecked items whose prose merely mentioned a gate name.

### Field repro (mcpgateway, 2026-05-28)
A docs-only Phase-3 checkpoint commit marked the 4 ship gates `- [x] N/A`. The justification text contained `- [ ]`, so the hook kept re-blocking the commit until the operator rephrased to drop the literal characters.

## Fix

One anchored regex requiring the unchecked marker **at line start** AND a canonical gate stem **immediately after it**:

```
^[[:space:]]*- \[ \][[:space:]]+(Code review loop|Simplified|Verified \(tests|E2E verified)
```

Mirrored in the `.ps1` (`^\s*- \[ \]\s+(...)`). This was strengthened on Codex's recommendation to anchor checkbox **and** stem, closing both false-positive classes.

## Tests

- `test-hooks.sh` **Test 7b** reproduces the field scenario (4 `[x] N/A` lines with `- [ ]` in prose) → asserts exit 0, plus a `.ps1` parity assertion.
- Full template suite green: **693 assertions across 10 suites, 0 failures**.
- Faithful downstream repro: fixed source hook run against reconstructed pre-rephrase `state.md` → exit 0.

## Scope

This hotfix is **only** the false-positive. The deeper gate-semantics issues found alongside it (N/A checkmarks permanently satisfying ship gates with nothing to re-open them; stale-N/A masking a later real PASS; malformed checked lines bypassing evidence; ps1 E2E-scan drift; `git -C` cwd mismatch) are tracked for a **separate `/new-feature`** pass and are NOT in this PR.

## ⚠️ Pre-merge

Per the standing harness rule, run `./setup.sh --upgrade` in `../mcpgateway` + a live smoke against the installed hook before merging. Fixture tests are necessary but not sufficient. **Not yet done.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)