### PR TITLE
chore(dogfood): sync forge's own .claude/ to v5.50

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -78,6 +78,8 @@ Exit when: no P0/P1/P2 from all available reviewers on the same pass.
 Codex is mandatory (this repo is Claude × Codex dual-engine). If Codex is unavailable, `/goal` halts and a human takes over; the loop cannot self-complete without real Codex evidence. The only ship escape is `- [x] Plan review loop — N/A: <reason>` for degraded interactive use, caught at PR review.
 Note: `/fix-bug` skips Phase 3 for simple fixes (1-2 files) UNLESS the fix touches a high-impact surface (see canonical list in `references/peer-review-protocol.md`).
 
+**Plan-stage severity — spec-loss is P1:** at the plan stage, an omission that could cause the **wrong feature to be built** is a **P1**, not a P2. This is because implementation subagents build FROM the plan's task list + test stubs, so a gap propagates and Gate 2 (code review) can only see code that is internally consistent with the _incomplete_ plan — plan-level spec-loss is invisible downstream. Classify as P1: missing required behavior, missing edge-case handling, a missing acceptance criterion needed to disambiguate implementation, or a missing test stub for a known-important behavior. Pure wording, organization, or maintainability smell stays P2. This sharpens classification only — it does **not** relax the exit; the loop still exits only on no P0/P1/P2.
+
 **Approach comparison** (Phase 3, after brainstorming): Claude fills comparison table with fixed axes (Complexity, Blast Radius, Reversibility, Time to Validate, User/Correctness Risk). Contrarian/Codex validates the "default wins" claim. Council fires on OBJECT + high-impact surface. Spike first if cheapest falsifying test < 30 min.
 If Codex unavailable: user validates skip.
 

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ docs/ci-templates/
 # we don't want the scaffolded dir tracked. The template's own regression
 # suite lives in tests/template/, which IS tracked.
 tests/e2e/
+
+# Volatile per-developer workflow state (PR #2 / continuity-split)
+.claude/local/


### PR DESCRIPTION
Ran `./setup.sh --upgrade` in-place so the forge's own (gitignored) `.claude/` dogfood tree follows the latest shipped templates. The refresh is local-only except the one tracked artifact `.claude/rules/workflow.md` (picks up the v5.50 plan-stage spec-loss=P1 rule) + the standard `.claude/local/` gitignore entry setup appends.

**Live dogfood confirmations from the run:**
- v5.45 self-copy guard held — in-place `--upgrade` reached the rules sync, no abort.
- v5.48 sentinel-aware banner fired correctly on the forge's own legacy `CONTINUITY.md` (sentinel `2026-04-28`): *"already migrated — remove once content landed"*, not the old unsatisfiable "run-the-migrate-command" nag.

Config sync only — no source/code change. 2 tracked files, +5 lines.
