### PR TITLE
chore(dogfood): sync forge's tracked .claude/rules/workflow.md to source

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -32,7 +32,7 @@ When a `/forge-goal`-driven `/goal` is active (`## /goal session` is populated i
 
 **Before asking the user any question during the autonomous run, ask yourself:**
 
-> *Is this a PR creation authorization?*
+> _Is this a PR creation authorization?_
 
 - **If YES:** call `AskUserQuestion` with the PR-create modal. The user's answer is the only human-authority signal in the loop.
 - **If NO:** invoke `/council` with the question. Apply the chairman's verdict. Continue the loop.
@@ -75,7 +75,7 @@ Two revision loops enforce quality as a discipline protocol. Both follow the sam
 
 **Plan review loop** (Phase 3, when entered): Claude + Codex review the plan against actual code.
 Exit when: no P0/P1/P2 from all available reviewers on the same pass.
-If Codex unavailable: Claude + user confirmation is sufficient.
+Codex is mandatory (this repo is Claude × Codex dual-engine). If Codex is unavailable, `/goal` halts and a human takes over; the loop cannot self-complete without real Codex evidence. The only ship escape is `- [x] Plan review loop — N/A: <reason>` for degraded interactive use, caught at PR review.
 Note: `/fix-bug` skips Phase 3 for simple fixes (1-2 files) UNLESS the fix touches a high-impact surface (see canonical list in `references/peer-review-protocol.md`).
 
 **Approach comparison** (Phase 3, after brainstorming): Claude fills comparison table with fixed axes (Complexity, Blast Radius, Reversibility, Time to Validate, User/Correctness Risk). Contrarian/Codex validates the "default wins" claim. Council fires on OBJECT + high-impact surface. Spike first if cheapest falsifying test < 30 min.
@@ -83,8 +83,23 @@ If Codex unavailable: user validates skip.
 
 **Code review loop** (Phase 5): Codex + PR Review Toolkit review the implementation.
 Exit when: no P0/P1/P2 from all available reviewers on the same pass.
-If Codex unavailable: PR Toolkit alone is sufficient.
-If PR Toolkit unavailable: Codex alone is sufficient.
-If neither available: alert user, manual review + user sign-off.
+Codex is mandatory (this repo is Claude × Codex dual-engine). If Codex is unavailable, `/goal` halts and a human takes over; the loop cannot self-complete without real Codex evidence. The only ship escape is `- [x] Code review loop — N/A: <reason>` for degraded interactive use, caught at PR review.
+Developer Demo honesty: when the PR body is a Developer Demo, an unsupported or wrong **diagram edge** — one that doesn't trace to a real `file:line` in the Evidence table (Gate 2 / claimed-current-behavior) — is a P1 finding. Gate-1 plan Briefing edges labeled `planned`/`inferred` are exempt.
 
 Never check a loop box until all available reviewers pass clean on the same iteration.
+
+**Per-iteration clean evidence (enforced by `check-workflow-gates` hook on ship actions):**
+
+For each loop, the agent MUST append a per-iteration clean line to `### Checklist` in `.claude/local/state.md`:
+
+- **Plan review:** `- [x] Plan review iteration <N> — codex clean — plan=\`<path>\` — plan_sha=\`<sha256>\` — ts=\`<ts>\``
+- **Code review:** `- [x] Code review iteration <N> — codex clean — head=\`<sha>\``AND`- [x] Code review iteration <N> — pr-toolkit clean — head=\`<sha>\``
+
+The `[x] Plan review loop (N iterations) — PASS` / `[x] Code review loop (N iterations) — PASS` checkbox is checked ONLY AFTER all available reviewers report clean AND the per-iter line(s) are written. The hook blocks `git commit`, `git push`, and `gh pr create` if the loop checkbox is PASS without matching per-iter evidence.
+
+**The only escape is N/A.** Codex is mandatory — there is no "codex unavailable" escape. For degraded interactive use only, the loop may be marked N/A:
+
+- `- [x] Plan review loop — N/A: <reason>`
+- `- [x] Code review loop — N/A: <reason>`
+
+An N/A line skips the per-iter evidence check on ship actions (mirrors the `E2E verified — N/A:` gate) and is caught by human reviewers at PR time. An N/A escape does NOT set the evidence gate clean in `build-evidence` — so a `/forge-goal`-driven `/goal` cannot self-complete on N/A; it halts for a human if Codex is genuinely unavailable.


### PR DESCRIPTION
## What

Dogfood: ran `./setup.sh --upgrade` in-place in the forge repo (now completes without aborting — v5.45's self-copy guard) to bring the forge's own `.claude/` config current with source. The gitignored `.claude/` tree (hooks, commands, all rules) refreshed locally so the maintainer's sessions follow the latest v5.44–v5.47 rules/commands.

The only **tracked** artifact under `.claude/` is `.claude/rules/workflow.md`, which had drifted behind source `rules/workflow.md`. This PR syncs it (+20/−5): picks up the v5.46 **Developer Demo Gate-2 honesty rule**, the **per-iteration clean-evidence** protocol, and the `/forge-goal` council section.

## Notes

- Config sync only — no source/template/logic change. (`rules/workflow.md`, the shipped template, already changed in v5.46/v5.47; this just realigns the forge's tracked working copy.)
- Reverted the redundant `.claude/local/` line setup re-appends to `.gitignore` (line 5's `.claude/` already covers it — a minor setup-quirk, out of scope here).
- Validates that v5.45 fixed the in-place `setup --upgrade` abort: the run reached the rules sync.
- Full template suite: 307 contract assertions green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)